### PR TITLE
Fix path segment of cluster logs

### DIFF
--- a/model/service_logs/v1/cluster_resource.model
+++ b/model/service_logs/v1/cluster_resource.model
@@ -18,7 +18,7 @@ limitations under the License.
 resource Cluster {
 
 	// Reference to the list of cluster logs for a specific cluster uuid.
-	locator ClusterLogsUUID {
+	locator ClusterLogs {
 		target ClusterLogsUUID
 	}
 }


### PR DESCRIPTION
The URL of the path segment for the logs of a specific cluster should be
`/api/service_logs/clusters/{id}/cluster_logs` but due to an error in
the corresponding locator the last segment is currently
`cluster_logs_uuid`. This patch fixes that.