### PR TITLE
addons: Support STS addons with multiple operators

### DIFF
--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -55,14 +55,8 @@ class AddOn {
 	// Indicates if this add-on has external resources associated with it
 	HasExternalResources Boolean
 
-	// The name of the service account used when authenticating
-	ServiceAccount String
-
-	// Name of the secret that will hold the credentials required to access cloud resources.
-	CredentialsSecret String
-
-	// List of policy permissions needed to access cloud resources
-	PolicyPermissions []String
+	// List of credentials requests to authenticate operators to access cloud resources.
+	CredentialsRequests []CredentialRequest
 
 	// List of parameters for this add-on.
 	link Parameters []AddOnParameter

--- a/model/clusters_mgmt/v1/credential_request_type.model
+++ b/model/clusters_mgmt/v1/credential_request_type.model
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to allow each operator to access the necessary AWS resources
+struct CredentialRequest {
+	// Name of the credentials secret used to access cloud resources
+	Name String
+
+	// Namespace where the credentials secret lives in the cluster
+	Namespace String
+
+	// Service account name to use when authenticating
+	ServiceAccount String
+
+	// List of policy permissions needed to access cloud resources
+	PolicyPermissions []String
+}


### PR DESCRIPTION
For STS addons that contain multiple operators, each operator may need
a different credentials request to ensure they have the least necessary
permission.

* https://github.com/mt-sre/managed-tenants-cli/pull/112
* https://gitlab.cee.redhat.com/service/managed-tenants/-/merge_requests/1843
* https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/4010
* https://github.com/openshift/rosa/compare/master...vkareh:SDA-5368/sts-addons