### PR TITLE
Release 0.0.26

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -2,6 +2,14 @@
 
 This document describes the relevant changes between releases of the API model.
 
+== 0.0.26 Dec 2 2019
+
+- Remove obsolete `aws` and `version` fields from the `Flavour` type.
+- Add instance type fields to the `Flavour` type.
+- Add `AWSVolume` and `AWSFlavour` types.
+- Add attributes required for _BYOC_.
+- Fix direction of `Body` parameters of updates.
+
 == 0.0.25 Nov 28 2019
 
 - Allow patching role binding.


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Remove obsolete `aws` and `version` fields from the `Flavour` type.
- Add instance type fields to the `Flavour` type.
- Add `AWSVolume` and `AWSFlavour` types.
- Add attributes required for _BYOC_.
- Fix direction of `Body` parameters of updates.