### PR TITLE
Add Updates method to Product resource, fix Status Get method

### DIFF
--- a/model/status_board/v1/product_resource.model
+++ b/model/status_board/v1/product_resource.model
@@ -29,5 +29,9 @@ resource Product {
 
   locator Applications {
     target Applications
-  } 
+  }
+
+  locator Updates {
+    target Statuses
+  }
 }

--- a/model/status_board/v1/status_resource.model
+++ b/model/status_board/v1/status_resource.model
@@ -17,7 +17,7 @@ limitations under the License.
 // Provides detailed information about the specified status.
 resource Status {
   method Get {
-    out Body Service
+    out Body Status
   }
 
   method Update {


### PR DESCRIPTION
This PR adds one method, and fixes one bug, for the status-board project.

Our products openapi config has this endpoint: `/api/status-board/v1/products/{id}/updates`, where an `update` is actually a status, hence the difference in type between the locator name and the target type.

While testing I noticed that I was a bit overzealous with the copy/paste and consequently set the `Get` type for the `Status` model incorrectly.