### PR TITLE
ARO-5950 | feat: add initial ARO-HCP Azure attributes

### DIFF
--- a/model/clusters_mgmt/v1/azure_type.model
+++ b/model/clusters_mgmt/v1/azure_type.model
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Microsoft Azure settings of a cluster.
+struct Azure {
+	// [Required] The Azure Subscription ID associated with the cluster. It must belong to
+	// the Microsoft Entra Tenant ID `tenant_id`.
+	SubscriptionID           String
+
+	// [Required] The Azure Resource Group Name of the cluster. It must be within `subscription_id`
+	// of the cluster. `resource_group_name` is located in the same Azure location
+	// as the cluster's region.
+	ResourceGroupName        String
+
+	// [Required] The Azure Resource Name of the cluster. It must be within the
+	// Azure Resource Group Name `resource_group_name`.
+	// `resource_name` is located in the same Azure location as the cluster's region.
+	ResourceName             String
+
+	// [Required] The Microsoft Entra Tenant ID where the cluster belongs.
+	TenantID                 String
+
+	// [Required] The name of the Azure Resource Group where the Azure Resources related
+	// to the cluster are created. The Azure Resource Group is created with the given
+	// value, within the Azure Subscription `subscription_id` of the cluster.
+	// `managed_resource_group_name` cannot be equal to the value of `managed_resource_group`.
+	// `managed_resource_group_name` is located in the same Azure location as the
+	//  cluster's region.
+	// Not to be confused with `resource_group_name`, which is the Azure Resource Group Name
+	// where the own Azure Resource associated to the cluster resides.
+	ManagedResourceGroupName String
+}

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -103,6 +103,9 @@ class Cluster {
 	// Google cloud platform settings of the cluster.
 	GCP GCP
 
+	// Microsoft Azure settings of the cluster.
+	Azure Azure
+
 	// Network settings of the cluster.
 	Network Network
 


### PR DESCRIPTION
Add initial set of attributes for ARO-HCP clusters. These will be needed when creating ARO-HCP clusters.

The set of attributes in this PR is only the initial ones, that we know should be needed. More will be added over time and there is work in progress to identify and design them. Future PRs will be created for those.