### PR TITLE
OCM-844|feat : Enable users to provide both hashed and plain-text passwords

### DIFF
--- a/model/clusters_mgmt/v1/htpasswd_user_type.model
+++ b/model/clusters_mgmt/v1/htpasswd_user_type.model
@@ -23,4 +23,8 @@ struct HTPasswdUser {
 
     // Password for a secondary user in the _HTPasswd_ data file.
     Password String
+
+    // Encryption status of the  password for a secondory user in the _HTPasswd_ data file.
+    // true indicates Password is a Hash
+    Hash Boolean
 }


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/OCM-844

currently CS only accepts plain-text passwords.

HTPassword files have passwords already hashed,  For rosacli or ui to support accepting user data from HTpassword files as input, It needs to be able to indicate to CS that the passwords has already been hashed so it doesnt try to rehash them.

This also allows for other scenarios where user does not wish to send passwords in plain-text to the rest API