### PR TITLE
Added top-level Notify endpoint to AMS

### DIFF
--- a/model/accounts_mgmt/v1/notify_resource.model
+++ b/model/accounts_mgmt/v1/notify_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the notify endpoint
+resource Notify {
+	// Notify user related to subscription/cluster via email
+	method Add {
+		in out Body SubscriptionNotify
+	}
+}

--- a/model/accounts_mgmt/v1/subscription_notify_type.model
+++ b/model/accounts_mgmt/v1/subscription_notify_type.model
@@ -17,12 +17,24 @@ limitations under the License.
 // This struct is a request to send a templated email to a user related to this
 // subscription.
 struct SubscriptionNotify {
+	// Indicates which Cluster (internal id) the resource type belongs to
+	ClusterID string
+
+	// Indicates which Cluster (external id) the resource type belongs to
+	ClusterUUID string
+
+	// Indicates which Subscription the resource type belongs to
+	SubscriptionID string
+
 	// The BCC address to be included on the email that is sent
 	BccAddress string
+
 	// The email subject
 	Subject string
+
 	// The name of the template used to construct the email contents
 	TemplateName string
+	
 	// The values which will be substituted into the templated email
 	TemplateParameters []TemplateParameter
 }


### PR DESCRIPTION
We need to add top-level /notify endpoint to the ocm-sdk so we could use it in other services as a client