### PR TITLE
Fix direction of `Body` parameter of updates

### DIFF
--- a/model/accounts_mgmt/v1/account_resource.model
+++ b/model/accounts_mgmt/v1/account_resource.model
@@ -23,6 +23,6 @@ resource Account {
 
 	// Updates the account.
 	method Update {
-		in Body Account
+		in out Body Account
 	}
 }

--- a/model/accounts_mgmt/v1/organization_resource.model
+++ b/model/accounts_mgmt/v1/organization_resource.model
@@ -23,7 +23,7 @@ resource Organization {
 
 	// Updates the organization.
 	method Update {
-		in Body Organization
+		in out Body Organization
 	}
 
 	// Reference to the service that manages the resource quotas for this

--- a/model/accounts_mgmt/v1/resource_quota_resource.model
+++ b/model/accounts_mgmt/v1/resource_quota_resource.model
@@ -23,7 +23,7 @@ resource ResourceQuota {
 
 	// Updates the resource quota.
 	method Update {
-		in Body ResourceQuota
+		in out Body ResourceQuota
 	}
 
 	// Deletes the resource quota.

--- a/model/accounts_mgmt/v1/role_resource.model
+++ b/model/accounts_mgmt/v1/role_resource.model
@@ -23,7 +23,7 @@ resource Role {
 
 	// Updates the role.
 	method Update {
-		in Body Role
+		in out Body Role
 	}
 
 	// Deletes the role.

--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -23,7 +23,7 @@ resource Cluster {
 
 	// Updates the cluster.
 	method Update {
-		in Body Cluster
+		in out Body Cluster
 	}
 
 	// Deletes the cluster.


### PR DESCRIPTION
The `Body` parameter of update operations should be input as output, as
the method should accept the attriutes to update and should return the
updated object.