### PR TITLE
README: more details on method blocks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -117,9 +117,12 @@ method List {
 	// Order criteria.
 	in Order String
 
+        // Kind of the result - "ClusterList".
+        out Kind String
+
 	// Total number of items of the collection that match the search criteria,
 	// regardless of the size of the page.
-	in Total Integer
+	out Total Integer
 
 	// Retrieved list of clusters.
 	out Items []Cluster
@@ -127,9 +130,27 @@ method List {
 ----
 
 Methods have _parameters_ defined by their direction (_in_ or _out_), their
-name and their type. In the above example there are five input parameters
-(named `Page`, `Size`, `Search` and `Order`) and one output parameter (named
+name and their type. In the above example there are four input parameters
+(named `Page`, `Size`, `Search` and `Order`) and four output parameter (named
 `Items`).
+
+- "List" conceptual method is implemented by http GET method, with
+  _in_ parameters represented in the URL as http query parameters.
+
+  `cluster_mgmt` API supports an alternative way to List — as http
+  POST method, with a `method=get` query parameter and _in_ paramaters
+  sent as fields of a JSON request body.
+
+  _Out_ parameters become top-level fields in the JSON response body.
+
+- "Get" is regular http GET method, declared with single _out_ parameter
+  representing the JSON response body.
+
+- "Add" is performed by http POST method, declared with single _in
+  out_ parameter representing the JSON request body — as well as the
+  response body.
+
+- "Delete" is performed by http DELETE method, with no parameters.
 
 In addition to methods resources also have _locators_, defined by nested
 `locator` blocks. Locators represent the relationships between resources. For
@@ -288,6 +309,5 @@ could be used:
 in Search String
 ----
 
-Currently this _AsciiDoc_ documentation isn't used to generate other
-documentation formats, but in the future it will be processed by tools that
-will automatically generate the reference documentation.
+This documentation is used to automatically generate OpenAPI reference
+documentation (with some constructs converted to markdown).

--- a/README.adoc
+++ b/README.adoc
@@ -117,9 +117,6 @@ method List {
 	// Order criteria.
 	in Order String
 
-        // Kind of the result - "ClusterList".
-        out Kind String
-
 	// Total number of items of the collection that match the search criteria,
 	// regardless of the size of the page.
 	out Total Integer
@@ -132,25 +129,29 @@ method List {
 Methods have _parameters_ defined by their direction (_in_ or _out_), their
 name and their type. In the above example there are four input parameters
 (named `Page`, `Size`, `Search` and `Order`) and four output parameter (named
-`Items`).
+`Page`, `Size`, `Total` and `Items`).
 
-- "List" conceptual method is implemented by http GET method, with
-  _in_ parameters represented in the URL as http query parameters.
+- "List" conceptual method is implemented by HTTP GET method, with
+  _in_ parameters represented in the URL as HTTP query parameters
+  (with names converted from _CamelCase_ to _snake_case_).
 
-  `cluster_mgmt` API supports an alternative way to List — as http
+  `cluster_mgmt` API supports an alternative way to List — as HTTP
   POST method, with a `method=get` query parameter and _in_ paramaters
-  sent as fields of a JSON request body.
+  sent as fields of a JSON request body (again, with _snake_case_ names).
 
-  _Out_ parameters become top-level fields in the JSON response body.
+  _Out_ parameters become top-level fields in the JSON response body
+  (again, with _snake_case_ names).
+  An additional `kind` field is added automatically (set to the type's
+  name + a "List" suffix), it should not be included in the method block.
 
-- "Get" is regular http GET method, declared with single _out_ parameter
+- "Get" is regular HTTP GET method, declared with single _out_ parameter
   representing the JSON response body.
 
-- "Add" is performed by http POST method, declared with single _in
+- "Add" is performed by HTTP POST method, declared with single _in
   out_ parameter representing the JSON request body — as well as the
   response body.
 
-- "Delete" is performed by http DELETE method, with no parameters.
+- "Delete" is performed by HTTP DELETE method, with no parameters.
 
 In addition to methods resources also have _locators_, defined by nested
 `locator` blocks. Locators represent the relationships between resources. For


### PR DESCRIPTION
I notice the meaning of parameters depends on method, so decided to document that better.

- see #111 about `Kind` parameter in List.

- wasn't sure where to document the `?method=Get` thing.  AFAICT `MethodMiddleware` code implementing this is specific to clusters-service, and SDK doesn't use it on client nor server side.  
  But it's used by some requests from the UI, so should be documented, and should appear in openapi (which adding to README doesn't achieve).

  An obvious place I thought is on root resource for clusters_mgmt, but its comment doesn't seem to get into the openapi.  The doc string for `/api/clusters_mgmt/v1` is "Retrieves the version metadata." which is hard-coded in the generator.