### PR TITLE
sts: Allow adding/removing operator roles

### DIFF
--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -139,4 +139,8 @@ resource Cluster {
 	locator GateAgreements {
 	    target VersionGateAgreements
 	}
+
+	locator STSOperatorRoles {
+		target OperatorIAMRoles
+	}
 }

--- a/model/clusters_mgmt/v1/operator_iam_role_resource.model
+++ b/model/clusters_mgmt/v1/operator_iam_role_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Red Hat, Inc.
+Copyright (c) 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Contains the necessary attributes to allow each operator to access the necessary AWS resources
-struct OperatorIAMRole {
-	// Randomly-generated ID to identify the operator role
-	ID String
-
-	// Name of the operator
-	Name String
-
-	// Namespace where the operator lives in the cluster
-	Namespace String
-
-	// Role to assume when accessing AWS resources
-	RoleARN String
-
-	// Service account name to use when authenticating
-	ServiceAccount String
+// Manages a list of operator roles for STS clusters.
+resource OperatorIAMRole {
+	// Deletes the operator role.
+	method Delete {
+	}
 }

--- a/model/clusters_mgmt/v1/operator_iam_roles_resource.model
+++ b/model/clusters_mgmt/v1/operator_iam_roles_resource.model
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of operator roles.
+resource OperatorIAMRoles {
+	// Retrieves the list of operator roles.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
+
+		// Retrieved list of operator roles.
+		out Items []OperatorIAMRole
+	}
+
+	// Adds a new operator role to the cluster.
+	method Add {
+		// Description of the operator role.
+		in out Body OperatorIAMRole
+	}
+
+	// Returns a reference to the service that manages a specific operator role.
+	locator OperatorIAMRole {
+		target OperatorIAMRole
+		variable ID
+	}
+}


### PR DESCRIPTION
This change allows users to fetch, add, remove operator roles. Operator
roles contain the name and namespace where the manifest configmap will
set it, along with a service account and associated role ARN for
verifying authentication.

This allows for day-2 operators and addons that rely on AssumeRole calls
for accessing cloud resources.

- https://issues.redhat.com/browse/SDA-5366
- https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3772