### PR TITLE
feat: convert os_disk_size_gibibytes in azure node pool to integer

### DIFF
--- a/model/clusters_mgmt/v1/azure_node_pool_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_type.model
@@ -40,7 +40,7 @@ struct AzureNodePool {
     // Nodes in the Node Pool. The property
     // is the number of bytes x 1024^3.
     // If not specified, OS disk size is 30 GiB.
-    OSDiskSizeGibibytes String
+    OSDiskSizeGibibytes Integer
 
     // The disk storage account type to use for the OS disks of the Nodes in the
     // Node Pool. Valid values are:


### PR DESCRIPTION
We convert the os_disk_size_gibibytes type from string to integer to match the type that is used in Azure ARM.

Even though changing the API type is considered a breaking change, this belongs to Azure Node Pools which we know at the moment of writing this no customer is using it and it is not available in OCM Commercial so it is fine changing this. 

There is a corresponding MR in CS to perform the corresponding server side changes.