### PR TITLE
Modify availability zone filed to support multiple availability zones

### DIFF
--- a/model/clusters_mgmt/v1/provider_data_inquiry_type.model
+++ b/model/clusters_mgmt/v1/provider_data_inquiry_type.model
@@ -35,5 +35,5 @@ struct CloudProviderData {
     Version Version
 
     // Availability zone
-    AvailabilityZone String
+    AvailabilityZones []String
 }


### PR DESCRIPTION
This change will enable to list of supported machine types for multiple availability zones.

Related: [SDA-7193](https://issues.redhat.com/browse/SDA-7193)

This change is reflected in the backend:
```
type CloudProviderInquiries struct {
	GCP               *GCP         `json:"gcp,omitempty"`
	Region            *CloudRegion `json:"region,omitempty"`
	KeyLocation       *string      `json:"key_location,omitempty"`
	KeyRingName       *string      `json:"key_ring_name,omitempty"`
	AWS               *AWS         `json:"aws,omitempty"`
	Version           *Version     `json:"version,omitempty"`
-->     AvailabilityZones []string     `json:"availability_zones,omitempty"`
}
```