### PR TITLE
Remove duplicated attribute

### DIFF
--- a/model/service_logs/v1/cluster_log_type.model
+++ b/model/service_logs/v1/cluster_log_type.model
@@ -29,9 +29,6 @@ class LogEntry {
 	// The name of the service who created the log.
 	ServiceName String
 
-	// The name of the service who created the log.
-	ServiceName String
-    
 	// External cluster ID.
 	ClusterUUID String
 


### PR DESCRIPTION
This patch removes the duplicated `ServiceName` attribute from the
`LogEntry` type.