### PR TITLE
OVN: Add network type selection

### DIFF
--- a/model/clusters_mgmt/v1/network_type.model
+++ b/model/clusters_mgmt/v1/network_type.model
@@ -16,6 +16,9 @@ limitations under the License.
 
 // Network configuration of a cluster.
 struct Network {
+	// The main controller responsible for rendering the core networking components.
+	Type String
+
 	// IP address block from which to assign pod IP addresses, for example `10.128.0.0/14`.
 	PodCIDR String
 


### PR DESCRIPTION
This enables preliminary support for OVNKubernetes in addition to
OpenShiftSDN.