### PR TITLE
[SDA-7757] Add bound service account signing key secret arn

### DIFF
--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -52,4 +52,7 @@ struct STS {
 
 	// Kms Id for the bound service account signing key.
 	BoundServiceAccountKeyKmsId String
+
+	// Secrets Manager ARN for the bound service account signing key.
+	BoundServiceAccountKeySecretArn String
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-7757

# What
Adds bound service account signing key secret arn option to sts

# Why
Allow clients to specify value for the secret arn which contains the bound service account signing key