### PR TITLE
aws tags: Support for any AWS CCS cluster instead of just STS

### DIFF
--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -31,6 +31,9 @@ struct AWS {
 	// Sets cluster to be inaccessible externally.
 	PrivateLink Boolean
 
+	// Optional keys and values that the installer will add as tags to all AWS resources it creates
+	Tags [String]String
+
 	// Contains the necessary attributes to support role-based authentication on AWS.
 	STS STS
 }

--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -27,7 +27,4 @@ struct STS {
 
 	// List of roles necessary to access the AWS resources of the various operators used during installation
 	OperatorIAMRoles []OperatorIAMRole
-
-	// Optional keys and values that the installer will add as tags to all AWS resources it creates
-	Tags [String]String
 }


### PR DESCRIPTION
Since AWS tags are useful for any AWS CCS cluster, and the OpenShift
installer supports it, we should allow custom tags to be set for any AWS
cluster.

Ref: https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/2899