### PR TITLE
[OCM-2111] add organization id to feature_review_request type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.325 September 28 2023
+- Add `OrganizationId` to `feature_review_request` type
+
 ## 0.0.324 September 26 2023
 - Add `CreatedAt` to `cluster_log` type
 - Add `CreatedBy` to `cluster_log` type

--- a/model/authorizations/v1/feature_review_request_type.model
+++ b/model/authorizations/v1/feature_review_request_type.model
@@ -22,4 +22,7 @@ struct FeatureReviewRequest {
 
   // Indicates the feature which can be toggled
   Feature String
+
+  // Defines the organisation id of the account of which access is being reviewed
+  OrganizationId String
 }


### PR DESCRIPTION
This PR adds the organization id to the feature_review_request model which is required for ocm-cs integration.
API reference to the feature_review endpoint --> [reference](https://api.openshift.com/?urls.primaryName=Accounts%20management%20service#/default/post_api_authorizations_v1_feature_review)


