### PR TITLE
[SDA-8369] Added HypershiftEnabled to Version type model and changes for release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.263 Mar 7 2023
+- Add `HypershiftEnabled` boolean to `Version` Type model.
+
 ## 0.0.262 Mar 6 2023
 - Add `Control Plane Upgrade Scheduler` endpoints.
 

--- a/model/clusters_mgmt/v1/version_type.model
+++ b/model/clusters_mgmt/v1/version_type.model
@@ -34,6 +34,9 @@ class Version {
 	// ROSAEnabled indicates whether this version can be used to create ROSA clusters.
 	ROSAEnabled Boolean
 
+	// HypershiftEnabled indicates whether this version can be used to create Hypershift clusters.
+	HypershiftEnabled Boolean
+
 	// AvailableUpgrades is the list of versions this version can be upgraded to.
 	AvailableUpgrades []String
 


### PR DESCRIPTION
SDA-8369 is about adding a new column to versions `hypershift_enabled` -- this is the start of this effort in which I am adding the field to the versions type model.