### PR TITLE
Change version gates resource to be gates instead of version_gates

### DIFF
--- a/model/clusters_mgmt/v1/version_resource.model
+++ b/model/clusters_mgmt/v1/version_resource.model
@@ -22,7 +22,7 @@ resource Version {
 	}
 
 	// Reference to version gates.
-	locator VersionGates {
+	locator Gates {
 		target VersionGates
 	}
 }


### PR DESCRIPTION
Change locator name to make sure the URL will be /versions/<version-id>/gates (instead of "version_gates").