### PR TITLE
Finalizing Installation state for cluster

### DIFF
--- a/model/clusters_mgmt/v1/cluster_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_state_type.model
@@ -28,6 +28,9 @@ enum ClusterState {
 	// The cluster is still being installed.
 	Installing
 
+	// The cluster is installed and being prepared for use.
+	FinalizingInstallation
+
 	// The cluster is ready to use.
 	Ready
 


### PR DESCRIPTION
Adding new ready-like HyperShift cluster state for SDA-5536.

HyperShift cluster will be in `finalizing_installation` state after its API and console URLs are available and before remaining work is completed (when it will reach `ready` state)
