### PR TITLE
Fix JSON names of identity provider types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@
 #
 
 # Details of the metamodel used to check the model:
-metamodel_version:=v0.0.45
+metamodel_version:=v0.0.54
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-linux-amd64
-metamodel_sum:=200ffc61e3e65d28b323f3068b642355795185cf7c335ba5115ba54ccebb7f71
+metamodel_sum:=76ea3d91a7d601c5e8891455c8c43a918e8dac21c9b1397f636c5b01af0afa7d
 
 .PHONY: check
 check: metamodel

--- a/model/clusters_mgmt/v1/identity_provider_type.model
+++ b/model/clusters_mgmt/v1/identity_provider_type.model
@@ -57,11 +57,22 @@ class IdentityProvider {
 
 // Type of identity provider.
 enum IdentityProviderType {
+	@json(name = "GithubIdentityProvider")
 	Github
+
+	@json(name = "GitlabIdentityProvider")
 	Gitlab
+
+	@json(name = "GoogleIdentityProvider")
 	Google
+
+	@json(name = "HTPasswdIdentityProvider")
 	Htpasswd
+
+	@json(name = "LDAPIdentityProvider")
 	LDAP
+
+	@json(name = "OpenIDIdentityProvider")
 	OpenID
 }
 


### PR DESCRIPTION
The values of the `IdentityProviderType` enum don't match what the
server accepts. This patch fixes that.

Related: https://github.com/openshift-online/ocm-sdk-go/issues/624