### PR TITLE
cluster: Remove support for expiration_timestamp

### DIFF
--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -112,6 +112,8 @@ class Cluster {
 	// Date and time when the cluster will be automatically deleted, using the format defined in
 	// https://www.ietf.org/rfc/rfc3339.txt[RFC3339]. If no timestamp is provided, the cluster
 	// will never expire.
+	//
+	// This option is unsupported.
 	ExpirationTimestamp Date
 
 	// Link to the cloud provider where the cluster is installed.


### PR DESCRIPTION
This option still exists but will no longer be supported. Clusters in
production never expire automatically.