### PR TITLE
Add ClusterType field to cluster resource

### DIFF
--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -205,4 +205,7 @@ class Cluster {
 
   // Contains information about Managed Service
   ManagedService ManagedService
+
+  // Contains the type of the cluster
+  ClusterType String
 }


### PR DESCRIPTION
* The ClusterType field indicates whether the cluster is created by Hive or Hypershift.