### PR TITLE
OCM-2437 | feat: Expose /api/v1/clusters_mgmt/aws_inquiries/sts_account_roles

### DIFF
--- a/model/clusters_mgmt/v1/aws_inquiries_resource.model
+++ b/model/clusters_mgmt/v1/aws_inquiries_resource.model
@@ -40,4 +40,9 @@ resource AWSInquiries {
     locator MachineTypes {
         target AWSRegionMachineTypesInquiry
     }
+
+    // Reference to the resource that manages aws sts roles
+    locator STSAccountRoles {
+        target AWSSTSAccountRolesInquiry
+    }
 }

--- a/model/clusters_mgmt/v1/aws_sts_account_role_type.model
+++ b/model/clusters_mgmt/v1/aws_sts_account_role_type.model
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of an sts account role for a rosa cluster
+struct AWSSTSAccountRole {
+
+    //The Prefix for this Account Role
+    Prefix String
+
+    //The list of STS Roles for this Account Role
+    Items []AWSSTSRole
+}

--- a/model/clusters_mgmt/v1/aws_sts_account_roles_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/aws_sts_account_roles_inquiry_resource.model
@@ -1,0 +1,50 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages STS Roles
+resource AWSSTSAccountRolesInquiry {
+    // Retrieves the list of STS Account Roles in the specified AWS Account.
+    // IMPORTANT: This collection doesn't currently support paging or searching, so the returned
+    // `page` will always be 1 and `size` and `total` will always be the total number of available account roles
+    // in the AWS Account
+
+    method Search {
+
+        // AWS Account Details required for the inquiry
+        in Body AWS
+
+        // Index of the returned page, where one corresponds to the first page. As this
+        // collection doesn't support paging the result will always be `1`.
+        in out Page Integer = 1
+
+        // Number of items that will be contained in the returned page. As this collection
+        // doesn't support paging or searching the result will always be the total number of
+        // be the total number of STS account roles.
+        in out Size Integer = 100
+
+        // Total number of items of the collection that match the search criteria,
+        // regardless of the size of the page. As this collection doesn't support paging or
+        // searching the result will always be the total number of STS account roles
+        out Total Integer
+
+        // The AWS Account Id for the STS Account Roles
+        @json(name = "aws_acccount_id")
+        out AwsAccountId String
+
+        // Retrieved list of STS Account Roles
+        out Items []AWSSTSAccountRole
+    }
+}

--- a/model/clusters_mgmt/v1/aws_sts_role_type.model
+++ b/model/clusters_mgmt/v1/aws_sts_role_type.model
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of an sts role for a rosa cluster
+struct AWSSTSRole {
+
+    //The AWS ARN for this Role
+    @json(name = "arn")
+    RoleARN String
+
+    //The type of this Role
+    @json(name = "type")
+    RoleType String
+
+    //Does this role have Admin permission?
+    @json(name = "isAdmin")
+    IsAdmin Boolean
+
+    //The Openshift Version for this Role
+    @json(name = "roleVersion")
+    RoleVersion String
+
+    //Does this Role have Managed Policies?
+    @json(name = "managedPolicies")
+    ManagedPolicies Boolean
+
+    //Does this Role have HCP Managed Policies?
+    @json(name = "hcpManagedPolicies")
+    HcpManagedPolicies Boolean
+}


### PR DESCRIPTION
This PR updates the API model to add support for the `/api/v1/clusters_mgmt/aws_inquiries/sts_account_roles` endpoint. The endpoint is already implemented, but is not exposed in the OpenAPI spec nor the SDK.
