### PR TITLE
Add ProductIds string param to statuses_resource.model

### DIFF
--- a/model/status_board/v1/statuses_resource.model
+++ b/model/status_board/v1/statuses_resource.model
@@ -22,6 +22,7 @@ resource Statuses {
     in out Size Integer = 100
     in CreatedAfter Date
     in CreatedBefore Date
+    in ProductIds String
     out Total Integer
     out Items []Status
   }


### PR DESCRIPTION
This PR adds a `ProductIds` input parameter for the `Status` model. This is to match the `/api/status-board/v1/status_updates` endpoint that was added in our openapi config.

Until `List` functions accept an array of params (see https://github.com/openshift-online/ocm-sdk-go/issues/565), this will have to be a comma separated string.