### PR TITLE
Implement new account reference type 

### DIFF
--- a/model/accounts_mgmt/v1/accout_reference_type.model
+++ b/model/accounts_mgmt/v1/accout_reference_type.model
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 class AccountReference {
-    Kind	    string
     Email	    string
     Name	    string
     Username	string

--- a/model/accounts_mgmt/v1/accout_reference_type.model
+++ b/model/accounts_mgmt/v1/accout_reference_type.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2019 Red Hat, Inc.
+Copyright (c) 2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,21 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-class Account {
-	Username String
-	Email String
-	FirstName String
-	LastName String
-	Banned Boolean
-	BanDescription String
-	BanCode String
-	CreatedAt Date
-	UpdatedAt Date
-	ServiceAccount Boolean
-	Organization Organization
-	Labels []Label
-        // RhitAccountID will be deprecated in favor of RhitWebUserId
-	RhitAccountID string
-	RhitWebUserId string
-	Capabilities []Capability
+class AccountReference {
+    Href	    string
+    Id	        string
+    Kind	    string
+    Email	    string
+    Name	    string
+    Username	string
 }

--- a/model/accounts_mgmt/v1/accout_reference_type.model
+++ b/model/accounts_mgmt/v1/accout_reference_type.model
@@ -15,8 +15,6 @@ limitations under the License.
 */
 
 class AccountReference {
-    Href	    string
-    Id	        string
     Kind	    string
     Email	    string
     Name	    string

--- a/model/accounts_mgmt/v1/subscription_type.model
+++ b/model/accounts_mgmt/v1/subscription_type.model
@@ -58,9 +58,10 @@ class Subscription {
 	TrialEndDate Date
 
 	// Link to the account that created the subscription.
-	// Deprecated: Creator exists for backwards compatibility with previous versoins of the model.
+	// Deprecated: Creator exists for backwards compatibility with previous versions of the model.
 	// Use CreatorAccount instead to consume the updated type of AccountReference
 	link Creator 	Account
+	
 	@json(name = "creator")
 	link CreatorAccount AccountReference
 }

--- a/model/accounts_mgmt/v1/subscription_type.model
+++ b/model/accounts_mgmt/v1/subscription_type.model
@@ -61,5 +61,6 @@ class Subscription {
 	// Deprecated: Creator exists for backwards compatibility with previous versoins of the model.
 	// Use CreatorAccount instead to consume the updated type of AccountReference
 	link Creator 	Account
+	@json(name = "creator")
 	link CreatorAccount AccountReference
 }

--- a/model/accounts_mgmt/v1/subscription_type.model
+++ b/model/accounts_mgmt/v1/subscription_type.model
@@ -58,5 +58,8 @@ class Subscription {
 	TrialEndDate Date
 
 	// Link to the account that created the subscription.
-	link Creator Account
+	// Deprecated: Creator exists for backwards compatibility with previous versoins of the model.
+	// Use CreatorAccount instead to consume the updated type of AccountReference
+	link Creator 	Account
+	link CreatorAccount AccountReference
 }


### PR DESCRIPTION
## Summary

* Create a new `AccountReference` type and link it to `Subscription.Creator`
* Remove `Name` attribute on `Account`

## Why

`Subscription.Creator` returns an `AccountReference` per the AMS api docs: https://api.openshift.com/?urls.primaryName=Accounts%20management%20service#/default/get_api_accounts_mgmt_v1_subscriptions

Currently an `Account` is being returned instead, which results in some info being lost when the AMS response is decoded into a Subscription object. One disrepancy is that `Account` contains `first_name` and `last_name`, while `AccountReference` contains `name`. So that means right now the name of the creator is lost when calling accounts mgmt get subscriptions.

I left in the existing `Creator` field of type `Account` for backwards compatibility purposes. I can remove that if requested or update things however needed for best practices

Slack thread for full context on this change: https://redhat-internal.slack.com/archives/CBDNMS43V/p1692729609296909

## Example

when querying for subscriptions at `/api/accounts_mgmt/v1/subscriptions/<sub id>?fetchAccounts=true`, ams returns a creator field that is a reference to the account that created the subscription

this field looks like this in the raw json response:
```
...
  "creator": {
    "email": "dagbay@redhat.com",
    "href": "/api/accounts_mgmt/v1/accounts/2P4XpdoEpHVoPgwfJ9imEN5HOfE",
    "id": "2P4XpdoEpHVoPgwfJ9imEN5HOfE",
    "kind": "Account",
    "name": "Daniel Agbay",
    "username": "rh-ee-dagbay"
  },
...
```

right now this gets unmarshalled into an `Account` object, which does not contain the `name` field, so that data gets lost