### PR TITLE
Add missing fields to cluster_log_type model

### DIFF
--- a/model/service_logs/v1/cluster_log_type.model
+++ b/model/service_logs/v1/cluster_log_type.model
@@ -66,4 +66,10 @@ class LogEntry {
 
 	// Type of the service log entry.
 	LogType LogType
+
+	// The time at which the cluster log was created
+	CreatedAt Date
+
+	// The name of the user who created the cluster log
+	CreatedBy String
 }

--- a/model/service_logs/v1/cluster_log_type.model
+++ b/model/service_logs/v1/cluster_log_type.model
@@ -70,6 +70,6 @@ class LogEntry {
 	// The time at which the cluster log was created.
 	CreatedAt Date
 
-	// The name of the user who created the cluster log
+	// The name of the user who created the cluster log.
 	CreatedBy String
 }

--- a/model/service_logs/v1/cluster_log_type.model
+++ b/model/service_logs/v1/cluster_log_type.model
@@ -67,7 +67,7 @@ class LogEntry {
 	// Type of the service log entry.
 	LogType LogType
 
-	// The time at which the cluster log was created
+	// The time at which the cluster log was created.
 	CreatedAt Date
 
 	// The name of the user who created the cluster log


### PR DESCRIPTION
When requesting service logs from the following endpoint, the follow properties are all present:
```bash
$ ocm get /api/service_logs/v1/clusters/cluster_logs -p cluster_id='266j72i94bvjn3v5u1katknb54nt9uv3' -p cluster_uuid='b1345368-1e91-45f1-a706-c0660d5a4b02' -p search="service_name='SREManualAction'"
{
  "items": [
    {
      "cluster_id": "266j72i94bvjn3v5u1katknb54nt9uv3",
      "cluster_uuid": "b1345368-1e91-45f1-a706-c0660d5a4b02",
      "created_at": "2023-09-12T21:10:12.978165Z",
      "created_by": "avulaj",
      "description": "bfc1b384-51b0-11ee-8889-0a580a801afc - test",
      "email": "",
      "event_stream_id": "2VJT720plooCm1b2wdrt52ODUcQ",
      "first_name": "",
      "href": "/api/service_logs/v1/cluster_logs/2VJT750UYRprmKdpSCPtj3PRHYy",
      "id": "2VJT750UYRprmKdpSCPtj3PRHYy",
      "internal_only": true,
      "kind": "ClusterLog",
      "last_name": "",
      "log_type": "",
      "service_name": "SREManualAction",
      "severity": "Warning",
      "summary": "Limited Support Evidence",
      "timestamp": "2023-09-12T21:10:12.978092Z",
      "username": ""
    },
    ...
  ],
  "kind": "ClusterLogList",
  "page": 1,
  "size": 5,
  "total": 5
}
```

However, when retrieving from the SDK model, some of those fields aren't present:
```go
// LogEntry represents the values of the 'log_entry' type.
type LogEntry struct {
	bitmap_        uint32
	id             string
	href           string
	clusterID      string
	clusterUUID    string
	description    string
	eventStreamID  string
	logType        LogType
	serviceName    string
	severity       Severity
	subscriptionID string
	summary        string
	timestamp      time.Time
	username       string
	internalOnly   bool
}
```

In particular:
- CreatedAt
- CreatedBy
- Email
- FirstName
- LastName

Per this [slack conversation](https://redhat-internal.slack.com/archives/CBDNMS43V/p1694721535552959?thread_ts=1694721210.708109&cid=CBDNMS43V), I've added both CreatedAt and CreatedBy to the cluster_log_type model. The other 3 aren't necessary at this time.