### PR TITLE
Use `@http` instead of `@json` for `dryRun` parameter

### DIFF
--- a/model/addons_mgmt/v1/addon_resource.model
+++ b/model/addons_mgmt/v1/addon_resource.model
@@ -24,7 +24,7 @@ resource Addon {
 	// Updates the addon.
 	method Update {
 		// DryRun indicates the request body will not be persisted when dryRun=true. 
-		@json(name = "dryRun")
+		@http(name = "dryRun")
 		in DryRun Boolean
 
 		in out Body Addon

--- a/model/addons_mgmt/v1/addon_version_resource.model
+++ b/model/addons_mgmt/v1/addon_version_resource.model
@@ -24,7 +24,7 @@ resource AddonVersion {
 	// Updates the addon version.
 	method Update {
 		// DryRun indicates the request body will not be persisted when dryRun=true. 
-		@json(name = "dryRun")
+		@http(name = "dryRun")
 		in DryRun Boolean
 
 		in out Body AddonVersion

--- a/model/addons_mgmt/v1/addon_versions_resource.model
+++ b/model/addons_mgmt/v1/addon_versions_resource.model
@@ -65,7 +65,7 @@ resource AddonVersions {
 	// Create a new addon version and add it to the collection of addons.
 	method Add {
 		// DryRun indicates the request body will not be persisted when dryRun=true. 
-		@json(name = "dryRun")
+		@http(name = "dryRun")
 		in DryRun Boolean
 
 		// Description of the addon version.

--- a/model/addons_mgmt/v1/addons_resource.model
+++ b/model/addons_mgmt/v1/addons_resource.model
@@ -65,7 +65,7 @@ resource Addons {
 	// Create a new addon and add it to the collection of addons.
 	method Add {
 		// DryRun indicates the request body will not be persisted when dryRun=true. 
-		@json(name = "dryRun")
+		@http(name = "dryRun")
 		in DryRun Boolean
 
 		// Description of the addon.


### PR DESCRIPTION
Currently we are using the `@json` annotation to force the name of the dry run query parameter to `dryRun`. But this is incorrect, and only works because of a bug in the metamodel that is going to be fixed. This patch replaces `@json` with `@http` which will work after the bug is fixed.

Related: https://github.com/openshift-online/ocm-api-metamodel/pull/197