### PR TITLE
feat: Makefile support OSX and Windows

### DIFF
--- a/.github/workflows/check-pull-request.yaml
+++ b/.github/workflows/check-pull-request.yaml
@@ -22,13 +22,19 @@ on:
     - main
 
 jobs:
+  test_matrix:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
     steps:
     - name: Checkout the source
       uses: actions/checkout@v2
+
+    - name: Install coreutils for macOS
+      if: matrix.os == 'macos-latest'
+      run: brew install coreutils
 
     - name: Run the checks
       run: make check


### PR DESCRIPTION
Prior to this patch, the models could only be built on Linux. Now
Windows and OSX are supported.
The Make build will fail if the OS is not Windows, Linux or OSX.

Signed-off-by: Sébastien Han <seb@redhat.com>