### PR TITLE
add OrderBy param to subscription list

### DIFF
--- a/model/accounts_mgmt/v1/subscriptions_resource.model
+++ b/model/accounts_mgmt/v1/subscriptions_resource.model
@@ -58,7 +58,6 @@ resource Subscriptions {
 		@http(name = "orderBy")
 		in OrderBy String
 
-		@deprecated
 		// Deprecated, it is not functional. Use OrderBy instead
 		in Order String
 

--- a/model/accounts_mgmt/v1/subscriptions_resource.model
+++ b/model/accounts_mgmt/v1/subscriptions_resource.model
@@ -55,6 +55,11 @@ resource Subscriptions {
 		//
 		// If the parameter isn't provided, or if the value is empty, then the order of the
 		// results is undefined.
+		@http(name = "orderBy")
+		in OrderBy String
+
+		@deprecated
+		// Deprecated, it is not functional. Use OrderBy instead
 		in Order String
 
 		// Projection


### PR DESCRIPTION
## Summary

* add `OrderBy` param to the `Subscriptions` resource

### Ticket

* https://issues.redhat.com/browse/OCM-3986

## Why

### Current State

When querying accounts management service, we can use the `orderBy` param to order the result set. 

ocm-sdk provides a `.Order()` method to set this parameter when querying for subscriptions: https://github.com/openshift-online/ocm-sdk-go/blob/main/accountsmgmt/v1/subscriptions_client.go#L169-L186. So we can use this method like so to order on "status":
```
	result, err := AMSclient.AccountsMgmt().V1().Subscriptions().List().
		Search(query string).
		Order("status").
		Size(10).
		Page(1).
                Send()
```

However, when the request is sent, the sdk sets `order` on the request to AMS, not `orderBy`. See here: https://github.com/openshift-online/ocm-sdk-go/blob/main/accountsmgmt/v1/subscriptions_client.go#L247-L249
So this param gets ignored by AMS and the result set of the request is not ordered like intended. 

In ocm cli terms:
```
ocm get subscriptions -p size=10 -p page=1 -p search="....." -p order="status"
```
is the request that gets sent by ocm-sdk now, which does not sort the result set

### Proposed Change

We would provide an `OrderBy` method that is used like this (added a new method to not break existing functionality):
```
	result, err := AMSclient.AccountsMgmt().V1().Subscriptions().List().
		Search(query string).
		OrderBy("status").
		Size(10).
		Page(1).
                Send()
```
which would generate the following request in ocm cli terms:
```
ocm get subscriptions -p size=10 -p page=1 -p search="....." -p orderBy="status"
```

AMS apispec detailing the `orderBy` param: https://api.openshift.com/?urls.primaryName=Accounts%20management%20service#/default/get_api_accounts_mgmt_v1_subscriptions
![image](https://github.com/openshift-online/ocm-api-model/assets/101584191/22286f59-c301-4fcc-a6ed-bba02e44804c)

## Current Workaround

Right now we can get around this by setting the `orderBy` param explicitly like so:

```
	result, err := AMSclient.AccountsMgmt().V1().Subscriptions().List().
		Search(query string).
		Parameter("orderBy", "status").
		Size(10).
		Page(1).
                Send()
``` 

### Testing

* generated new sdk locally via `make model_version=HEAD model_url=../ocm-api-model generate`
* verified sdk appends the `orderBy` param to the generated request to AMS