### PR TITLE
Reverting the addition of new finalizing_installation cluster state

### DIFF
--- a/model/clusters_mgmt/v1/cluster_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_state_type.model
@@ -28,9 +28,6 @@ enum ClusterState {
 	// The cluster is still being installed.
 	Installing
 
-	// The cluster is installed and being prepared for use.
-	FinalizingInstallation
-
 	// The cluster is ready to use.
 	Ready
 


### PR DESCRIPTION
The current approach changed and the new state won't be needed (for now).