### PR TITLE
addons: Support attributes necessary for STS

### DIFF
--- a/model/clusters_mgmt/v1/add_on_installation_type.model
+++ b/model/clusters_mgmt/v1/add_on_installation_type.model
@@ -34,6 +34,9 @@ class AddOnInstallation {
 	// Version of the operator installed by the add-on.
 	OperatorVersion String
 
+	// Role ARN used to authenticate the addon operator
+	RoleARN String
+
 	// List of add-on parameters for this add-on installation.
 	link Parameters []AddOnInstallationParameter
 

--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -55,6 +55,12 @@ class AddOn {
 	// Indicates if this add-on has external resources associated with it
 	HasExternalResources Boolean
 
+	// The name of the service account used when authenticating
+	ServiceAccount String
+
+	// List of policy permissions needed to access cloud resources
+	PolicyPermissions []String
+
 	// List of parameters for this add-on.
 	link Parameters []AddOnParameter
 


### PR DESCRIPTION
Add-ons that need access to AWS resources on STS clusters need to define
a list of policy permissions, a service account, and the installation
needs a role ARN to allow the operator to authenticate.

* https://issues.redhat.com/browse/SDA-5367
* https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/3783