### PR TITLE
Document more about CloudRegion

### DIFF
--- a/model/clusters_mgmt/v1/cloud_provider_type.model
+++ b/model/clusters_mgmt/v1/cloud_provider_type.model
@@ -22,4 +22,7 @@ class CloudProvider {
 	// Name of the cloud provider for display purposes. It can contain any characters,
 	// including spaces.
 	DisplayName String
+
+	// (optional) Provider's regions - only included when listing providers with `fetchRegions=true`.
+	Regions []CloudRegion
 }

--- a/model/clusters_mgmt/v1/cloud_providers_resource.model
+++ b/model/clusters_mgmt/v1/cloud_providers_resource.model
@@ -54,6 +54,10 @@ resource CloudProviders {
 		// results is undefined.
 		in Order String
 
+		// If true, includes the regions on each provider in the output. Could slow request response time.
+		@http(name = "fetchRegions")
+		in FetchRegions Boolean
+
 		// Total number of items of the collection that match the search criteria,
 		// regardless of the size of the page.
 		out Total Integer

--- a/model/clusters_mgmt/v1/cloud_region_type.model
+++ b/model/clusters_mgmt/v1/cloud_region_type.model
@@ -43,4 +43,13 @@ class CloudRegion {
 	// Whether the region is an AWS GovCloud region.
 	@json(name = "govcloud")
 	GovCloud Boolean
+
+	// (GCP only) Comma-separated list of KMS location IDs that can be used with this region.
+	// E.g. "global,nam4,us". Order is not guaranteed.
+	KMSLocationID String
+
+	// (GCP only) Comma-separated list of display names corresponding to KMSLocationID.
+	// E.g. "Global,nam4 (Iowa, South Carolina, and Oklahoma),US". Order is not guaranteed but will match KMSLocationID.
+	// Unfortunately, this API doesn't allow robust splitting - Contact ocm-feedback@redhat.com if you want to rely on this.
+	KMSLocationName String
 }

--- a/model/clusters_mgmt/v1/cloud_region_type.model
+++ b/model/clusters_mgmt/v1/cloud_region_type.model
@@ -28,7 +28,7 @@ class CloudRegion {
 	// Link to the cloud provider that the region belongs to.
 	link CloudProvider CloudProvider
 
-	// Whether the region is enabled for deploying an OSD cluster.
+	// Whether the region is enabled for deploying a managed cluster.
 	Enabled Boolean
 
 	// Whether the region supports multiple availability zones.
@@ -40,4 +40,7 @@ class CloudRegion {
 	// 'true' if the region is supported for Hypershift deployments, 'false' otherwise.
 	SupportsHypershift Boolean
 
+	// Whether the region is an AWS GovCloud region.
+	@json(name = "govcloud")
+	GovCloud Boolean
 }


### PR DESCRIPTION
These fields has existed on cloud_providers/..., aws_inquiries/regions, gcp_inquiries/regions APIs for a long time, but missing in openapi & SDK.

- @vkareh I don't know what else we can explain about `govcloud`?  IIUC from https://github.com/openshift/rosa/pull/702, govcloud regions will always have `"enabled": false` in main api.openshift.com, to actually use them one would need an entirely different API deployment?

  Anyway for me in UI, the `"enabled": false, "govcloud": true` combination is useful (UI will start showing some disabled regions with a reason why disabled; checking this field allows the 2 govcloud ones to remain hidden)

- Added `kms_location_id`, `kms_location_name` (the latter tricky to use imho, added suggestion to mail ocm-feedback if someone wants to rely on it).

- Covered `cloud_providers?fetchRegions=true` mode.
