### PR TITLE
Ocm 5976 | REverting change for DELETE provision_shards/{id}

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.356 Feb 19 2024
+- Reverting change to remove DELETE `provision_shards/{id}`
+
 ## 0.0.355 Feb 16 2024
 - [OCM-5976] Removed undefined api calls
 

--- a/model/clusters_mgmt/v1/provision_shard_resource.model
+++ b/model/clusters_mgmt/v1/provision_shard_resource.model
@@ -25,4 +25,8 @@ resource ProvisionShard {
 	method Update {
 		in out Body ProvisionShard
 	}
+
+	// Delete the provision shard.
+	method Delete {
+	}
 }


### PR DESCRIPTION
[JIRA ](https://issues.redhat.com/browse/OCM-5976) 

Reverting change for DELETE `provision_shards/{id}`

Related to https://github.com/openshift-online/ocm-api-model/pull/899