### PR TITLE
Add `ARN` field to the `AWSSTSPolicy` struct

### DIFF
--- a/model/clusters_mgmt/v1/aws_sts_policies_type.model
+++ b/model/clusters_mgmt/v1/aws_sts_policies_type.model
@@ -25,4 +25,7 @@ struct AWSSTSPolicy {
 
     //Type of policy operator/account role
     Type String
+
+    //The ARN of the managed policy
+    ARN String
 }


### PR DESCRIPTION
The field will contain the ARN of the AWS-managed policy.

Related: [SDA-7640](https://issues.redhat.com/browse/SDA-7640)

This PR reflects a recent change in the backend https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/blob/master/pkg/models/aws_sts_policies.go#L7.