### PR TITLE
Revert "OCM-1534: add backplane_url field in the environment struct."

### DIFF
--- a/model/clusters_mgmt/v1/environment_type.model
+++ b/model/clusters_mgmt/v1/environment_type.model
@@ -24,7 +24,4 @@ struct Environment {
 
 	// last time that the worker checked for limited support clusters
 	LastLimitedSupportCheck Date
-
-	// the backplane url for the environment
-	BackplaneURL String
 }


### PR DESCRIPTION
Reverts openshift-online/ocm-api-model#830

We'll no longer be taking this direction. 

Reverting the change for now and I'll create a new release afterwards.

/cc @tzvatot 