### PR TITLE
flavours: Remove infra and compute nodes

### DIFF
--- a/model/clusters_mgmt/v1/flavour_nodes_type.model
+++ b/model/clusters_mgmt/v1/flavour_nodes_type.model
@@ -18,10 +18,4 @@ limitations under the License.
 struct FlavourNodes {
 	// Number of master nodes of the cluster.
 	Master Integer
-
-	// Number of compute nodes of the cluster.
-	Compute Integer
-
-	// Number of infra nodes of the cluster.
-	Infra Integer
 }

--- a/model/clusters_mgmt/v1/flavour_resource.model
+++ b/model/clusters_mgmt/v1/flavour_resource.model
@@ -25,7 +25,6 @@ resource Flavour {
 	//
 	// Attributes that can be updated are:
 	//
-	// - `nodes.infra`
 	// - `aws.infra_volume`
 	// - `aws.infra_instance_type`
 	// - `gcp.infra_instance_type`


### PR DESCRIPTION
Since infra and compute nodes are now calculated based on a combination
of CCS and MultiAZ flags, they are no longer considered part of
a flavour, since they can be different defaults in each combination of
the flags. We now calculate the required default nodes as part of the
cluster creation process.