### PR TITLE
Add `order` parameter to collections that support it

### DIFF
--- a/model/clusters_mgmt/v1/clusters_resource.model
+++ b/model/clusters_mgmt/v1/clusters_resource.model
@@ -30,11 +30,11 @@ resource Clusters {
 
 		// Search criteria.
 		// 
-		// The syntax of this parameter is similar to the syntax of the _where_ clause
-		// of an SQL statement, but using the names of the attributes of the cluster
-		// instead of the names of the columns of a table. For example, in order to
-		// retrieve all the clusters with a name starting with `my` in the
-		// `us-east-1` region the value should be:
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the cluster instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// clusters with a name starting with `my` in the `us-east-1` region the value
+		// should be:
 		//
 		// [source,sql]
 		// ----
@@ -44,6 +44,22 @@ resource Clusters {
 		// If the parameter isn't provided, or if the value is empty, then all the
 		// clusters that the user has permission to see will be returned.
 		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the cluster instead of
+		// the names of the columns of a table. For example, in order to sort the clusters
+		// descending by region identifier the value should be:
+		//
+		// [source,sql]
+		// ----
+		// region.id desc
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.

--- a/model/clusters_mgmt/v1/dashboards_resource.model
+++ b/model/clusters_mgmt/v1/dashboards_resource.model
@@ -30,10 +30,9 @@ resource Dashboards {
 
 		// Search criteria.
 		//
-		// The syntax of this parameter is similar to the syntax of the
-		// _where_ clause of an SQL statement, but using the names of
-		// the attributes of the dashboard instead of the names of the
-		// columns of a table. For example, in order to retrieve all the
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the dashboard instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
 		// dashboards with a name starting with `my` the value should be:
 		//
 		// [source,sql]
@@ -41,10 +40,25 @@ resource Dashboards {
 		// name like 'my%'
 		// ----
 		//
-		// If the parameter isn't provided, or if the value is empty,
-		// then all the dashboards that the user has permission to see
-		// will be returned.
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// dashboards that the user has permission to see will be returned.
 		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the dashboard instead of
+		// the names of the columns of a table. For example, in order to sort the dashboards
+		// descending by name the value should be:
+		//
+		// [source,sql]
+		// ----
+		// name desc
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.

--- a/model/clusters_mgmt/v1/flavours_resource.model
+++ b/model/clusters_mgmt/v1/flavours_resource.model
@@ -17,37 +17,53 @@ limitations under the License.
 // Manages the collection of cluster flavours.
 resource Flavours {
 	method List {
-                // Index of the requested page, where one corresponds to the first page.
-                //
-                // Default value is `1`.
-                in out Page Integer
+		// Index of the requested page, where one corresponds to the first page.
+		//
+		// Default value is `1`.
+		in out Page Integer
 
-                // Maximum number of items that will be contained in the returned page.
-                //
-                // Default value is `100`.
-                in out Size Integer
+		// Maximum number of items that will be contained in the returned page.
+		//
+		// Default value is `100`.
+		in out Size Integer
 
-                // Search criteria.
-                //
-                // The syntax of this parameter is similar to the syntax of the _where_ clause
-                // of an SQL statement, but using the names of the attributes of the cluster
-                // instead of the names of the columns of a table. For example, in order to
-                // retrieve all the flavours with a name starting with `my`the value should be:
-                //
-                // [source,sql]
-                // ----
-                // name like 'my%'
-                // ----
-                //
-                // If the parameter isn't provided, or if the value is empty, then all the
-                // flavours that the user has permission to see will be returned.
-                in Search String
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+		// SQL statement, but using the names of the attributes of the flavour instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// flavours with a name starting with `my`the value should be:
+		//
+		// [source,sql]
+		// ----
+		// name like 'my%'
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the flavours
+		// that the user has permission to see will be returned.
+		in Search String
 
-                // Total number of items of the collection that match the search criteria,
-                // regardless of the size of the page.
-                in out Total Integer
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the flavour instead of
+		// the names of the columns of a table. For example, in order to sort the flavours
+		// descending by name the value should be:
+		//
+		// [source,sql]
+		// ----
+		// name desc
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
-                // Retrieved list of flavours.
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		in out Total Integer
+
+		// Retrieved list of flavours.
 		out Items []Flavour
 	}
 

--- a/model/clusters_mgmt/v1/versions_resource.model
+++ b/model/clusters_mgmt/v1/versions_resource.model
@@ -30,7 +30,7 @@ resource Versions {
 
 		// Search criteria.
 		//
-		// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
 		// SQL statement, but using the names of the attributes of the version instead of
 		// the names of the columns of a table. For example, in order to retrieve all the
 		// versions that are enabled:
@@ -40,9 +40,25 @@ resource Versions {
 		// enabled = 't'
 		// ----
 		//
-		// If the parameter isn't provided, or if the value is empty, then all the
-		// versoins that the user has permission to see will be returned.
+		// If the parameter isn't provided, or if the value is empty, then all the versions
+		// that the user has permission to see will be returned.
 		in Search string
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the version instead of
+		// the names of the columns of a table. For example, in order to sort the versions
+		// descending by identifier the value should be:
+		//
+		// [source,sql]
+		// ----
+		// id desc
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.


### PR DESCRIPTION
This patch adds the description of the `order` parameter to the
collections of the clusters management service that support it.