### PR TITLE
Fix OSDFM typo

### DIFF
--- a/model/osd_fleet_mgmt/v1/management_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_type.model
@@ -75,7 +75,7 @@ class ManagementCluster {
 	link Parent ManagementClusterParent
 
 	// Labels on management cluster
-	link LabelsReference []LabelReference
+	LabelsReference []LabelReference
 
 	// Creation timestamp of the cluster
 	CreationTimestamp Date

--- a/model/osd_fleet_mgmt/v1/provision_shard_reference_type.model
+++ b/model/osd_fleet_mgmt/v1/provision_shard_reference_type.model
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Provision Shards Reference of the cluster.
-struct ProvisionShardsReference {
+// Provision Shard Reference of the cluster.
+struct ProvisionShardReference {
   // Id of the Provision Shards associated to the Ocluster
   Id String
   // link to the Provision Shards associated to the cluster

--- a/model/osd_fleet_mgmt/v1/service_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_type.model
@@ -72,8 +72,8 @@ class ServiceCluster {
 	Sector String
 
 	// Labels refrences on service cluster
-	link LabelsReference []LabelReference
+	LabelsReference []LabelReference
 
 	// Provision shard reference for the service cluster
-	link ProvisionShardsReference ProvisionShardsReference
+	ProvisionShardReference ProvisionShardReference
 }


### PR DESCRIPTION
In the model, there was `provision_shards_reference` while `provision_shards_reference` is expected (`shard**S**` instead of `shard`)