### PR TITLE
 [SDA-8611] fix: Update cluster creation flow to use oidc-config-id 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.268 Mar 24 2023
+- Replace `OidcConfigId` for `OidcConfig` in `STS` resource.
+
 ## 0.0.267 Mar 24 2023
 - Add `OidcConfigId` to `STS` resource.
 - Remove `OidcPrivateKeySecretArn` from `STS` resource.

--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -50,6 +50,6 @@ struct STS {
 	// If true, cluster account and operator roles have managed policies attached.
 	ManagedPolicies Boolean
 
-	// Registered Oidc Config ID, if available holds information related to the oidc config
-	OidcConfigId String
+	// Registered Oidc Config, if available holds information related to the oidc config
+	OidcConfig OidcConfig
 }


### PR DESCRIPTION
## 0.0.268 Mar 24 2023
- Replace `OidcConfigId` for `OidcConfig` in `STS` resource.