### PR TITLE
AddOns: Fix link attribute name

### DIFF
--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -23,7 +23,7 @@ class AddOn {
 	Description String
 
 	// Link to documentation about the add-on.
-	Link String
+	DocsLink String
 
 	// Label used to attach to a cluster deployment when add-on is installed.
 	Label String


### PR DESCRIPTION
Using Link causes collision with the client