### PR TITLE
Fetch tags of metamodel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check: metamodel
 .PHONY: metamodel
 metamodel:
 	[ -d "$@" ] || git clone "$(metamodel_url)" "$@"
-	cd "$@" && git fetch origin
+	cd "$@" && git fetch --tags origin
 	cd "$@" && git checkout -B build "$(metamodel_version)"
 	make -C "$@"
 


### PR DESCRIPTION
Currently the `metamodel` target of the _Makefile_ clones the
corresponding repository only if needed, and then it always does a `git
fetch` to get the latest code. But it doesn't use the `--tags` options
and as a result some tags may be missing. This patch adds that `--tags`
option.