### PR TITLE
WIP: adding field to hold validation error message

### DIFF
--- a/model/clusters_mgmt/v1/add_on_parameter_type.model
+++ b/model/clusters_mgmt/v1/add_on_parameter_type.model
@@ -32,6 +32,9 @@ class AddOnParameter {
 	// Validation rule for the add-on parameter.
 	Validation String
 
+	// Error message to return should the parameter be invalid.
+	ValidationErrMsg String
+
 	// Indicates if this parameter is required by the add-on.
 	Required Boolean
 


### PR DESCRIPTION
When a user enters an invalid value for an add-on parameter, they are returned an error message with the regular expression that the parameter failed to match. This is not a good user experience if the regular expression is long and complex.

I've filed an MR ([uhc-clusters-service!3547](https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3547)) to clusters-service that adds a validation_error_message field that AddOn developers can use to return a custom error message should an invalid parameter value be provided.

This PR adds the ValidationErrMsg field to the api model.