### PR TITLE
OCM-7306 | feat: Added support for KubeletConfigs to HCP MachinePools

### DIFF
--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -188,6 +188,10 @@ resource Cluster {
 		target TuningConfigs
 	}
 
+	locator KubeletConfigs {
+	    target KubeletConfigs
+	}
+
 	locator DeleteProtection {
 		target DeleteProtection
 	}

--- a/model/clusters_mgmt/v1/kubelet_config_resource.model
+++ b/model/clusters_mgmt/v1/kubelet_config_resource.model
@@ -35,3 +35,21 @@ resource KubeletConfig {
 	method Delete {
 	}
 }
+
+// Manages KubeletConfig configuration for Hosted Control Plane clusters. This resource does not support POST operations
+// in contrast to the KubeletConfig resource for Classic clusters.
+resource HcpKubeletConfig {
+	// Retrieves the KubeletConfig specified by the id.
+	method Get {
+		out Body KubeletConfig
+	}
+
+	// Updates the KubeletConfig specified by the id.
+	method Update {
+		in out Body KubeletConfig
+	}
+
+	// Deletes the KubeletConfig specified by the id.
+	method Delete {
+	}
+}

--- a/model/clusters_mgmt/v1/kubelet_config_type.model
+++ b/model/clusters_mgmt/v1/kubelet_config_type.model
@@ -17,7 +17,11 @@ limitations under the License.
 // OCM representation of KubeletConfig, exposing the fields of Kubernetes
 // KubeletConfig that can be managed by users
 class KubeletConfig {
-	// Allows user to specify the podPidsLimit to be applied via KubeletConfig.
+	// Allows the user to specify the podPidsLimit to be applied via KubeletConfig.
 	// Useful if workloads have greater PIDs limit requirements than the OCP default.
 	PodPidsLimit Integer
+
+	// Allows the user to specify the name to be used to identify this KubeletConfig.
+	// Optional. A name will be generated if not provided.
+	Name String
 }

--- a/model/clusters_mgmt/v1/kubelet_configs_resource.model
+++ b/model/clusters_mgmt/v1/kubelet_configs_resource.model
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of KubeletConfigs for a cluster.
+resource KubeletConfigs {
+	// Retrieves the list of KubeletConfigs for the cluster.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Number of items contained in the returned page.
+		in out Size Integer = 100
+
+		// Total number of items of the collection.
+		out Total Integer
+
+		// Retrieved list of KubeletConfigs.
+		out Items []KubeletConfig
+	}
+
+	// Adds a new KubeletConfig to the cluster.
+	method Add {
+		// Description of the KubeletConfig.
+		in out Body KubeletConfig
+	}
+
+	// Reference to the service that manages a specific KubeletConfig.
+	locator KubeletConfig {
+		target HcpKubeletConfig
+		variable ID
+	}
+}

--- a/model/clusters_mgmt/v1/node_pool_type.model
+++ b/model/clusters_mgmt/v1/node_pool_type.model
@@ -51,6 +51,9 @@ class NodePool {
     // The names of the tuning configs for this node pool.
     TuningConfigs []String
 
+    // The names of the KubeletConfigs for this node pool.
+    KubeletConfigs []String
+
     // Time to wait for a NodePool to drain when it is upgraded or replaced before it is forcibly removed.
     NodeDrainGracePeriod Value
 }


### PR DESCRIPTION
This PR adds in API Model definitions for the `KubeletConfig` endpoints to support custom PIDs limits on HCP clusters. In this PR we add the following:

- Expose the `/api/clusters_mgmt/v1/clusters/{id}/kubelet_configs` endpoint that allows users to create one or more KubeletConfigs for their HCP clusters
   - For Classic Clusters, validation on this endpoint will permit the creation of a single KubeletConfig
- Expose the `/api/clusters_mgmt/v1/clusters/{id}/kubelet_configs/{kubelet_config_id}` endpoint that allows the user to retrieve details of the specific KubeletConfig
- Add the `kubelet_configs` field to the NodePool resource    