### PR TITLE
OCM-5803 | feat: add vpc ids field to the cloud provider data struct

### DIFF
--- a/model/clusters_mgmt/v1/provider_data_inquiry_type.model
+++ b/model/clusters_mgmt/v1/provider_data_inquiry_type.model
@@ -39,4 +39,7 @@ struct CloudProviderData {
 
     // Subnets
     Subnets []String
+
+    // VPC ids
+    VpcIds []string
 }


### PR DESCRIPTION
The new field enables filtering VPCs by VPC ids.

The equivalent change in the backend:
```
type CloudProviderInquiries struct {
	GCP               *GCP         `json:"gcp,omitempty"`
	Region            *CloudRegion `json:"region,omitempty"`
	KeyLocation       *string      `json:"key_location,omitempty"`
	KeyRingName       *string      `json:"key_ring_name,omitempty"`
	AWS               *AWS         `json:"aws,omitempty"`
	Version           *Version     `json:"version,omitempty"`
	AvailabilityZones []string     `json:"availability_zones,omitempty"`
	Subnets           []string     `json:"subnets,omitempty"`
-->	VpcIds            []string     `json:"vpc_ids,omitempty"`
}
```