### PR TITLE
Add StatusUpdate model to match endpoint in status-board

### DIFF
--- a/model/status_board/v1/status_update_resource.model
+++ b/model/status_board/v1/status_update_resource.model
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Provides detailed information about the specified status.
+resource StatusUpdate {
+  method Get {
+    out Body Status
+  }
+
+  method Update {
+    in out Body Status
+  }
+
+  method Delete {
+  }
+}

--- a/model/status_board/v1/status_update_type.model
+++ b/model/status_board/v1/status_update_type.model
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Definition of a Status Board status update. In reality, just a Status for
+// its own endpoint.
+
+class StatusUpdate {
+  // Object creation timestamp.
+  CreatedAt Date
+
+  // Object modification timestamp.
+  UpdatedAt Date
+
+  // The associated service ID.
+  Service Service
+
+  // Additional Service related data.
+  ServiceInfo ServiceInfo
+
+  // A status message for the given service.
+  Status String
+
+  // Miscellaneous metadata about the application.
+  Metadata Interface
+}

--- a/model/status_board/v1/status_updates_resource.model
+++ b/model/status_board/v1/status_updates_resource.model
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of statuses
+resource StatusUpdates {
+  // Retrieves the list of statuses.
+  method List {
+    in out Page Integer = 1
+    in out Size Integer = 100
+    in CreatedAfter Date
+    in CreatedBefore Date
+    out Total Integer
+    out Items []Status
+  }
+
+  method Add {
+    in out Body Status
+  }
+
+  locator Status {
+    target Status
+    variable ID
+  }
+}

--- a/model/status_board/v1/status_updates_resource.model
+++ b/model/status_board/v1/status_updates_resource.model
@@ -22,6 +22,7 @@ resource StatusUpdates {
     in out Size Integer = 100
     in CreatedAfter Date
     in CreatedBefore Date
+    in ProductIds String
     out Total Integer
     out Items []Status
   }


### PR DESCRIPTION
Currently we have an endpoint defined within status-board as `/api/status-board/v1/status_updates` instead of the expected `/api/status-board/v1/statuses`.

That means that currently doing something like `connection.StatusBoard().V1().Statuses()` will result in an error `The requested resource '/api/status-board/v1/statuses' doesn't exist`. (However, it may be defined at some point, so I'd like to leave it for now.)

So, this PR adds a `StatusUpdate` model to match the currently defined endpoint.

If this isn't necessary and/or I'm doing something wrong, please let me know.