### PR TITLE
Added API for the new service_logs microservice

### DIFF
--- a/model/service_logs/v1/cluster_log_resource.model
+++ b/model/service_logs/v1/cluster_log_resource.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific log entry.
+resource LogEntry {
+	// Retrieves the details of the log entry.
+	method Get {
+		out Body LogEntry
+	}
+
+	// Deletes the log entry.
+	method Delete {
+	}
+}

--- a/model/service_logs/v1/cluster_log_type.model
+++ b/model/service_logs/v1/cluster_log_type.model
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+enum Severity {
+	Debug
+	Info
+	Warning
+	Error
+	Fatal
+}
+
+class LogEntry {
+
+    // Log severity for the specific log entry
+    Severity        Severity
+
+    // The name of the service who created the log
+    ServiceName     String
+    
+    ClusterUUID     String
+    Summary         String
+    Description     String
+
+    // A flag that indicates whether the log entry should be internal/private only
+    InternalOnly    Boolean
+    
+    Timestamp       Date
+}

--- a/model/service_logs/v1/cluster_logs_resource.model
+++ b/model/service_logs/v1/cluster_logs_resource.model
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of cluster logs.
+resource ClusterLogs {
+	// Retrieves the list of cluster logs.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement. For example, in order to sort the
+		// cluster logs descending by name identifier the value should be:
+		//
+		// [source,sql]
+		// ----
+		// name desc
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause
+		// of an SQL statement, but using the names of the attributes of the cluster logs
+		// instead of the names of the columns of a table. For example, in order to
+	        // retrieve cluster logs with service_name starting with my:
+		//
+		// [source,sql]
+		// ----
+		// service_name like 'my%'
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// items that the user has permission to see will be returned.
+		in Search String
+
+		// Retrieved list of Cluster logs.
+		out Items []LogEntry
+	}
+
+	// Creates a new log entry.
+	method Add {
+		// Log entry data.
+		in out Body LogEntry
+	}
+
+	// Reference to the service that manages a specific Log entry.
+	locator LogEntry {
+		target LogEntry
+		variable ID
+	}
+}

--- a/model/service_logs/v1/root_resource.model
+++ b/model/service_logs/v1/root_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Root of the tree of resources of the service logs service.
+resource Root {
+	// Reference to the resource that manages the collection of cluster logs.
+	locator ClusterLogs {
+		target ClusterLogs
+	}
+}


### PR DESCRIPTION
This PR adds API for the service_logs microservice.
It includes the main `Cluster Logs` endpoint which support the following actions: Get, Create, Delete

List of `Cluster Logs` is supported as well so each item would contain a  single `Log entry`
 