### PR TITLE
This patch fixes the directions of paging parameters

### DIFF
--- a/model/accounts_mgmt/v1/accounts_resource.model
+++ b/model/accounts_mgmt/v1/accounts_resource.model
@@ -30,7 +30,7 @@ resource Accounts {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Order criteria.
 		//

--- a/model/accounts_mgmt/v1/organizations_resource.model
+++ b/model/accounts_mgmt/v1/organizations_resource.model
@@ -30,7 +30,7 @@ resource Organizations {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Search criteria.
 		//

--- a/model/accounts_mgmt/v1/permissions_resource.model
+++ b/model/accounts_mgmt/v1/permissions_resource.model
@@ -30,7 +30,7 @@ resource Permissions {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of permissions.
 		out Items []Permission

--- a/model/accounts_mgmt/v1/quota_summary_resource.model
+++ b/model/accounts_mgmt/v1/quota_summary_resource.model
@@ -47,7 +47,7 @@ resource QuotaSummary {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved quota summary items.
 		out Items []QuotaSummary

--- a/model/accounts_mgmt/v1/registries_resource.model
+++ b/model/accounts_mgmt/v1/registries_resource.model
@@ -30,7 +30,7 @@ resource Registries {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of registries.
 		out Items []Registry

--- a/model/accounts_mgmt/v1/registry_credentials_resource.model
+++ b/model/accounts_mgmt/v1/registry_credentials_resource.model
@@ -30,7 +30,7 @@ resource RegistryCredentials {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of registry credentials.
 		out Items []RegistryCredential

--- a/model/accounts_mgmt/v1/resource_quotas_resource.model
+++ b/model/accounts_mgmt/v1/resource_quotas_resource.model
@@ -30,7 +30,7 @@ resource ResourceQuotas {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Search criteria.
 		//

--- a/model/accounts_mgmt/v1/role_bindings_resource.model
+++ b/model/accounts_mgmt/v1/role_bindings_resource.model
@@ -30,7 +30,7 @@ resource RoleBindings {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Search criteria.
 		//

--- a/model/accounts_mgmt/v1/roles_resource.model
+++ b/model/accounts_mgmt/v1/roles_resource.model
@@ -30,7 +30,7 @@ resource Roles {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Search criteria.
 		//
@@ -47,7 +47,6 @@ resource Roles {
 		// If the parameter isn't provided, or if the value is empty, then all the
 		// items that the user has permission to see will be returned.
 		in Search String
-
 
 		// Retrieved list of roles.
 		out Items []Role

--- a/model/accounts_mgmt/v1/subscription_reserved_resources_resource.model
+++ b/model/accounts_mgmt/v1/subscription_reserved_resources_resource.model
@@ -30,7 +30,7 @@ resource SubscriptionReservedResources {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of reserved resources.
 		out Items []ReservedResource

--- a/model/accounts_mgmt/v1/subscriptions_resource.model
+++ b/model/accounts_mgmt/v1/subscriptions_resource.model
@@ -30,7 +30,7 @@ resource Subscriptions {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Search criteria.
 		//

--- a/model/clusters_mgmt/v1/add_ons_resource.model
+++ b/model/clusters_mgmt/v1/add_ons_resource.model
@@ -62,7 +62,7 @@ resource AddOns {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of add-ons.
 		out Items []AddOn

--- a/model/clusters_mgmt/v1/cloud_providers_resource.model
+++ b/model/clusters_mgmt/v1/cloud_providers_resource.model
@@ -62,7 +62,7 @@ resource CloudProviders {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of cloud providers.
 		out Items []CloudProvider

--- a/model/clusters_mgmt/v1/cloud_regions_resource.model
+++ b/model/clusters_mgmt/v1/cloud_regions_resource.model
@@ -24,12 +24,12 @@ resource CloudRegions {
 	method List {
 		// Index of the returned page, where one corresponds to the first page. As this
 		// collection doesn't support paging the result will always be `1`.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items that will be contained in the returned page. As this collection
 		// doesn't support paging or searching the result will always be the total number of
 		// regions of the provider.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page. As this collection doesn't support paging or

--- a/model/clusters_mgmt/v1/cluster_status_resource.model
+++ b/model/clusters_mgmt/v1/cluster_status_resource.model
@@ -17,6 +17,6 @@ limitations under the License.
 // Provides detailed information about the status of an specific cluster.
 resource ClusterStatus {
 	method Get {
-		out Status ClusterStatus
+		out Body ClusterStatus
 	}
 }

--- a/model/clusters_mgmt/v1/clusters_resource.model
+++ b/model/clusters_mgmt/v1/clusters_resource.model
@@ -63,7 +63,7 @@ resource Clusters {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of clusters.
 		out Items []Cluster

--- a/model/clusters_mgmt/v1/dashboards_resource.model
+++ b/model/clusters_mgmt/v1/dashboards_resource.model
@@ -62,7 +62,7 @@ resource Dashboards {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of dashboards.
 		out Items []Dashboard

--- a/model/clusters_mgmt/v1/flavours_resource.model
+++ b/model/clusters_mgmt/v1/flavours_resource.model
@@ -61,7 +61,7 @@ resource Flavours {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total Integer
+		out Total Integer
 
 		// Retrieved list of flavours.
 		out Items []Flavour

--- a/model/clusters_mgmt/v1/groups_resource.model
+++ b/model/clusters_mgmt/v1/groups_resource.model
@@ -19,10 +19,10 @@ resource Groups {
 	// Retrieves the list of groups.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/model/clusters_mgmt/v1/identity_providers_resource.model
+++ b/model/clusters_mgmt/v1/identity_providers_resource.model
@@ -19,10 +19,10 @@ resource IdentityProviders {
 	// Retrieves the list of identity providers.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/model/clusters_mgmt/v1/logs_resource.model
+++ b/model/clusters_mgmt/v1/logs_resource.model
@@ -19,10 +19,10 @@ resource Logs {
 	// Retrieves the list of clusters.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/model/clusters_mgmt/v1/users_resource.model
+++ b/model/clusters_mgmt/v1/users_resource.model
@@ -19,10 +19,10 @@ resource Users {
 	// Retrieves the list of users.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
-		out Page Integer
+		in out Page Integer
 
 		// Number of items contained in the returned page.
-		out Size Integer
+		in out Size Integer
 
 		// Total number of items of the collection.
 		out Total Integer

--- a/model/clusters_mgmt/v1/versions_resource.model
+++ b/model/clusters_mgmt/v1/versions_resource.model
@@ -62,7 +62,7 @@ resource Versions {
 
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
-		in out Total integer
+		out Total integer
 
 		// Retrieved list of versions.
 		out Items []Version


### PR DESCRIPTION
Some of the places where we are specifying paging parameters (`page`,
`size` and `total`) are using incorrect directions. This patch fixes
that.