### PR TITLE
Add `auths` attribute to the `AccessToken` type

### DIFF
--- a/model/accounts_mgmt/v1/access_token_auth_type.model
+++ b/model/accounts_mgmt/v1/access_token_auth_type.model
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-struct AccessToken {
-	Auths [string]AccessTokenAuth
+struct AccessTokenAuth {
+	Auth string
+	Email string
 }


### PR DESCRIPTION
This patch adds the `auths` attribute to the `AccessToken` type. This
new attribute is a map of objects of the new `AccessTokenAuth` type.