### PR TITLE
Update cluster authorization resource

### DIFF
--- a/model/accounts_mgmt/v1/cluster_authorization_request_type.model
+++ b/model/accounts_mgmt/v1/cluster_authorization_request_type.model
@@ -15,11 +15,14 @@ limitations under the License.
 */
 
 struct ClusterAuthorizationRequest {
-	ClusterID String
 	AccountUsername String
+	AvailabilityZone String
+	BYOC Boolean
+	ClusterID String
+	Disconnected Boolean
+	DisplayName String
+	ExternalClusterID String
 	Managed Boolean
 	Reserve Boolean
-	BYOC Boolean
-	AvailabilityZone String
 	Resources []ReservedResource
 }

--- a/model/accounts_mgmt/v1/cluster_authorization_response_type.model
+++ b/model/accounts_mgmt/v1/cluster_authorization_response_type.model
@@ -17,5 +17,5 @@ limitations under the License.
 struct ClusterAuthorizationResponse {
 	Allowed Boolean
 	ExcessResources []ReservedResource
-	Subscription Subscription
+	link Subscription Subscription
 }

--- a/model/accounts_mgmt/v1/reserved_resource_type.model
+++ b/model/accounts_mgmt/v1/reserved_resource_type.model
@@ -15,9 +15,11 @@ limitations under the License.
 */
 
 struct ReservedResource {
+	AvailabilityZoneType String
+	BYOC Boolean
+	Count Integer
+	CreatedAt Date
 	ResourceName String
 	ResourceType String
-	BYOC Boolean
-	AvailabilityZoneType String
-	Count Integer
+	UpdatedAt Date
 }


### PR DESCRIPTION
This patch adds the missing `Disconnected`, `DisplayName` and
`ExtrnalClusterID` attributes to the cluster authorization request type.