### PR TITLE
OCM-1534: add backplane_url field in the environment struct.

### DIFF
--- a/model/clusters_mgmt/v1/environment_type.model
+++ b/model/clusters_mgmt/v1/environment_type.model
@@ -24,4 +24,7 @@ struct Environment {
 
 	// last time that the worker checked for limited support clusters
 	LastLimitedSupportCheck Date
+
+	// the backplane url for the environment
+	BackplaneURL String
 }


### PR DESCRIPTION
This allows the backplane url to be returned as a response for the GET & PATCH call to the /api/clusters_mgmt/v1/environment API

ping @tzvatot 

I am opening it as draft in preparation for the DDR acceptance. But it can already be reviewed.