### PR TITLE
Add `PackageImage` field to `AddonVersion`

### DIFF
--- a/model/addons_mgmt/v1/addon_version_type.model
+++ b/model/addons_mgmt/v1/addon_version_type.model
@@ -22,6 +22,9 @@ class AddonVersion {
     // The catalog source image for this addon version.
     SourceImage String
 
+    // The package image for this addon version
+    PackageImage String
+
     // The pull secret name used for this addon version.
     PullSecretName String
 


### PR DESCRIPTION
Adding `PackageImage` field to `AddonVersion` because it is already present in OCM API.
I need this field to implement the automatic addon upgrade functionality in my project. 
Most probably related with OCM-3385