### PR TITLE
fix: Changed DNS Domain from Class to a Struct.

### DIFF
--- a/model/clusters_mgmt/v1/dns_domain_type.model
+++ b/model/clusters_mgmt/v1/dns_domain_type.model
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Contains the properties of a DNS domain.
-class DNSDomain {
+struct DNSDomain {
     // Contains the DNS base domain.
     ID string
 


### PR DESCRIPTION
A class tells the metamodel to include an id and href field in the go-generated structure. Since this type also specified and ID, the ID field was listed twice, leading to compilation errors.