### PR TITLE
Add proper output fields to Push

### DIFF
--- a/model/job_queue/v1/queue_resource.model
+++ b/model/job_queue/v1/queue_resource.model
@@ -23,7 +23,15 @@ resource Queue {
 
     // PUSH a new job into job queue
     method Push {
-        in out Body Job
+        out ID String
+        out Kind String
+        out HREF String
+        in out Arguments String
+        out Attempts Integer
+        out AbandonedAt Date
+        out ReceiptId String
+        out CreatedAt Date
+        out UpdatedAt Date
     }
 
     // POP new job from a job queue


### PR DESCRIPTION
This is the output of `push`:
```json
{
  "id": "3ba0d748-26a4-47f1-bbe3-f4065d303517",
  "kind": "Job",
  "href": "/api/job_queue/v1/jobs/3ba0d748-26a4-47f1-bbe3-f4065d303517",
  "arguments": "foo bar",
  "abandoned_at": "0001-01-01T00:00:00Z",
  "created_at": "2021-05-03T14:22:15.932197971Z",
  "updated_at": "0001-01-01T00:00:00Z"
}

```