### PR TITLE
sts: Change custom roles to instance roles

### DIFF
--- a/model/clusters_mgmt/v1/instance_iam_roles.model
+++ b/model/clusters_mgmt/v1/instance_iam_roles.model
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 // Contains the necessary attributes to support role-based authentication on AWS.
-struct CustomIAMRoles {
-	// The name of the IAM role that will be attached to master instances
-	MasterIAMRole String
+struct InstanceIAMRoles {
+	// The IAM role ARN that will be attached to master instances
+	MasterRoleARN String
 
-	// The name of the IAM role that will be attached to worker instances
-	WorkerIAMRole String
+	// The IAM role ARN that will be attached to worker instances
+	WorkerRoleARN String
 
 
 }

--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -28,6 +28,6 @@ struct STS {
 	// List of roles necessary to access the AWS resources of the various operators used during installation
 	OperatorIAMRoles []OperatorIAMRole
 
-	//Custom IAM roles to use for the instance profiles of the master and worker instances
-	CustomIAMRoles CustomIAMRoles
+	// Instance IAM roles to use for the instance profiles of the master and worker instances
+	InstanceIAMRoles InstanceIAMRoles
 }


### PR DESCRIPTION
To prevent user confusion, we change from Custom IAM Roles to Instance
IAM Roles. Also, we now take a full Role ARN instead of just the Role
Name.