### PR TITLE
OCM-9884 | feat: add AWSVolume to AWSNodePool to support custom disk sizes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.386 Jul 29 2024
+- Add `RootVolume` attribute to `AWSNodePool` model
+
 ## 0.0.385 Jul 29 2024
 - Update WIF endpoint path
 - Remove WIF templates endpoints

--- a/model/clusters_mgmt/v1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_type.model
@@ -44,4 +44,7 @@ class AWSNodePool {
     // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
     @json(name = "ec2_metadata_http_tokens")
     Ec2MetadataHttpTokens Ec2MetadataHttpTokens    
+    
+    // AWS Volume specification to be used to set custom worker disk size
+    RootVolume AWSVolume
 }

--- a/model/clusters_mgmt/v2alpha1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v2alpha1/aws_node_pool_type.model
@@ -44,4 +44,7 @@ class AWSNodePool {
     // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
     @json(name = "ec2_metadata_http_tokens")
     Ec2MetadataHttpTokens Ec2MetadataHttpTokens    
+
+    // AWS Volume specification to be used to set custom worker disk size
+    RootVolume AWSVolume
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-9884

As part of the custom worker disk sizes epic https://issues.redhat.com/browse/XCMSTRAT-285 we want to store the desired size for the custom disk size in an AWSVolume in the AWSNodePool object. This MR adds that field to the model.