### PR TITLE
OCM-3559 - Feat : Add DisplayName and Description to billing_model_item_type.model

### DIFF
--- a/model/accounts_mgmt/v1/billing_model_item_type.model
+++ b/model/accounts_mgmt/v1/billing_model_item_type.model
@@ -8,4 +8,8 @@ struct BillingModelItem {
 	Model String
 	// Indicates the marketplace of the billing model. e.g. gcp, aws, etc.
 	Marketplace String
+	// User friendly display name of the billing model.
+	DisplayName String
+	// Single line description of the billing model for better understanding.
+	Description String
 }


### PR DESCRIPTION
**Changed**
- Add DisplayName and Description to billing_model_item_type.model

**Tested**
- DisplayName and Description properties should be visible through ocm sdk : tested