### PR TITLE
Update to metamodel 0.0.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 # Details of the metamodel used to check the model:
-metamodel_version:=v0.0.8
+metamodel_version:=v0.0.9
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
 
 .PHONY: check


### PR DESCRIPTION
The more relevant changes in the new version of the metamodel are the
following:

- Generate shorter adapter names.
- Use constants from the `http` package.
- Shorter _read_ and _write_ names.
- Rename `SetStatusCode` to `Status`.
- Improve naming of variables.
- Set default status.
- Move errors and helpers generators to separate files.