### PR TITLE
Add ids to role binding type

### DIFF
--- a/model/accounts_mgmt/v1/role_binding_type.model
+++ b/model/accounts_mgmt/v1/role_binding_type.model
@@ -18,7 +18,10 @@ class RoleBinding {
 	Type String
 	Subscription Subscription
 	Account Account
+	AccountID String
 	Organization Organization
+	OrganizationID string
 	Role Role
+	RoleID String
 	ConfigManaged Boolean
 }


### PR DESCRIPTION
Account id in particular is required to create a role binding