### PR TITLE
ARO-9520: Add state struct to node pool

### DIFF
--- a/model/clusters_mgmt/v2alpha1/node_pool_state_type.model
+++ b/model/clusters_mgmt/v2alpha1/node_pool_state_type.model
@@ -15,13 +15,10 @@ limitations under the License.
 */
 
 // Representation of the status of a node pool.
-class NodePoolStatus {
-    // The current number of replicas for the node pool.
-    CurrentReplicas Integer
+class NodePoolState {
+    // The current state of the node pool.
+    Value NodePoolStateValues
 
-    // Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas.
-    Message String
-
-    // The Current NodePool state.
-    State NodePoolState
+    // Detailed user friendly status for node pool state.
+    Details String
 }

--- a/model/clusters_mgmt/v2alpha1/node_pool_state_values_type.model
+++ b/model/clusters_mgmt/v2alpha1/node_pool_state_values_type.model
@@ -14,14 +14,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Representation of the status of a node pool.
-class NodePoolStatus {
-    // The current number of replicas for the node pool.
-    CurrentReplicas Integer
+// Overall state of a node pool.
+enum NodePoolStateValues {
+	// The node pool is being uninstalled.
+	Deleting
 
-    // Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas.
-    Message String
+	// Error during installation or change.
+	Error
 
-    // The Current NodePool state.
-    State NodePoolState
+	// The node pool is still being created.
+	Creating
+
+	// The node pool is pending resources before being provisioned.
+	Pending
+
+	// The node pool is ready to use.
+	Ready
+
+	// The state of the node pool is unknown.
+	Unknown
+
+	// The state of the node pool is unknown.
+	Updating
+
+	// The node pool is validating user input.
+	Validating
 }


### PR DESCRIPTION
This change will add a new struct to store the status of a node pool for v2 API.

We should consider the possibility of joining NodePool.Status.Message and NodePool.Status.State.Detail. 

Added an enum with the possible states of a NodePool, this should be reviewed with future investigations.