### PR TITLE
SDA-6528: Add Hypershift endpoint

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.224 Sep 16 2022
+- Add hypershift endpoint with its ManagementCluster.
+- Align hypershift case usage.
+
 ## 0.0.223 Sep 12 2022
 - Add `Version` property to CloudProviderData model.
 - Add `InfraID` property to Cluster model.

--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -146,4 +146,8 @@ resource Cluster {
 	locator STSOperatorRoles {
 		target OperatorIAMRoles
 	}
+
+	locator Hypershift {
+		target Hypershift
+	}
 }

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -205,6 +205,6 @@ class Cluster {
   // Contains information about Managed Service
   ManagedService ManagedService
 
-	// HyperShift configuration.
-	Hypershift HyperShift
+	// Hypershift configuration.
+	Hypershift Hypershift
 }

--- a/model/clusters_mgmt/v1/hypershift_config_type.model
+++ b/model/clusters_mgmt/v1/hypershift_config_type.model
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Hypershift configuration.
-struct Hypershift {
+struct HypershiftConfig {
 	// Boolean flag indicating if the cluster should be creating using _Hypershift_.
 	//
 	// By default this is `false`.
@@ -23,4 +23,8 @@ struct Hypershift {
 	// To enable it the cluster needs to be ROSA cluster and the organization of the user needs
 	// to have the `hypershift` capability enabled.
 	Enabled Boolean
+
+	// Contains the name of the current management cluster for this Hypershift cluster.
+	// Empty for non Hypershift clusters.
+	ManagementCluster String
 }

--- a/model/clusters_mgmt/v1/hypershift_resource.model
+++ b/model/clusters_mgmt/v1/hypershift_resource.model
@@ -14,13 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Hypershift configuration.
-struct Hypershift {
-	// Boolean flag indicating if the cluster should be creating using _Hypershift_.
-	//
-	// By default this is `false`.
-	//
-	// To enable it the cluster needs to be ROSA cluster and the organization of the user needs
-	// to have the `hypershift` capability enabled.
-	Enabled Boolean
+// Manages a specific Hypershift cluster.
+resource Hypershift {
+	// Retrieves the Hypershift details for a single cluster.
+	method Get {
+		out Body HypershiftConfig
+	}
 }


### PR DESCRIPTION
Add an endpoint to get Hypershift cluster info
Align case usage with CS to use Hypershift instead of HyperShift