### PR TITLE
OCM-6419 | feat: add OidcThumbprint / OidcThumbprintInput to support thumbprints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.388 Aug 06 2024
+- Add 'OidcThumbprint' type model to v1 and v2alpha1
+- Add 'OidcThumbprintInput' type model to v1 and v2alpha1
+- Add 'OidcThumbprint' resource model to v1 and v2alpha1
+
 ## 0.0.387 Aug 05 2024
 - Add `ProjectNumber` field to `WifConfig` model
 

--- a/model/clusters_mgmt/v1/aws_inquiries_resource.model
+++ b/model/clusters_mgmt/v1/aws_inquiries_resource.model
@@ -50,4 +50,9 @@ resource AWSInquiries {
     locator ValidateCredentials {
         target AwsValidateCredentials
     }
+
+    // Reference to the resource that manages OIDC Config Thumbprint fetching.
+    locator OidcThumbprint {
+        target OidcThumbprint
+    }
 }

--- a/model/clusters_mgmt/v1/oidc_thumbprint_input_type.model
+++ b/model/clusters_mgmt/v1/oidc_thumbprint_input_type.model
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to fetch an OIDC Configuration thumbprint
+struct OidcThumbprintInput {
+
+	// OidcConfigId is the ID for the oidc config used, exclusive from ClusterId.
+	OidcConfigId String
+
+	// ClusterId is the for the cluster used, exclusive from OidcConfigId.
+	ClusterId String
+}

--- a/model/clusters_mgmt/v1/oidc_thumbprint_resource.model
+++ b/model/clusters_mgmt/v1/oidc_thumbprint_resource.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages an Oidc Config Thumbprint configuration.
+resource OidcThumbprint {
+	// Fetches/creates an OIDC Config Thumbprint from either a cluster ID, or an oidc config ID.
+	method Post {
+	    out Body OidcThumbprint
+	    in Body OidcThumbprintInput
+	}
+}

--- a/model/clusters_mgmt/v1/oidc_thumbprint_type.model
+++ b/model/clusters_mgmt/v1/oidc_thumbprint_type.model
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support oidc configuration thumbprint operations such as fetching/creation of a thumbprint
+struct OidcThumbprint {
+
+	// OidcConfigId is the ID for the oidc config used, filled in response.
+	OidcConfigId String
+
+	// ClusterId is the for the cluster used, filled in response.
+	ClusterId String
+
+	// Thumbprint is the thumbprint itself, filled in response.
+	Thumbprint String
+
+	// HREF for the oidc config thumbprint, filled in response.
+  	HREF String
+
+  	// Kind is the resource type, filled in response.
+  	Kind String
+}

--- a/model/clusters_mgmt/v2alpha1/aws_inquiries_resource.model
+++ b/model/clusters_mgmt/v2alpha1/aws_inquiries_resource.model
@@ -50,4 +50,9 @@ resource AWSInquiries {
     locator ValidateCredentials {
         target AwsValidateCredentials
     }
+
+    // Reference to the resource that manages OIDC Config Thumbprint fetching.
+    locator OidcThumbprint {
+        target OidcThumbprint
+    }
 }

--- a/model/clusters_mgmt/v2alpha1/oidc_thumbprint_input_type.model
+++ b/model/clusters_mgmt/v2alpha1/oidc_thumbprint_input_type.model
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to fetch an OIDC Configuration thumbprint
+struct OidcThumbprintInput {
+
+	// OidcConfigId is the ID for the oidc config used, exclusive from ClusterId.
+	OidcConfigId String
+
+	// ClusterId is the for the cluster used, exclusive from OidcConfigId.
+	ClusterId String
+}

--- a/model/clusters_mgmt/v2alpha1/oidc_thumbprint_resource.model
+++ b/model/clusters_mgmt/v2alpha1/oidc_thumbprint_resource.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages an Oidc Config Thumbprint configuration.
+resource OidcThumbprint {
+	// Fetches/creates an OIDC Config Thumbprint from either a cluster ID, or an oidc config ID.
+	method Post {
+	    out Body OidcThumbprint
+	    in Body OidcThumbprintInput
+	}
+}

--- a/model/clusters_mgmt/v2alpha1/oidc_thumbprint_type.model
+++ b/model/clusters_mgmt/v2alpha1/oidc_thumbprint_type.model
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support oidc configuration thumbprint operations such as fetching/creation of a thumbprint
+struct OidcThumbprint {
+
+	// OidcConfigId is the ID for the oidc config used, filled in response.
+	OidcConfigId String
+
+	// ClusterId is the for the cluster used, filled in response.
+	ClusterId String
+
+	// Thumbprint is the thumbprint itself, filled in response.
+	Thumbprint String
+
+	// HREF for the oidc config thumbprint, filled in response.
+  	HREF String
+
+  	// Kind is the resource type, filled in response.
+  	Kind String
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/OCM-6419

Part of an epic for allowing customers to fetch/create the OIDC Configuration Thumbprint for their oidc configs, allowing access to oidc configs when using proxies.
https://issues.redhat.com/browse/OCM-2534 (epic link)