### PR TITLE
Document clusters/{id}/metric_queries/alerts endpoint

### DIFF
--- a/model/clusters_mgmt/v1/alert_info_type.model
+++ b/model/clusters_mgmt/v1/alert_info_type.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Provides information about a single alert firing on the cluster.
+struct AlertInfo {
+	// The alert name. Multiple alerts with same name are possible.
+	Name string
+
+	// The alert severity.
+	Severity AlertSeverity
+}

--- a/model/clusters_mgmt/v1/alert_severity_type.model
+++ b/model/clusters_mgmt/v1/alert_severity_type.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Severity of a cluster alert received via telemetry.
+enum AlertSeverity {
+	// This level is only used for the "Watchdog" alert that is always on.
+	None
+
+	// Warning.
+	Warning
+
+	// Critical.
+	Critical
+}

--- a/model/clusters_mgmt/v1/alerts_info_type.model
+++ b/model/clusters_mgmt/v1/alerts_info_type.model
@@ -1,0 +1,20 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Provides information about the alerts firing on the cluster.
+struct AlertsInfo {
+	Alerts []AlertInfo
+}

--- a/model/clusters_mgmt/v1/alerts_metric_query_resource.model
+++ b/model/clusters_mgmt/v1/alerts_metric_query_resource.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Provides information about the alerts firing on the cluster.
+resource AlertsMetricQuery {
+	method Get {
+		out Body AlertsInfo
+	}
+}

--- a/model/clusters_mgmt/v1/metric_queries_resource.model
+++ b/model/clusters_mgmt/v1/metric_queries_resource.model
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages metric queries for a cluster.
+// Manages telemetry queries for a cluster.
 resource MetricQueries {
 	// Reference to the resource that retrieves the total cpu
 	// capacity in the cluster by node role and operating system.
@@ -26,6 +26,11 @@ resource MetricQueries {
 	// capacity in the cluster by node role and operating system.
 	locator SocketTotalByNodeRolesOS {
 		target SocketTotalByNodeRolesOSMetricQuery
+	}
+
+	// Reference to the resource that retrieves the firing alerts in the cluster.
+	locator Alerts {
+		target AlertsMetricQuery
 	}
 
 	// Reference to the resource that retrieves the cluster operator status metrics.


### PR DESCRIPTION
(https://issues.redhat.com/browse/SDA-1919, part 1, more to come in separate PRs)

modeled on #102.  For some reason it's not getting into generated openapi for me — the types are added but there is still no `metric_queries/alerts` endpoint :man_shrugging: 