### PR TITLE
addons: Add credentials secret name attribute

### DIFF
--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -58,6 +58,9 @@ class AddOn {
 	// The name of the service account used when authenticating
 	ServiceAccount String
 
+	// Name of the secret that will hold the credentials required to access cloud resources.
+	CredentialsSecret String
+
 	// List of policy permissions needed to access cloud resources
 	PolicyPermissions []String
 

--- a/model/clusters_mgmt/v1/operator_iam_role_type.model
+++ b/model/clusters_mgmt/v1/operator_iam_role_type.model
@@ -19,10 +19,10 @@ struct OperatorIAMRole {
 	// Randomly-generated ID to identify the operator role
 	ID String
 
-	// Name of the operator
+	// Name of the credentials secret used to access cloud resources
 	Name String
 
-	// Namespace where the operator lives in the cluster
+	// Namespace where the credentials secret lives in the cluster
 	Namespace String
 
 	// Role to assume when accessing AWS resources


### PR DESCRIPTION
To support STS addons, we need to allow addon developers to choose their
own naming convention for credentials secret, rather than enforcing one
in OCM. This attribute ensures that we can create the secret syncset
with the correct information.