### PR TITLE
Add key to label_type

### DIFF
--- a/model/clusters_mgmt/v1/label_type.model
+++ b/model/clusters_mgmt/v1/label_type.model
@@ -16,6 +16,8 @@ limitations under the License.
 
 // Representation of a label in clusterdeployment.
 class Label {
+	// the key of the label
+	Key String
 	// the value to set in the label
 	Value String
 }


### PR DESCRIPTION
ID can't be used as label key, because it can't support keys with prefix and `/` character.
So ID will be generated by OCM and label key will be passed in by the user.