### PR TITLE
Release 0.0.6

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -2,6 +2,10 @@
 
 This document describes the relevant changes between releases of the API model.
 
+== 0.0.6 Sep 16 2019
+
+- Remove the `creator` attribute of the `Cluster` type.
+
 == 0.0.5 Sep 12 2019
 
 - Add `order` parameter to the methods to list accounts and subscriptions.


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Remove the `creator` attribute of the `Cluster` type.