### PR TITLE
make: Allow passing local copy of metamodel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,14 @@ openapi: metamodel
 .PHONY: metamodel
 metamodel:
 	rm -rf "$@"
-	git clone "$(metamodel_url)" "$@"
-	cd "$@" && git fetch --tags origin
-	cd "$@" && git checkout -B build "$(metamodel_version)"
+	if [ -d "$(metamodel_url)" ]; then \
+		cp -r "$(metamodel_url)" "$@"; \
+	else \
+		git clone "$(metamodel_url)" "$@"; \
+		cd "$@"; \
+		git fetch --tags origin; \
+		git checkout -B build "$(metamodel_version)"; \
+	fi
 	make -C "$@"
 
 # Enforce indentation by tabs. License contains 2 spaces, so reject 3+.


### PR DESCRIPTION
To do local development, we should not need to wait until a new release of
the metamodel to verify that it works. We can now run `make check` with
a local copy of the metamodel repository by running:

	make metamodel_url=/path/to/ocm-api-metamodel check

This change supports both local directory and git repository.