### PR TITLE
Add missing connection to Clusters collection

### DIFF
--- a/model/service_logs/v1/root_resource.model
+++ b/model/service_logs/v1/root_resource.model
@@ -20,4 +20,8 @@ resource Root {
 	locator ClusterLogs {
 		target ClusterLogs
 	}
+	// Reference to the resource that manages the collection of clusters for clusters logs.
+	locator Clusters {
+		target Clusters
+	}
 }


### PR DESCRIPTION
IIUC, this connection between the ServiceLogs.V1 resource and the Clusters collection is preventing generation of this method in the ocm-sdk-go.

/cc @vkareh 