### PR TITLE
OCM-6294 | add get /load_balancer_quota_values

### DIFF
--- a/model/clusters_mgmt/v1/load_balancer_quota_values_resource.model
+++ b/model/clusters_mgmt/v1/load_balancer_quota_values_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages load balancer quota values.
+resource LoadBalancerQuotaValues {
+	// Retrieves the list of Load Balancer Quota Values.
+	method Get {
+		out Body LoadBalancerQuotaValues
+	}
+}

--- a/model/clusters_mgmt/v1/load_balancer_quota_values_type.model
+++ b/model/clusters_mgmt/v1/load_balancer_quota_values_type.model
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of an upgrade policy state that that is set for a cluster.
+class LoadBalancerQuotaValues {
+		// Index of the requested page, where one corresponds to the first page.
+		Page Integer
+
+		// Number of items contained in the returned page.
+		Size Integer
+
+		// Total number of items of the collection.
+		Total Integer
+
+		// Retrieved list of items.
+		Items []Integer
+}

--- a/model/clusters_mgmt/v1/root_resource.model
+++ b/model/clusters_mgmt/v1/root_resource.model
@@ -116,4 +116,9 @@ resource Root {
 	locator TrustedIPAddresses {
 		target TrustedIps
 	}
+
+	// Reference to the resource that manages the load balancer quota values.
+	locator LoadBalancerQuotaValues{
+		target LoadBalancerQuotaValues
+	}
 }


### PR DESCRIPTION
This PR adds a new endpoint to get load_balancer_quota_values.

It uses the GET method. Using the list method was discarded because this endpoint returns a list of integers, at this moment the meta-model doesn't allow it and it cannot build the SDK.


Issue: https://issues.redhat.com/browse/OCM-6294