### PR TITLE
Update flavour type to latest API

### DIFF
--- a/model/clusters_mgmt/v1/aws_flavour_type.model
+++ b/model/clusters_mgmt/v1/aws_flavour_type.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Volume specification for different classes of nodes inside a flavour.
+struct AWSFlavour {
+	// Master volume specification.
+	MasterVolume AWSVolume
+
+	// Infra volume specification.
+	InfraVolume AWSVolume
+
+	// Worker volume specification.
+	WorkerVolume AWSVolume
+}

--- a/model/clusters_mgmt/v1/aws_volume_type.model
+++ b/model/clusters_mgmt/v1/aws_volume_type.model
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Holds settings for an AWS storage volume.
+struct AWSVolume {
+	// Volume provisioned IOPS.
+	IOPS Integer
+
+	// Volume size in Gib.
+	Size Integer
+
+	// Volume Type
+    //
+    // Possible values are: 'io1', 'gp2', 'st1', 'sc1', 'standard'
+	Type String
+}

--- a/model/clusters_mgmt/v1/flavour_type.model
+++ b/model/clusters_mgmt/v1/flavour_type.model
@@ -20,10 +20,7 @@ class Flavour {
 	// Default _Amazon Web Services_ settings of the cluster.
 	//
 	// These can be overriden specifying in the clsuter itself a different set of settings.
-	AWS AWS
-
-	// Version of _OpenShift_ that will be used to create the cluster.
-	Version String
+	AWS AWSFlavour
 
 	// Number of nodes that will be used by default when creating a cluster that uses
 	// this flavour.
@@ -41,4 +38,15 @@ class Flavour {
 	//
 	// These can be overriden specifying in the cluster itself a different set of settings.
 	Network Network
+
+	// AWS default instance type for the master volume.
+	MasterInstanceType String
+
+	// AWS default instance type for the worker volume.
+	//
+	// Tins can be overriden specifying in the cluster itself a type for compute node.
+	ComputeInstanceType String
+
+	// AWS default instance type for the infra volume.
+	InfraInstanceType String
 }


### PR DESCRIPTION
Remove obsolete `aws` and `version` fields
Add instance type fields
Create `aws_volume` and `aws_flavour` subtypes