### PR TITLE
SDA-3849 - fix addon installation in model

### DIFF
--- a/model/clusters_mgmt/v1/add_on_installation_type.model
+++ b/model/clusters_mgmt/v1/add_on_installation_type.model
@@ -16,27 +16,9 @@ limitations under the License.
 
 // Representation of an add-on installation in a cluster.
 class AddOnInstallation {
-	// ID used to identify the cluster that this add-on is attached to.
-	link Cluster Cluster
-
 	// Link to add-on attached to this cluster.
 	link Addon AddOn
 
-	// Overall state of the add-on installation.
-	State AddOnInstallationState
-
-	// Reason for the current State.
-	StateDescription String
-
-	// Version of the operator installed by the add-on.
-	OperatorVersion String
-
 	// List of add-on parameters for this add-on installation.
 	link Parameters []AddOnInstallationParameter
-
-	// Date and time when the add-on was initially installed in the cluster.
-	CreationTimestamp Date
-
-	// Date and time when the add-on installation information was last updated.
-	UpdatedTimestamp Date
 }


### PR DESCRIPTION
Closes : https://issues.redhat.com/browse/SDA-3849

Currently we have the wrong object for an AddOn Installation. I created a gist to show the example as how it is outlined in the api [1] versus what the object should look like.  

@jhernand @mikenairn @vkareh PTAL 
Currently the addOnInstallation is a direct representation of the object within Cluster Service. Does this need to be declared in the API, or can we just declare the link to the `AddOn` and the `AddOnInstallationParameters`

[1] - https://api.openshift.com/#/default/post_api_clusters_mgmt_v1_clusters__cluster_id__addons