### PR TITLE
Add cluster.infra_id.

### DIFF
--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -54,6 +54,9 @@ class Cluster {
 	// cluster is created.
 	Name String
 
+	// InfraID is used for example to name the VPCs.
+	InfraID String
+
 	// Link to the _flavour_ that was used to create the cluster.
 	link Flavour Flavour
 


### PR DESCRIPTION
the infra_id is missing from the mode

here I can see it:
```
❯ ocm get clusters
{
  "kind": "ClusterList",
  "page": 1,
  "size": 1,
  "total": 1,
  "items": [
    {
      "kind": "Cluster",
      "id": "1uhu7h9aff2affamolrda6lggqhoicjo",
      "href": "/api/clusters_mgmt/v1/clusters/1uhu7h9aff2affamolrda6lggqhoicjo",
      "name": "cna-binding1",
      "external_id": "6c35426b-1a06-4a05-bf49-1c5df07f861d",
      "infra_id": "cna-binding1-hhvk5",
      "display_name": "cna-binding1",
      ...
```

I'm new here. Do I need to do something else? This is part of this effort: https://issues.redhat.com/browse/OSDEV-681
     