### PR TITLE
Update methods don't return body

### DIFF
--- a/model/accounts_mgmt/v1/account_resource.model
+++ b/model/accounts_mgmt/v1/account_resource.model
@@ -23,6 +23,6 @@ resource Account {
 
 	// Updates the account.
 	method Update {
-		in out Body Account
+		in Body Account
 	}
 }

--- a/model/accounts_mgmt/v1/organization_resource.model
+++ b/model/accounts_mgmt/v1/organization_resource.model
@@ -23,7 +23,7 @@ resource Organization {
 
 	// Updates the organization.
 	method Update {
-		in out Body Organization
+		in Body Organization
 	}
 
 	// Reference to the service that manages the resource quotas for this

--- a/model/accounts_mgmt/v1/resource_quota_resource.model
+++ b/model/accounts_mgmt/v1/resource_quota_resource.model
@@ -23,6 +23,6 @@ resource ResourceQuota {
 
 	// Updates the resource quota.
 	method Update {
-		in out Body ResourceQuota
+		in Body ResourceQuota
 	}
 }

--- a/model/accounts_mgmt/v1/role_resource.model
+++ b/model/accounts_mgmt/v1/role_resource.model
@@ -23,7 +23,7 @@ resource Role {
 
 	// Updates the role.
 	method Update {
-		in out Body Role
+		in Body Role
 	}
 
 	// Deletes the role.

--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -23,7 +23,7 @@ resource Cluster {
 
 	// Updates the cluster.
 	method Update {
-		in out Body Cluster
+		in Body Cluster
 	}
 
 	// Deletes the cluster.


### PR DESCRIPTION
This patch updates the definitions of the `Update` methods so that they
don't return a body, as that is how our services currently work. Without
this change the SDK will expect a response body and will return an `EOF`
error for a successful update.