### PR TITLE
AddOns: Add link attribute

### DIFF
--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -22,6 +22,9 @@ class AddOn {
 	// Description of the add-on.
 	Description String
 
+	// Link to documentation about the add-on.
+	Link String
+
 	// Label used to attach to a cluster deployment when add-on is installed.
 	Label String
 


### PR DESCRIPTION
This new link attribute will be used to provide additional information
to the user when looking at the different add-ons.