### PR TITLE
OCM-2795: add the remainder of autoscaler params

### DIFF
--- a/model/clusters_mgmt/v1/autoscaler_resource_limits_gpu_limit_type.model
+++ b/model/clusters_mgmt/v1/autoscaler_resource_limits_gpu_limit_type.model
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+struct AutoscalerResourceLimitsGPULimit {
+	// The type of GPU to associate with the minimum and maximum limits.
+	// This value is used by the Cluster Autoscaler to identify Nodes that will have GPU capacity by searching
+	// for it as a label value on the Node objects. For example, Nodes that carry the label key
+	// `cluster-api/accelerator` with the label value being the same as the Type field will be counted towards
+	// the resource limits by the Cluster Autoscaler.
+	Type String
+
+	Range ResourceRange
+}

--- a/model/clusters_mgmt/v1/autoscaler_resource_limits_type.model
+++ b/model/clusters_mgmt/v1/autoscaler_resource_limits_type.model
@@ -26,4 +26,8 @@ struct AutoscalerResourceLimits {
 	// Minimum and maximum number of gigabytes of memory in cluster, in the format <min>:<max>.
 	// Cluster autoscaler will not scale the cluster beyond these numbers.
 	Memory ResourceRange
+
+	// Minimum and maximum number of different GPUs in cluster, in the format <gpu_type>:<min>:<max>.
+	// Cluster autoscaler will not scale the cluster beyond these numbers. Can be passed multiple times.
+	GPUS []AutoscalerResourceLimitsGPULimit
 }

--- a/model/clusters_mgmt/v1/cluster_autoscaler_type.model
+++ b/model/clusters_mgmt/v1/cluster_autoscaler_type.model
@@ -33,6 +33,22 @@ class ClusterAutoscaler {
 	// Gives pods graceful termination time before scaling down.
 	MaxPodGracePeriod Integer
 
+	// To allow users to schedule "best-effort" pods, which shouldn't trigger
+	// Cluster Autoscaler actions, but only run when there are spare resources available,
+	// More info: https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#how-does-cluster-autoscaler-work-with-pod-priority-and-preemption.
+	PodPriorityThreshold Integer
+
+	// Should CA ignore DaemonSet pods when calculating resource utilization for scaling down. false by default.
+	IgnoreDaemonsetsUtilization Boolean
+
+	// Maximum time CA waits for node to be provisioned.
+	MaxNodeProvisionTime String
+
+	// This option specifies labels that cluster autoscaler should ignore when considering node group similarity.
+	// For example, if you have nodes with "topology.ebs.csi.aws.com/zone" label, you can add name of this label here
+	// to prevent cluster autoscaler from splitting nodes into different node groups based on its value.
+	BalancingIgnoredLabels []String
+
 	// Constraints of autoscaling resources.
 	ResourceLimits AutoscalerResourceLimits
 


### PR DESCRIPTION
Adding the remaining cluster-autoscaler parameters. During the design preparation it was requested to start with a minimal set of parameters to make it easier to develop, review, and test.

This should add a support for all the currently available parameters.