### PR TITLE
Release 0.0.177

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.1.177 Mar 3 2022
+
+- Fix update method of environment endpoint, should be `Update` instead of
+  `Patch`.
+
+- Remove unimplemented `POST /api/service_logs/v1/cluster_logs/clusters/{uuid}/cluster_logs`
+  method.
+
 ## 0.1.176 Mar 02 2022
 - Add environment endpoint get and patch
 


### PR DESCRIPTION
The more relevant changes in the new version are the following:

- Fix update method of environment endpoint, should be `Update` instead of
  `Patch`.

- Remove unimplemented `POST /api/service_logs/v1/cluster_logs/clusters/{uuid}/cluster_logs`
  method.