### PR TITLE
OCM-6052 | feat: add `securityGroupIds` to the aws node pool struct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.354 Feb 12 2024
+- Add `AdditionalSecurityGroupIds` to `AWS Node Pool` type.
+
 ## 0.0.353 Feb 08 2024
 - Add support for `PackageImage` in `clusters_mgmt`
 

--- a/model/clusters_mgmt/v1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_type.model
@@ -30,4 +30,7 @@ class AWSNodePool {
 
     // Associates nodepool availability zones with zone types (e.g. wavelength, local).
     AvailabilityZoneTypes [String]String
+
+    // Additional AWS Security Groups to be added node pool.
+    AdditionalSecurityGroupIds []String
 }


### PR DESCRIPTION
Allow the user to provide additional security group IDs for the node pool.