### PR TITLE
Add event and site code to Terms and SelfTerms requests

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -2,6 +2,11 @@
 
 This document describes the relevant changes between releases of the API model.
 
+== 0.0.115 Apr 13 2021
+
+- Add event_code and site_code to TermsReviewRequest type
+- Add new SelfTermsReviewRequest type
+
 == 0.0.114 Apr 6 2021
 
 - related-resources: Add resource type and cloud provider

--- a/model/authorizations/v1/self_terms_review_request_type.model
+++ b/model/authorizations/v1/self_terms_review_request_type.model
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages Red Hat's Terms and Conditions for using OpenShift Dedicated and Amazon Red Hat OpenShift [Terms]
-// self-review requests.
-resource SelfTermsReview {
-	// Reviews a user's status of Terms.
-	method Post {
-		in Request SelfTermsReviewRequest
-		out Response TermsReviewResponse
-	}
+// Representation of Red Hat's Terms and Conditions for using OpenShift Dedicated and Amazon Red Hat OpenShift [Terms]
+// review requests.
+struct SelfTermsReviewRequest {
+	// Defines the site code of the terms being checked
+	SiteCode string
+	// Defines the event code of the terms being checked
+	EventCode string
 }

--- a/model/authorizations/v1/terms_review_request_type.model
+++ b/model/authorizations/v1/terms_review_request_type.model
@@ -19,4 +19,8 @@ limitations under the License.
 struct TermsReviewRequest {
 	// Defines the username of the account of which Terms is being reviewed.
 	AccountUsername string
+    // Defines the site code of the terms being checked
+    SiteCode string
+    // Defines the event code of the terms being checked
+    EventCode string
 }


### PR DESCRIPTION
These will default to `ocm` and `register` if not provided. This was the previous behavior.