### PR TITLE
OCM-16: add root volume capabilities to cluster nodes

### DIFF
--- a/model/clusters_mgmt/v1/cluster_nodes_root_volume_type.model
+++ b/model/clusters_mgmt/v1/cluster_nodes_root_volume_type.model
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Machine type root volume.
-struct MachineTypeRootVolume {
+// Root volume capabilities.
+struct RootVolume {
 	// AWS volume specification
 	AWS AWSVolume
 

--- a/model/clusters_mgmt/v1/cluster_nodes_type.model
+++ b/model/clusters_mgmt/v1/cluster_nodes_type.model
@@ -50,4 +50,7 @@ struct ClusterNodes {
 
 	// The infra machine type to use, for example `r5.xlarge` (Optional).
 	InfraMachineType MachineType
+
+	// The compute machine root volume capabilities.
+	ComputeRootVolume RootVolume
 }

--- a/model/clusters_mgmt/v1/machine_pool_type.model
+++ b/model/clusters_mgmt/v1/machine_pool_type.model
@@ -17,11 +17,11 @@ limitations under the License.
 // Representation of a machine pool in a cluster.
 class MachinePool {
 	// The number of Machines (and Nodes) to create.
-	// Replicas and autoscaling cannot be used together.    
+	// Replicas and autoscaling cannot be used together.
 	Replicas Integer
 
 	// Details for auto-scaling the machine pool.
-	// Replicas and autoscaling cannot be used together.    
+	// Replicas and autoscaling cannot be used together.
 	Autoscaling MachinePoolAutoscaling
 
 	// The instance type of Nodes to create.
@@ -46,5 +46,5 @@ class MachinePool {
 	SecurityGroupFilters []MachinePoolSecurityGroupFilter
 
 	// The machine root volume capabilities.
-	RootVolume MachineTypeRootVolume
+	RootVolume RootVolume
 }

--- a/model/clusters_mgmt/v1/machine_type_type.model
+++ b/model/clusters_mgmt/v1/machine_type_type.model
@@ -42,7 +42,4 @@ class MachineType {
 
 	// 'true' if the instance type is supported only for CCS clusters, 'false' otherwise.
 	CCSOnly Boolean
-
-	// The machine root volume capabilities.
-	RootVolume MachineTypeRootVolume
 }


### PR DESCRIPTION
Add ComputeRootVolume into ClusterNodes to reflect the root volume capabilities of a cluster node.