### PR TITLE
Add PackageImage to the AddOnVersion (clusters_mgmt)

### DIFF
--- a/model/clusters_mgmt/v1/add_on_version_type.model
+++ b/model/clusters_mgmt/v1/add_on_version_type.model
@@ -26,6 +26,9 @@ class AddOnVersion {
 	// The catalog source image for this add-on version.
 	SourceImage String
 
+	// The package image for this addon version
+	PackageImage String
+
 	// The specific addon catalog source channel of packages
 	Channel String
 


### PR DESCRIPTION
Adding `PackageImage` field to `clusters_mgmt` `AddOnVersion` because it is already present in OCM API.
I need this field to implement the automatic addon upgrade functionality in my project.