### PR TITLE
Products: Add product attribute to cluster object

### DIFF
--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -70,4 +70,9 @@ resource Cluster {
 	locator AWSInfrastructureAccessRoleGrants {
 		target AWSInfrastructureAccessRoleGrants
 	}
+
+	// Reference to the resource that manages the product type of the cluster
+	locator Product {
+		target Product
+	}
 }

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -160,4 +160,7 @@ class Cluster {
 
 	// Flag indicating if cluster-admin access is enabled.
 	ClusterAdminEnabled Boolean
+
+	// Link to the product type of this cluster.
+	link Product Product
 }


### PR DESCRIPTION
To support creating clusters of a specific product type, we need to
allow the cluster object to reference the product object itself. When
a cluster is created as part of a specific product, certain defaults
will be enforced and quota will be reserved accordingly.