### PR TITLE
OCM-3852 | feat: Exposed KubeletConfig endpoints and models for day 2 operations of setting PIDs limits

### DIFF
--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -200,4 +200,8 @@ resource Cluster {
 	locator Vpc {
 		target Vpc
 	}
+
+	locator KubeletConfig {
+	    target KubeletConfig
+	}
 }

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -226,4 +226,7 @@ class Cluster {
 
 	// Details for `htpasswd` identity provider.
 	Htpasswd HTPasswdIdentityProvider
+
+	// Details of cluster-wide KubeletConfig
+	KubeletConfig KubeletConfig
 }

--- a/model/clusters_mgmt/v1/kubeletconfig_resource.model
+++ b/model/clusters_mgmt/v1/kubeletconfig_resource.model
@@ -1,0 +1,38 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages global KubeletConfig configuration for worker nodes in a cluster.
+resource KubeletConfig {
+	// Retrieves the KubeletConfig for a cluster
+	method Get {
+		out Body KubeletConfig
+	}
+
+	// Creates a new cluster KubeletConfig
+	method Post {
+		in Request KubeletConfig
+		out Body KubeletConfig
+	}
+
+	// Updates the existing cluster KubeletConfig
+	method Update {
+		in out Body KubeletConfig
+	}
+
+	// Deletes the cluster KubeletConfig
+	method Delete {
+	}
+}

--- a/model/clusters_mgmt/v1/kubeletconfig_type.model
+++ b/model/clusters_mgmt/v1/kubeletconfig_type.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// OCM representation of KubeletConfig, exposing the fields of Kubernetes
+// KubeletConfig that can be managed by users
+class KubeletConfig {
+	// Allows user to specify the podPidsLimit to be applied via KubeletConfig.
+	// Useful if workloads have greater PIDs limit requirements than the OCP default.
+	PodPidsLimit Integer
+}


### PR DESCRIPTION
This PR updates the `clusters_mgmt` OpenAPI spec to include endpoints and models for managing `podPidsLimits` as a day 2 operation. In particular this PR:

- Exposes the `/api/clusters_mgmt/v1/clusters/{id}/kubelet_config` endpoint and supporting methods
  - `GET` to read
  - `POST` to create
  - `PATCH` to update
  - `DELETE` to delete
- Creates the `KubeletConfig` struct to support the above endpoint
- Updates the `Cluster` struct to embed the `KubeletConfig` struct to allow customers to read details of the `KubeletConfig` they have applied (if any) via the Cluster resource