### PR TITLE
Use released metamodel binary

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -30,13 +30,5 @@ jobs:
     - name: Checkout the source
       uses: actions/checkout@v2
 
-    - name: Setup Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
-
-    - name: Setup Goimports
-      run: go install golang.org/x/tools/cmd/goimports@v0.0.0-20200518194103-259583f2d8a9
-
     - name: Run the checks
       run: make check

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/
-/metamodel/
+/metamodel
 /openapi/

--- a/Makefile
+++ b/Makefile
@@ -15,29 +15,22 @@
 #
 
 # Details of the metamodel used to check the model:
-metamodel_version:=v0.0.36
-metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel.git
+metamodel_version:=v0.0.45
+metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-linux-amd64
+metamodel_sum:=200ffc61e3e65d28b323f3068b642355795185cf7c335ba5115ba54ccebb7f71
 
 .PHONY: check
 check: metamodel
-	metamodel/metamodel check --model=model
+	./metamodel check --model=model
 
 .PHONY: openapi
 openapi: metamodel
-	metamodel/metamodel generate openapi --model=model --output=openapi
+	./metamodel generate openapi --model=model --output=openapi
 
-.PHONY: metamodel
 metamodel:
-	rm -rf "$@"
-	if [ -d "$(metamodel_url)" ]; then \
-		cp -r "$(metamodel_url)" "$@"; \
-	else \
-		git clone "$(metamodel_url)" "$@"; \
-		cd "$@"; \
-		git fetch --tags origin; \
-		git checkout -B build "$(metamodel_version)"; \
-	fi
-	make -C "$@"
+	wget --progress=dot:giga --output-document="$@" "$(metamodel_url)"
+	echo "$(metamodel_sum) $@" | sha256sum --check
+	chmod +x "$@"
 
 # Enforce indentation by tabs. License contains 2 spaces, so reject 3+.
 lint:


### PR DESCRIPTION
This patch changes the build process so that instead of cloning and
building the metamodel it downloads the prebuilt binary.