### PR TITLE
Remove `cluster.creator`

### DIFF
--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -129,9 +129,6 @@ class Cluster {
 	// Link to the collection of groups of user of the cluster.
 	link Groups []Group
 
-	// Mail address of the user that created the cluster.
-	Creator String
-
 	// Link to the version of _OpenShift_ that will be used to install the cluster.
 	link Version Version
 


### PR DESCRIPTION
This patch removes the `creator` attribute from the `Cluster` type.

Related: https://jira.coreos.com/browse/SDA-1395