### PR TITLE
Add errors resource for webrca

### DIFF
--- a/model/web_rca/v1/error_resource.model
+++ b/model/web_rca/v1/error_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Red Hat, Inc.
+Copyright (c) 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Root of the tree of resources for applications.
-resource Root {
-  locator Incidents {
-    target Incidents 
-  }
-
-  locator Users {
-    target Users
-  }
-
-  locator Errors {
-    target Errors
+// Provides detailed information about a specific error.
+resource Error {
+  method Get {
+    out Body Error
   }
 }

--- a/model/web_rca/v1/error_type.model
+++ b/model/web_rca/v1/error_type.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Red Hat, Inc.
+Copyright (c) 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Root of the tree of resources for applications.
-resource Root {
-  locator Incidents {
-    target Incidents 
-  }
-
-  locator Users {
-    target Users
-  }
-
-  locator Errors {
-    target Errors
-  }
+// Definition of a Web RCA error.
+class Error {
+  Code String
+  Reason String
 }

--- a/model/web_rca/v1/errors_resource.model
+++ b/model/web_rca/v1/errors_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Red Hat, Inc.
+Copyright (c) 2022 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Root of the tree of resources for applications.
-resource Root {
-  locator Incidents {
-    target Incidents 
+// Manages the collection of errors.
+resource Errors {
+  // Retrieves the list of errors.
+  method List {
+    in out Page Integer = 1
+    in out Size Integer = 100
+    out Total Integer
+    out Items []Error
   }
 
-  locator Users {
-    target Users
-  }
-
-  locator Errors {
-    target Errors
+  locator Error {
+    target Error
+    variable ID
   }
 }


### PR DESCRIPTION
This adds the `errors` resource for web-rca.

Marked draft for now because even after running `make model_version=HEAD model_url=/home/dberger/Dev/ocm-api-model generate` it doesn't seem to generate an `Errors` function.