### PR TITLE
OCM-5802 Add external_auth_config to cluster

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.350 Jan 29 2024
+- [OCM-5802] Add `ExternalAuthConfig` to `Cluster` model.
+
 ## 0.0.349 Jan 28 2024
 -  [OCM-5561] Remove redundant fields from /notify_details
 

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -229,4 +229,7 @@ class Cluster {
 
 	// Details of cluster-wide KubeletConfig
 	KubeletConfig KubeletConfig
+
+	// External authentication configuration
+	ExternalAuthConfig ExternalAuthConfig
 }

--- a/model/clusters_mgmt/v1/external_auth_config.type.model
+++ b/model/clusters_mgmt/v1/external_auth_config.type.model
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// ExternalAuthConfig configuration
+struct ExternalAuthConfig {
+    // Boolean flag indicating if the cluster should use an external authentication configuration.
+    //
+    // By default this is false.
+    //
+    // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
+    // to have the `external-authentication` feature toggle enabled.
+    Enabled Boolean
+}


### PR DESCRIPTION
It adds the ExternalAuthConfig struct under the cluster model.