### PR TITLE
LDAP: Fix attributes property name

### DIFF
--- a/model/clusters_mgmt/v1/identity_provider_type.model
+++ b/model/clusters_mgmt/v1/identity_provider_type.model
@@ -124,7 +124,7 @@ struct GoogleIdentityProvider {
 // Details for `ldap` identity providers.
 struct LDAPIdentityProvider {
 	// LDAP attributes used to configure the provider.
-	LDAPAttributes LDAPAttributes
+	Attributes LDAPAttributes
 
 	// Optional distinguished name to use to bind during the search phase.
 	BindDN String


### PR DESCRIPTION
When creating an LDAP IDP, the attributes is a required property.
However, the current name resolves in the SDK as "ldap_attributes", thus
failing creation with a "400: 'attributes' field is mandatory" error
message.