### PR TITLE
Fix `fetchLabels` and `fetchAccounts` url parameter names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(error "please install 'shasum' or 'sha256sum'")
 endif
 
 # Details of the metamodel used to check the model:
-metamodel_version:=v0.0.58
+metamodel_version:=v0.0.59
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-$(UNAME)-amd64
 metamodel_sha1_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-$(UNAME)-amd64.sha256
 

--- a/model/accounts_mgmt/v1/accounts_resource.model
+++ b/model/accounts_mgmt/v1/accounts_resource.model
@@ -66,8 +66,8 @@ resource Accounts {
 		in Fields String
 
 		// If true, includes the labels on an account in the output. Could slow request response time.
-		in fetchLabels Boolean
-
+		@http(name = "fetchLabels")
+		in FetchLabels Boolean
 
 		// Retrieved list of accounts.
 		out Items []Account

--- a/model/accounts_mgmt/v1/organizations_resource.model
+++ b/model/accounts_mgmt/v1/organizations_resource.model
@@ -52,7 +52,8 @@ resource Organizations {
 		in Fields String
 
 		// If true, includes the labels on an organization in the output. Could slow request response time.
-		in fetchLabels Boolean
+		@http(name = "fetchLabels")
+		in FetchLabels Boolean
 
 		// Retrieved list of organizations.
 		out Items []Organization

--- a/model/accounts_mgmt/v1/subscriptions_resource.model
+++ b/model/accounts_mgmt/v1/subscriptions_resource.model
@@ -74,11 +74,13 @@ resource Subscriptions {
 		//
 		in Labels String
 
-        // If true, includes the account reference information in the output. Could slow request response time.
-        in fetchAccounts Boolean
+		// If true, includes the account reference information in the output. Could slow request response time.
+		@http(name = "fetchAccounts")
+		in FetchAccounts Boolean
 
-        // If true, includes the labels on a subscription in the output. Could slow request response time.
-        in fetchLabels Boolean
+		// If true, includes the labels on a subscription in the output. Could slow request response time.
+		@http(name = "fetchLabels")
+		in FetchLabels Boolean
 
 		// Retrieved list of subscriptions.
 		out Items []Subscription


### PR DESCRIPTION
Requires metamodel >= 0.0.59 to respect the annotation (https://github.com/openshift-online/ocm-api-metamodel/pull/197)

However, generated names before were wrong anyway.