### PR TITLE
Add CreatedAt and UpdatedAt fields to the Subscription type

### DIFF
--- a/model/accounts_mgmt/v1/subscription_type.model
+++ b/model/accounts_mgmt/v1/subscription_type.model
@@ -21,6 +21,8 @@ class Subscription {
 	ExternalClusterID String
 	OrganizationID String
 	DisplayName String
+	CreatedAt Date
+	UpdatedAt Date
 
 	// Last telemetry authorization request for this subscription.
 	LastTelemetryDate Date


### PR DESCRIPTION
cc: @jhernand @tiwillia @igoihman @cben @Lir10 @tzvatot @gshilin-sdb

Current subscription model (and its derivatives, e.g. the openapi) does not contain the `CreatedAt` and `UpdatedAt` fields which **do exist** in the current API supplied by the service. These fields are needed for the `subscription-cleaner` CronJob we are planning the run.

