### PR TITLE
sts: Add support role ARN

### DIFF
--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -22,6 +22,9 @@ struct STS {
 	// Optional unique identifier when assuming role in another account
 	ExternalID String
 
+	// ARN of the AWS role used by SREs to access the cluster AWS account in order to provide support
+	SupportRoleARN String
+
 	// URL of the location where OIDC configuration and keys are available
 	OIDCEndpointURL String
 


### PR DESCRIPTION
To enable SREs to access an STS cluster's AWS account in order to
provide support, we expose a support role ARN attribute that gets set in
the accountclaim.