### PR TITLE
Fix names of add-ons types and resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ check: metamodel
 
 .PHONY: metamodel
 metamodel:
-	[ -d "$@" ] || git clone "$(metamodel_url)" "$@"
+	rm -rf "$@"
+	git clone "$(metamodel_url)" "$@"
 	cd "$@" && git fetch --tags origin
 	cd "$@" && git checkout -B build "$(metamodel_version)"
 	make -C "$@"

--- a/model/clusters_mgmt/v1/add_on_resource.model
+++ b/model/clusters_mgmt/v1/add_on_resource.model
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 // Manages a specific add-on.
-resource Addon {
+resource AddOn {
 	// Retrieves the details of the add-on.
 	method Get {
-		out Body Addon
+		out Body AddOn
 	}
 
 	// Updates the add-on.
 	method Update {
-		in out Body Addon
+		in out Body AddOn
 	}
 
 	// Deletes the add-on.

--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Representation of an add-on that can be installed in a cluster.
-class Addon {
+class AddOn {
 	// Name of the add-on.
 	Name String
 

--- a/model/clusters_mgmt/v1/add_ons_resource.model
+++ b/model/clusters_mgmt/v1/add_ons_resource.model
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Manages the collection of add-ons.
-resource Addons {
+resource AddOns {
 	// Retrieves the list of add-ons.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
@@ -65,18 +65,18 @@ resource Addons {
 		in out Total Integer
 
 		// Retrieved list of add-ons.
-		out Items []Addon
+		out Items []AddOn
 	}
 
 	// Create a new add-on and add it to the collection of add-ons.
 	method Add {
 		// Description of the add-on.
-		in out Body Addon
+		in out Body AddOn
 	}
 
 	// Returns a reference to the service that manages a specific add-on.
 	locator Addon {
-		target Addon
+		target AddOn
 		variable ID
 	}
 }

--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -62,6 +62,6 @@ resource Cluster {
 
 	// Refrence to the resource that manages the collection of add-ons installed on this cluster.
 	locator Addons {
-		target Addons
+		target AddOns
 	}
 }

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -141,5 +141,5 @@ class Cluster {
 	Metrics ClusterMetrics
 
 	// List of add-ons on this cluster.
-	link Addons []Addon
+	link Addons []AddOn
 }

--- a/model/clusters_mgmt/v1/root_resource.model
+++ b/model/clusters_mgmt/v1/root_resource.model
@@ -18,7 +18,7 @@ limitations under the License.
 resource Root {
 	// Reference to the resource that manages the collection of add-ons.
 	locator Addons {
-		target Addons
+		target AddOns
 	}
 
 	// Reference to the resource that manages the collection of cloud providers.


### PR DESCRIPTION
The names of the types in the server are `AddOn` but in the model they
are `Addon`. This patch fixes that.