### PR TITLE
OCM-4744 | fix: Ensure consistency between post and update methods on KubeletConfig resource

### DIFF
--- a/model/clusters_mgmt/v1/kubeletconfig_resource.model
+++ b/model/clusters_mgmt/v1/kubeletconfig_resource.model
@@ -23,8 +23,7 @@ resource KubeletConfig {
 
 	// Creates a new cluster KubeletConfig
 	method Post {
-		in Request KubeletConfig
-		out Body KubeletConfig
+		in out Body KubeletConfig
 	}
 
 	// Updates the existing cluster KubeletConfig


### PR DESCRIPTION
This PR ensures consistency between the `post` and `update` methods on the `KubeletConfig` resource. The purpose of this change is to ensure consistency in the SDK experience when working with the `KubeletConfig` resource. There are no functional changes to the API as part of this PR.