### PR TITLE
[SDA-8611] Update cluster creation flow to use oidc-config-id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.267 Mar 24 2023
+- Add `OidcConfigId` to `STS` resource.
+- Remove `OidcPrivateKeySecretArn` from `STS` resource.
+
 ## 0.0.266 Mar 17 2023
 - Adjust `Oidc Configs` endpoints.
 

--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -47,9 +47,9 @@ struct STS {
 	// Optional user provided permission boundary.
 	PermissionBoundary String
 
-	// Secrets Manager ARN for the OIDC private key key.
-	OidcPrivateKeySecretArn String
-
 	// If true, cluster account and operator roles have managed policies attached.
 	ManagedPolicies Boolean
+
+	// Registered Oidc Config ID, if available holds information related to the oidc config
+	OidcConfigId String
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/SDA-8611

## 0.0.267 Mar 24 2023
- Add `OidcConfigId` to `STS` resource.
- Remove `OidcPrivateKeySecretArn` from `STS` resource.