### PR TITLE
Add Status query param for incidents resource

### DIFF
--- a/model/web_rca/v1/incidents_resource.model
+++ b/model/web_rca/v1/incidents_resource.model
@@ -29,7 +29,7 @@ resource Incidents {
     in ResponsibleManagerId String
     in ParticipantId String
     in Mine Boolean
-    // in Status String - TODO: This causes problems, figure out why
+    in Status String
     in IncidentName String
     out Total Integer
     out Items []Incident


### PR DESCRIPTION
After making this change I ran `>make model_version=HEAD model_url=/Users/dberger/Dev/ocm-api-model generate`. That seemed to work.

However, if I then try to build an example web-rca program with those changes I get the following:

```
>go build examples/list_webrca_incidents.go

# github.com/openshift-online/ocm-sdk-go/webrca/v1
webrca/v1/incidents_resource_json.go:102:9: request.status undefined (type *IncidentsListServerRequest has no field or method status)
```

It looks like it generated a `Status_` function and `status_` fields instead for some reason. Is the word "status" a keyword of some sort? What am I doing wrong?