### PR TITLE
Releae 0.0.3

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -2,6 +2,11 @@
 
 This document describes the relevant changes between releases of the API model.
 
+== 0.0.3 Sep 11 2019
+
+- Add `order` parameter to the collections that suport it.
+- Add cloud providers collection.
+
 == 0.0.2 Sep 10 2019
 
 - Add `DisplayName` attribute to `Subscription` type.


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Add `order` parameter to the collections that suport it.
- Add cloud providers collection.