### PR TITLE
OCM-2899 | Add upgrade policy related constants also for node pools

### DIFF
--- a/model/clusters_mgmt/v1/node_pool_upgrade_policy_type.model
+++ b/model/clusters_mgmt/v1/node_pool_upgrade_policy_type.model
@@ -25,11 +25,11 @@ class NodePoolUpgradePolicy {
 	// Schedule cron expression that defines automatic upgrade scheduling.
 	Schedule String
 
-	// Schedule type can be either "manual" (single execution) or "automatic" (re-occurring).
-	ScheduleType String
+	// Schedule type of the upgrade.
+	ScheduleType ScheduleType
 
-	// Upgrade type specify the type of the upgrade. Can only be "NodePool".
-	UpgradeType String
+	// Upgrade type of the node pool.
+	UpgradeType UpgradeType
 
 	// Version is the desired upgrade version.
 	Version String


### PR DESCRIPTION
Missed in https://github.com/openshift-online/ocm-api-model/pull/796