### PR TITLE
Fix sku list

### DIFF
--- a/model/accounts_mgmt/v1/root_resource.model
+++ b/model/accounts_mgmt/v1/root_resource.model
@@ -82,8 +82,8 @@ resource Root {
 	}
 
 	// Reference to the resource that manages the collection of
-	// SKUS
-	locator SKUS {
-		target SKUS
+	// Skus
+	locator Skus {
+		target Skus
 	}
 }

--- a/model/accounts_mgmt/v1/sku_resource.model
+++ b/model/accounts_mgmt/v1/sku_resource.model
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages a specific SKU.
-resource SKU {
-	// Retrieves the details of the SKU.
+// Manages a specific Sku.
+resource Sku {
+	// Retrieves the details of the Sku.
 	method Get {
-		out Body SKU
+		out Body Sku
 	}
 }

--- a/model/accounts_mgmt/v1/sku_type.model
+++ b/model/accounts_mgmt/v1/sku_type.model
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Identifies computing resources
-class SKU {
+class Sku {
 	// platform-specific name, such as "M5.2Xlarge" for a type of EC2 node
 	ResourceName String
 	ResourceType String

--- a/model/accounts_mgmt/v1/skus_resource.model
+++ b/model/accounts_mgmt/v1/skus_resource.model
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages the collection of SKUS.
-resource SKUS {
-	// Retrieves a list of SKUS.
+// Manages the collection of Skus.
+resource Skus {
+	// Retrieves a list of Skus.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
 		//
@@ -35,9 +35,9 @@ resource SKUS {
 		// Search criteria.
 		//
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
-		// of an SQL statement, but using the names of the attributes of the SKU
+		// of an SQL statement, but using the names of the attributes of the Sku
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve SKUS large sized resources:
+	        // retrieve Skus large sized resources:
 		//
 		// [source,sql]
 		// ----
@@ -48,13 +48,13 @@ resource SKUS {
 		// items that the user has permission to see will be returned.
 		in Search String
 
-		// Retrieved list of SKUS.
-		out Items []SKU
+		// Retrieved list of Skus.
+		out Items []Sku
 	}
 
-	// Reference to the service that manages a specific SKU.
-	locator SKU {
-		target SKU
+	// Reference to the service that manages a specific Sku.
+	locator Sku {
+		target Sku
 		variable ID
 	}
 }


### PR DESCRIPTION
I ran into some problems using the sdk with all caps SKUS (I also tried SKUs). I suspect there is a problem somewhere in the plural snake case generation.


Here is an example snippet and the error generated:
```golang
        ctx := context.Background()
        token := os.Getenv("OCM_TOKEN")
	connection, err := sdk.NewConnectionBuilder().
		Tokens(token).
		BuildContext(ctx)
	if err != nil {
		glog.Fatalf("Can't build connection %v", err)
		os.Exit(1)
	}
	defer connection.Close()

        skusResource := connection.AccountsMgmt().V1().SKUS()

	skusResponse, err := skusResource.List().Send()
	if err != nil {
		glog.Fatalf("Can't list skus: %v", err)
	}
```

```
F1024 10:54:49.180540   81265 main.go:113] Can't list skus: expected kind 'SKU' or 'SKULink' but got 'Sku'
```

However naming as `Sku`, `Skus` etc works fine