### PR TITLE
Add `availability zone` field to the cloud provider data struct

### DIFF
--- a/model/clusters_mgmt/v1/provider_data_inquiry_type.model
+++ b/model/clusters_mgmt/v1/provider_data_inquiry_type.model
@@ -33,4 +33,7 @@ struct CloudProviderData {
 
     // Openshift version
     Version Version
+
+    // Availability zone
+    AvailabilityZone String
 }


### PR DESCRIPTION
The new field will enable filtering machine types per availability zone.

The equivalent change in the backend:
```
type CloudProviderInquiries struct {
	GCP              *GCP         `json:"gcp,omitempty"`
	Region           *CloudRegion `json:"region,omitempty"`
	KeyLocation      *string      `json:"key_location,omitempty"`
	KeyRingName      *string      `json:"key_ring_name,omitempty"`
	AWS              *AWS         `json:"aws,omitempty"`
	Version          *Version     `json:"version,omitempty"`
-->     AvailabilityZone *string      `json:"availability_zone,omitempty"`
}
```

Related: [SDA-7193](https://issues.redhat.com/browse/SDA-7193), [SDA-7161](https://issues.redhat.com/browse/SDA-7161)