### PR TITLE
AddOnInstallations: Remove DELETE operation

### DIFF
--- a/model/clusters_mgmt/v1/add_on_installation_resource.model
+++ b/model/clusters_mgmt/v1/add_on_installation_resource.model
@@ -20,8 +20,4 @@ resource AddOnInstallation {
 	method Get {
 		out Body AddOnInstallation
 	}
-
-	// Deletes the add-on installation.
-	method Delete {
-	}
 }


### PR DESCRIPTION
Deleting Add-On Installations is not a supported operation in Clusters
Service at the moment. Removing this from the OpenAPI spec will remove
user confusion while app-sre determines the correct strategy for
operator clean-up.