### PR TITLE
AddOns: Add ResourceName and ResourceCost

### DIFF
--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -30,4 +30,10 @@ class AddOn {
 
 	// Indicates if this add-on can be added to clusters.
 	Enabled Boolean
+
+	// Used to determine from where to reserve quota for this add-on.
+	ResourceName String
+
+	// Used to determine how many units of quota an add-on consumes per resource name.
+	ResourceCost Float
 }


### PR DESCRIPTION
To reserve quota for specific add-ons, we need to track the resource
name and cost portion used by each add-on.