### PR TITLE
Add `hypershift.enabled` to cluster type

### DIFF
--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -205,4 +205,7 @@ class Cluster {
 
   // Contains information about Managed Service
   ManagedService ManagedService
+
+	// HyperShift configuration.
+	Hypershift HyperShift
 }

--- a/model/clusters_mgmt/v1/hypershift_type.model
+++ b/model/clusters_mgmt/v1/hypershift_type.model
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// HyperShift configuration.
+struct HyperShift {
+	// Boolean flag indicating if the cluster should be creating using _HyperShift_.
+	//
+	// By default this is `false`.
+	//
+	// To enable it the cluster needs to be ROSA cluster and the organization of the user needs
+	// to have the `hypershift` capability enabled.
+	Enabled Boolean
+}


### PR DESCRIPTION
This patch adds the `hypershift.enabled` flag to the cluster type. This
will be used to indicate if the cluster should be created using
`HyperShift`.

Related: Related: https://issues.redhat.com/browse/SDE-1586  