### PR TITLE
version: Add moa_enabled flag

### DIFF
--- a/model/clusters_mgmt/v1/version_type.model
+++ b/model/clusters_mgmt/v1/version_type.model
@@ -27,4 +27,7 @@ class Version {
 	// ChannelGroup is a mechanism to partition the images to different groups,
 	// each image belongs to only a single group.
 	ChannelGroup string
+
+	// MOAEnabled indicates whether this version can be used to create MOA clusters.
+	MOAEnabled boolean
 }


### PR DESCRIPTION
To track versions that support MOA clusters, we add a new moa_enabled
flag. This flag is populated in the database based on the existence of
AMI overrides for MOA in the corresponding ClusterImageSet.