### PR TITLE
Feat/embed labels in cluster type

### DIFF
--- a/model/osd_fleet_mgmt/v1/label_type.model
+++ b/model/osd_fleet_mgmt/v1/label_type.model
@@ -15,9 +15,7 @@ limitations under the License.
 */
 
 // label settings of the cluster.
-struct Label {
-	// Label ID associated to the OSD FM managed cluster
-    Id String
+class Label {
     // Label key associated to the OSD FM managed cluster
     Key String
     // Label value associated to the OSD FM managed cluster

--- a/model/osd_fleet_mgmt/v1/management_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_type.model
@@ -75,7 +75,7 @@ class ManagementCluster {
 	link Parent ManagementClusterParent
 
 	// Labels on management cluster
-	LabelsReference []LabelReference
+	Labels []Label
 
 	// Creation timestamp of the cluster
 	CreationTimestamp Date

--- a/model/osd_fleet_mgmt/v1/service_cluster_request_payload.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_request_payload.model
@@ -17,4 +17,5 @@ limitations under the License.
 struct ServiceClusterRequestPayload {
 	CloudProvider String
 	Region String
+	Labels []LabelRequestPayload
 }

--- a/model/osd_fleet_mgmt/v1/service_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_type.model
@@ -4,8 +4,7 @@ Copyright (c) 2022 Red Hat, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -71,8 +70,8 @@ class ServiceCluster {
 	//Sector of cluster
 	Sector String
 
-	// Labels refrences on service cluster
-	LabelsReference []LabelReference
+	// Labels on service cluster
+	Labels []Label
 
 	// Provision shard reference for the service cluster
 	ProvisionShardReference ProvisionShardReference

--- a/model/osd_fleet_mgmt/v1/service_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_type.model
@@ -4,7 +4,8 @@ Copyright (c) 2022 Red Hat, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-http://www.apache.org/licenses/LICENSE-2.0
+
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
replace list of references to cluster labels in `ServiceCluster` and `ManagementCluster` types with the actual `Label` objects themselves, removing a level of indirection and simplifying the process of searching/filtering for clusters by label.

This is associated with changes to the OSDFM API in response to [OCM-2265](https://issues.redhat.com/browse/OCM-2265), and corresponds to [this MR](https://gitlab.cee.redhat.com/service/osd-fleet-manager/-/merge_requests/504) in the fleet-manager repo