### PR TITLE
Add Subnets field to the cloud provider data struct

### DIFF
--- a/model/clusters_mgmt/v1/provider_data_inquiry_type.model
+++ b/model/clusters_mgmt/v1/provider_data_inquiry_type.model
@@ -36,4 +36,7 @@ struct CloudProviderData {
 
     // Availability zone
     AvailabilityZones []String
+
+    // Subnets
+    Subnets []String
 }


### PR DESCRIPTION
The new field enables filtering VPCs by associated subnets.

The equivalent change in the backend:

```
type CloudProviderInquiries struct {
	GCP              *GCP         `json:"gcp,omitempty"`
	Region           *CloudRegion `json:"region,omitempty"`
	KeyLocation      *string      `json:"key_location,omitempty"`
	KeyRingName      *string      `json:"key_ring_name,omitempty"`
	AWS              *AWS         `json:"aws,omitempty"`
	Version          *Version     `json:"version,omitempty"`
        AvailabilityZone *string      `json:"availability_zone,omitempty"`
-->     Subnets           []string     `json:"subnets,omitempty"`
}

```

Related: [SDA-8840](https://issues.redhat.com/browse/SDA-8840)