### PR TITLE
Add ReleaseImage to Version

### DIFF
--- a/model/clusters_mgmt/v1/version_type.model
+++ b/model/clusters_mgmt/v1/version_type.model
@@ -40,4 +40,7 @@ class Version {
 	// EndOfLifeTimestamp is the date and time when the version will get to End of Life, using the
 	// format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].
 	EndOfLifeTimestamp Date
+
+	// ReleaseImage contains the URI of Openshift release image
+	ReleaseImage String
 }


### PR DESCRIPTION
In order to spin up Hypershift clusters, we need to be able to retrieve the
release image info from the Version object. This PR aims to add
this info by adding a String field to Version model.

* Relates SDA-5531