### PR TITLE
Release 0.0.206

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.206 Jun 09 2022
+- Add `excludeSubscriptionStatuses` field to ResourceReview type.
+
 ## 0.0.205 Jun 03 2022
 - Add `BillingMarketplaceAccount` field to ReservedResource type.
 

--- a/model/authorizations/v1/resource_review_request_type.model
+++ b/model/authorizations/v1/resource_review_request_type.model
@@ -28,4 +28,8 @@ struct ResourceReviewRequest {
 	// If true, in the case when all subscriptions in organization are permitted, response will *not* include
 	// these subscriptions' ID, but organization only.
 	ReduceClusterList Boolean
+
+	// A comma-separated list of subscription statuses.
+	// Subscriptions with these statuses will be excluded from results.
+	excludeSubscriptionStatuses string
 }


### PR DESCRIPTION
Add excludeSubscriptionStatuses field to ResourceReview type. Its value is a comma-separated list of subscription statuses. Subscriptions with these statuses will be excluded from results.
