### PR TITLE
OCM-8300 | feat: add multi_arch_enabled attribute to clusters

### DIFF
--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -239,4 +239,7 @@ class Cluster {
 
 	// External authentication configuration
 	ExternalAuthConfig ExternalAuthConfig
+
+	// Indicate whether the cluster is enabled for multi arch workers
+	MultiArchEnabled Boolean
 }


### PR DESCRIPTION
Update the Cluster API model to support the multi_arch_enabled flag.