### PR TITLE
revert pr 817

### DIFF
--- a/model/accounts_mgmt/v1/account_type.model
+++ b/model/accounts_mgmt/v1/account_type.model
@@ -19,7 +19,6 @@ class Account {
 	Email String
 	FirstName String
 	LastName String
-	Name String
 	Banned Boolean
 	BanDescription String
 	BanCode String


### PR DESCRIPTION
revert adding name to account type from https://github.com/openshift-online/ocm-api-model/pull/817

further investigations/discussions have lead us to question the best approach here so we are reverting these changes for now. slack thread with more context: https://redhat-internal.slack.com/archives/CBDNMS43V/p1692729609296909