### PR TITLE
Add a `PrivateHostedZoneID` to the `AWS` type

### DIFF
--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -28,6 +28,9 @@ struct AWS {
 	// The subnet ids to be used when installing the cluster.
 	SubnetIDs []String
 
+	// PrivateHostedZoneID to use preexisting hosted zone for BYO VPC clusters
+	PrivateHostedZoneID String
+
 	// Sets cluster to be inaccessible externally.
 	PrivateLink Boolean
 


### PR DESCRIPTION
This change reflects the change in this MR https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/5752/diffs#cf6ea32f1c0f546fee0f1a7dffbe6b6eb8a41d82_504_504.
Can be merged once the MR in the CS repo is merged.

Related: [OCM-200](https://issues.redhat.com/browse/OCM-200)