### PR TITLE
Add Cluster API listening method

### DIFF
--- a/model/clusters_mgmt/v1/listening_method_type.model
+++ b/model/clusters_mgmt/v1/listening_method_type.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 Red Hat, Inc.
+Copyright (c) 2020 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,10 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Information about the API of a cluster.
-struct ClusterAPI {
-	// The URL of the API server of the cluster.
-	URL String
-	// The listening method of the API server.
-	Listening ListeningMethod
+// Cluster components listening method.
+enum ListeningMethod {
+	// Uses only internal traffic.
+	Internal
+
+	// Uses both external and internal traffic.
+	External
 }


### PR DESCRIPTION
In order to support Private OSD clusters, we need to mark the API as external or internal.