### PR TITLE
Add `ManagedPolicies` field to the `STS` struct

### DIFF
--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -49,4 +49,7 @@ struct STS {
 
 	// Secrets Manager ARN for the OIDC private key key.
 	OidcPrivateKeySecretArn String
+
+	// If true, cluster account and operator roles have managed policies attached.
+	ManagedPolicies Boolean
 }


### PR DESCRIPTION
The field will help to identify if the cluster is using managed policies.

This MR reflects a recent change in the backend:
https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/5317/diffs#560bb0a58d31177945b6df30a235999b3b84c020_400_400

Related: [SDA-8278](https://issues.redhat.com/browse/SDA-8278)