### PR TITLE
Query resource quota from root and delete by id

### DIFF
--- a/model/accounts_mgmt/v1/resource_quota_resource.model
+++ b/model/accounts_mgmt/v1/resource_quota_resource.model
@@ -25,4 +25,8 @@ resource ResourceQuota {
 	method Update {
 		in Body ResourceQuota
 	}
+
+	// Deletes the resource quota.
+	method Delete {
+	}
 }

--- a/model/accounts_mgmt/v1/root_resource.model
+++ b/model/accounts_mgmt/v1/root_resource.model
@@ -75,6 +75,12 @@ resource Root {
 		target RoleBindings
 	}
 
+	// Reference to the resource that manages the collection of resource
+	// quota.
+	locator ResourceQuota {
+		target ResourceQuotas
+	}
+
 	// Reference to the resource that manages the collection of
 	// subscriptions.
 	locator Subscriptions {


### PR DESCRIPTION
This enables deletion of resource quota via id and listing of resource quota without specifying an organization id