### PR TITLE
OCM-844 | feat: Add HashedPassword field  to provide encrypted value

### DIFF
--- a/model/clusters_mgmt/v1/htpasswd_user_type.model
+++ b/model/clusters_mgmt/v1/htpasswd_user_type.model
@@ -21,10 +21,11 @@ struct HTPasswdUser {
     // Username for a secondary user in the _HTPasswd_ data file.
     Username String
 
-    // Password for a secondary user in the _HTPasswd_ data file.
+    // Password in plain-text for a  user in the _HTPasswd_ data file.
+    // The value of this field is hashed before setting it in the  _HTPasswd_ data file for the HTPasswd IDP
     Password String
 
-    // Encryption status of the  password for a secondory user in the _HTPasswd_ data file.
-    // true indicates Password is a Hash
-    Hash Boolean
+   // HTPasswd Hashed Password for a user in the _HTPasswd_ data file.
+   // The value of this field is set as-is in the _HTPasswd_ data file for the HTPasswd IDP
+    HashedPassword String
 }


### PR DESCRIPTION
Instead of overloading Password field and using a  boolean to indicate the encryption status Adding a seperate HashedPassword field to make it more apparent to the user

Ref: https://issues.redhat.com/browse/OCM-844