### PR TITLE
Revert "Changing parameter name from HttpTokensState to Ec2MetadataHttpTokens"

### DIFF
--- a/model/clusters_mgmt/v1/aws_http_token_state_type.model
+++ b/model/clusters_mgmt/v1/aws_http_token_state_type.model
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
-enum Ec2MetadataHttpTokens {
+// Which HttpTokensState to use for metadata service interaction options for EC2 instances
+enum HttpTokenState {
 	// imdsv2 is optional
 	Optional
 

--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -52,6 +52,6 @@ struct AWS {
 	// Audit log forwarding configuration
 	AuditLog AuditLog
 
-	// Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
-	Ec2MetadataHttpTokens Ec2MetadataHttpTokens
+       // Which HttpTokensState to use for metadata service interaction options for EC2 instances
+	HttpTokensState HttpTokenState
 }


### PR DESCRIPTION
Reverts openshift-online/ocm-api-model#738

Because a release of ROSA has been made with the API using the original parameter name, we'll need to coordinate a new release before making this change so that the feature is not broken.