### PR TITLE
Update to metamodel 0.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 # Details of the metamodel used to check the model:
-metamodel_version:=v0.0.2
+metamodel_version:=v0.0.3
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: check


### PR DESCRIPTION
Version 0.0.3 of the metamodel doesn't try to install the binaries to
the `bin` directory of the user, which is needed to be able to run the
checks in the Jenkins environment.