### PR TITLE
[OCM-16] Add RootVolume to MachineType

### DIFF
--- a/model/clusters_mgmt/v1/machine_type_root_volume_type.model
+++ b/model/clusters_mgmt/v1/machine_type_root_volume_type.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Machine type root volume.
+struct MachineTypeRootVolume {
+	// AWS volume specification
+	AWS AWSVolume
+
+	// GCP Volume specification
+	GCP GCPVolume
+}

--- a/model/clusters_mgmt/v1/machine_type_type.model
+++ b/model/clusters_mgmt/v1/machine_type_type.model
@@ -42,4 +42,7 @@ class MachineType {
 
 	// 'true' if the instance type is supported only for CCS clusters, 'false' otherwise.
 	CCSOnly Boolean
+
+	// The machine root volume capabilities.
+	RootVolume MachineTypeRootVolume
 }


### PR DESCRIPTION
This will allow us to set a Size and/or IOPS for a given root volume.

Signed-off-by: Sébastien Han <seb@redhat.com>