### PR TITLE
CS: Adding kind and id field to gcp authentication structure

### DIFF
--- a/model/clusters_mgmt/v1/gcp_authentication_type.model
+++ b/model/clusters_mgmt/v1/gcp_authentication_type.model
@@ -16,6 +16,12 @@ limitations under the License.
 
 // Google cloud platform authentication method of a cluster.
 struct GcpAuthentication {
-    // Self Link
+    // Indicates the type of this object
+    Kind String
+
+    // Unique identifier of the object
+    Id String
+
+    // Self link
     Href String
 }


### PR DESCRIPTION
For OSD-GCP deployments that will use new cloud authentication methods, namely wif_config, the kind and id fields are  being added. Through these fields the user will specify the resource that will be used during and after cluster deployments to access resources relating to their GCP project.