### PR TITLE
Products: Support for top-level cluster types

### DIFF
--- a/model/clusters_mgmt/v1/product_resource.model
+++ b/model/clusters_mgmt/v1/product_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific product.
+resource Product {
+	// Retrieves the details of the product.
+	method Get {
+		out Body Product
+	}
+}

--- a/model/clusters_mgmt/v1/product_type.model
+++ b/model/clusters_mgmt/v1/product_type.model
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of an product that can be selected as a cluster type.
+class Product {
+	// Name of the product.
+	Name String
+}

--- a/model/clusters_mgmt/v1/products_resource.model
+++ b/model/clusters_mgmt/v1/products_resource.model
@@ -1,0 +1,72 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of products.
+resource Products {
+	// Retrieves the list of products.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+		// SQL statement, but using the names of the attributes of the product instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// products with a name starting with `my` the value should be:
+		//
+		// [source,sql]
+		// ----
+		// name like 'my%'
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the products
+		// that the user has permission to see will be returned.
+		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the product instead of
+		// the names of the columns of a table. For example, in order to sort the products
+		// descending by name the value should be:
+		//
+		// [source,sql]
+		// ----
+		// name desc
+		// ----
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
+
+		// Retrieved list of products.
+		out Items []Product
+	}
+
+	// Returns a reference to the service that manages a specific product.
+	locator Product {
+		target Product
+		variable ID
+	}
+}

--- a/model/clusters_mgmt/v1/root_resource.model
+++ b/model/clusters_mgmt/v1/root_resource.model
@@ -56,4 +56,9 @@ resource Root {
 	locator AWSInfrastructureAccessRoles {
 		target AWSInfrastructureAccessRoles
 	}
+
+	// Reference to the resource that manages the collection of products.
+	locator Products {
+		target Products
+	}
 }


### PR DESCRIPTION
We want to support the concept of product types for clusters, rather
than relying on discrete flags (e.g. cluster.Managed). This will allow
us to enforce specific configurations depending on the product (e.g.
automatically adding necessary add-ons to an RHMI cluster), as well as
improved quota reservation mechanisms (e.g. bypassing quota checks when
reshaping MOA clusters).