### PR TITLE
Openapi model fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@
 #
 
 # Details of the metamodel used to check the model:
-metamodel_version:=v0.0.54
+metamodel_version:=v0.0.57
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-linux-amd64
-metamodel_sum:=76ea3d91a7d601c5e8891455c8c43a918e8dac21c9b1397f636c5b01af0afa7d
+metamodel_sum:=c229bd1fbaa882de5d2ba1f435d10cb3f86d6f79a441e8accc9c90ebb5365e93
 
 .PHONY: check
 check: metamodel

--- a/model/clusters_mgmt/v1/add_on_installation_type.model
+++ b/model/clusters_mgmt/v1/add_on_installation_type.model
@@ -16,9 +16,6 @@ limitations under the License.
 
 // Representation of an add-on installation in a cluster.
 class AddOnInstallation {
-	// ID used to identify the cluster that this add-on is attached to.
-	link Cluster Cluster
-
 	// Link to add-on attached to this cluster.
 	link Addon AddOn
 

--- a/model/clusters_mgmt/v1/ingress_type.model
+++ b/model/clusters_mgmt/v1/ingress_type.model
@@ -16,9 +16,6 @@ limitations under the License.
 
 // Representation of an ingress.
 class Ingress {
-	// ID used to identify the cluster that this ingress is attached to. 
-	link Cluster Cluster
-
 	// Indicates if this is the default ingress.
 	Default Boolean
 

--- a/model/clusters_mgmt/v1/machine_pool_type.model
+++ b/model/clusters_mgmt/v1/machine_pool_type.model
@@ -16,9 +16,6 @@ limitations under the License.
 
 // Representation of a machine pool in a cluster.
 class MachinePool {
-	// ID used to identify the cluster that this machinepool is attached to.
-	link Cluster Cluster
-
 	// The number of Machines (and Nodes) to create.
 	// Replicas and autoscaling cannot be used together.    
 	Replicas Integer

--- a/model/clusters_mgmt/v1/node_pool_type.model
+++ b/model/clusters_mgmt/v1/node_pool_type.model
@@ -16,9 +16,6 @@ limitations under the License.
 
 // Representation of a node pool in a cluster.
 class NodePool {
-    // ID used to identify the cluster that this node pool is attached to.
-    link Cluster Cluster
-
     // The number of Machines (and Nodes) to create.
     // Replicas and autoscaling cannot be used together.
     Replicas Integer


### PR DESCRIPTION
This change contains a number of fixes for the openapi model. The openapi model created for clusters_mgmt currently is not a valid openapi model, due to missing parameter elements and circular dependencies.

First is bumping the metamodel version, this is to include a vital change to the openapi which is generator, to include the field `required: true` for path parameters.

The second change is removing  the circular dependency from clusters mgmt, as we have a number of objects which reference the cluster object. Despite not using these references at the api level. 