### PR TITLE
Export cluster name for mgmt, mgmt_parent, and svc clusters

### DIFF
--- a/model/osd_fleet_mgmt/v1/management_cluster_parent_type.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_parent_type.model
@@ -19,6 +19,9 @@ struct ManagementClusterParent {
 	// Parent Cluster ID 
 	ClusterId String
 
+	// Parent Cluster Name
+	Name String
+
 	// Reference link to internal parent cluster
 	Href String 
 

--- a/model/osd_fleet_mgmt/v1/management_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_type.model
@@ -53,6 +53,9 @@ class ManagementCluster {
 	// Cluster mgmt reference
 	ClusterManagementReference ClusterManagementReference
 
+	// Cluster name
+	Name String
+
 	// Cloud provider region where the cluster is installed.
 	Region String
 
@@ -67,6 +70,4 @@ class ManagementCluster {
 
 	// Management cluster handling the management cluster
 	link Parent ManagementClusterParent
-
-
 }

--- a/model/osd_fleet_mgmt/v1/service_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_type.model
@@ -53,6 +53,9 @@ class ServiceCluster {
 	// Cluster mgmt reference
 	ClusterManagementReference ClusterManagementReference
 
+	// Cluster name
+	Name String
+
 	// Cloud provider region where the cluster is installed.
 	Region String
 


### PR DESCRIPTION
For https://github.com/openshift-online/ocm-cli/pull/441, having the `Name` of these clusters available through ocm-sdk-go will save additional unneeded requests to the API.

Internal IDs are already available via `ClusterManagementReference`s