### PR TITLE
Refactor flavour nodes

### DIFF
--- a/model/clusters_mgmt/v1/flavour_nodes_type.model
+++ b/model/clusters_mgmt/v1/flavour_nodes_type.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Counts of different classes of nodes inside a flavour.
+struct FlavourNodes {
+	// Number of master nodes of the cluster.
+	Master Integer
+
+	// Number of compute nodes of the cluster.
+	Compute Integer
+}

--- a/model/clusters_mgmt/v1/flavour_type.model
+++ b/model/clusters_mgmt/v1/flavour_type.model
@@ -29,7 +29,7 @@ class Flavour {
 	// this flavour.
 	//
 	// These can be overriden specifying in the cluster itself a different number of nodes.
-	Nodes ClusterNodes
+	Nodes FlavourNodes
 
 	// Human friendly identifier of the cluster, for example `4`.
 	//


### PR DESCRIPTION
This patch changes the `Flavour` type so that it uses a separate type to
specify the number of nodes instead of the same type used by the
`Cluster` type.