### PR TITLE
Add more MachineType fields

### DIFF
--- a/model/clusters_mgmt/v1/machine_type_category_type.model
+++ b/model/clusters_mgmt/v1/machine_type_category_type.model
@@ -24,4 +24,7 @@ enum MachineTypeCategory {
 
 	// Compute Optimized machine type.
 	ComputeOptimized
+
+	// Accelerated Computing machine type.
+	AcceleratedComputing
 }

--- a/model/clusters_mgmt/v1/machine_type_type.model
+++ b/model/clusters_mgmt/v1/machine_type_type.model
@@ -31,6 +31,12 @@ class MachineType {
 	// The size of the machine type.
 	Size MachineTypeSize
 
+	// Generic name for quota purposes, for example `highmem-4`.
+	// Cloud provider agnostic - many values are shared between "similar"
+	// machine types on different providers.
+	// Corresponds to `resource_name` values in "compute.node"  quota cost data.
+	GenericName String
+
 	// Link to the cloud provider that the machine type belongs to.
 	link CloudProvider CloudProvider
 

--- a/model/clusters_mgmt/v1/machine_type_type.model
+++ b/model/clusters_mgmt/v1/machine_type_type.model
@@ -33,4 +33,7 @@ class MachineType {
 
 	// Link to the cloud provider that the machine type belongs to.
 	link CloudProvider CloudProvider
+
+	// 'true' if the instance type is supported only for CCS clusters, 'false' otherwise.
+	CCSOnly Boolean
 }


### PR DESCRIPTION
My specific need is honoring `ccs_only` when `ocm create cluster` asking/completing machine types (https://issues.redhat.com/browse/SDA-4245), but saw some other missing stuff.

@tzvatot @ciaranRoche please review.