### PR TITLE
Add `Name` to Account model v1

### DIFF
--- a/model/accounts_mgmt/v1/account_type.model
+++ b/model/accounts_mgmt/v1/account_type.model
@@ -19,6 +19,7 @@ class Account {
 	Email String
 	FirstName String
 	LastName String
+	Name String
 	Banned Boolean
 	BanDescription String
 	BanCode String


### PR DESCRIPTION
## What
add `name` to account model in accounts_mgmt v1

## Why
when querying for subscriptions at  `/api/accounts_mgmt/v1/subscriptions/<sub id>?fetchAccounts=true`, ams returns a `creator` field that is a reference to the account that created the subscription

this field looks like this in the raw json response:
```
...
  "creator": {
    "email": "dagbay@redhat.com",
    "href": "/api/accounts_mgmt/v1/accounts/2P4XpdoEpHVoPgwfJ9imEN5HOfE",
    "id": "2P4XpdoEpHVoPgwfJ9imEN5HOfE",
    "kind": "Account",
    "name": "Daniel Agbay",
    "username": "rh-ee-dagbay"
  },
...
```
the `name` field is present here, but `ocm-sdk-go` does not unmarshal `name` into an `Account` object because it looks for `first_name` and `last_name` instead. `name` is not on the `Account` class at all
see here: https://github.com/openshift-online/ocm-sdk-go/blob/v0.1.344/accountsmgmt/v1/account_type_json.go#L266
and here: https://github.com/openshift-online/ocm-sdk-go/blob/v0.1.344/accountsmgmt/v1/account_type_json.go#L274

so adding `name` to `Account` should allow ocm-sdk to then marshal/unmarshal that field which will bubble up the field to end users of the sdk

## Testing
I ran the validation steps listed here: https://github.com/openshift-online/ocm-sdk-go/blob/main/CONTRIBUTING.md#validating-model-updates and everything passed