### PR TITLE
Add comments on ClusterOperatorInfo fields and enum values

### DIFF
--- a/model/clusters_mgmt/v1/cluster_operator_info_type.model
+++ b/model/clusters_mgmt/v1/cluster_operator_info_type.model
@@ -15,9 +15,14 @@ limitations under the License.
 */
 
 struct ClusterOperatorInfo {
+	// Time when the sample was obtained, in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format.
 	Time Date
+	// Name of the operator.
 	Name String
-	Reason String
+	// Current version of the operator.  Empty string if unknown.
 	Version String
+	// Operator status.  Empty string if unknown.
 	Condition ClusterOperatorState
+	// Extra detail on condition, if available.  Empty string if unknown.
+	Reason String
 }

--- a/model/clusters_mgmt/v1/cluster_operators_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_operators_state_type.model
@@ -16,8 +16,12 @@ limitations under the License.
 
 // Overall state of a cluster operator.
 enum ClusterOperatorState {
+	// Operator is working normally.
 	Available
+	// Operator is partially working, there is an issue.
 	Degraded
+	// Operator is not running or not working.
 	Failing
+	// Operator is upgrading to newer version, possibly degraded until upgrade completes.
 	Upgrading
 }


### PR DESCRIPTION
Followup to #102.  @jhernand @pvasant please review.

P.S. `Upgrading` condition is currently broken, not returned by backend in practice.
Possibly we'll remove or replace it, not decided yet.  (https://issues.redhat.com/browse/SDA-1542)