### PR TITLE
Revert "Revert "OCM-1534: add backplane_url field in the environment struct.""

### DIFF
--- a/model/clusters_mgmt/v1/environment_type.model
+++ b/model/clusters_mgmt/v1/environment_type.model
@@ -24,4 +24,7 @@ struct Environment {
 
 	// last time that the worker checked for limited support clusters
 	LastLimitedSupportCheck Date
+
+	// the backplane url for the environment
+	BackplaneURL String
 }


### PR DESCRIPTION
Reverts openshift-online/ocm-api-model#840

We can now go ahead with the change. 

Reverting this in preparation for the implementation

/cc @tzvatot 