### PR TITLE
OCM-7374 | add AdditionalAllowedPrincipals to aws model

### DIFF
--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -70,4 +70,7 @@ struct AWS {
 
 	// Additional AWS Security Groups to be added to default control plane machine pool.
 	AdditionalControlPlaneSecurityGroupIds []String
+
+	// Additional allowed principal ARNs to be added to the hosted control plane's VPC Endpoint Service.
+	AdditionalAllowedPrincipals []String
 }


### PR DESCRIPTION
Add AdditionalAllowedPrincipals to the aws model.
The AdditionalAllowedPrincipals specifies a list of additional allowed principal ARNs to be added to the hosted control plane's VPC Endpoint Service.

Ref: https://issues.redhat.com/browse/OCM-7374