### PR TITLE
OCM-10387 | Wif API updates to suppport SRE access

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.392 Sep 03 2024
+- Defined "support" field in WifConfig structure
+- Added "vm" WIF access method
+
 ## 0.0.391 Aug 28 2024
 - Add `RegistryConfig` attribute to `Cluster` model
 - Add `RegistryAllowlist` resource and endpoints

--- a/model/clusters_mgmt/v1/wif_config_type.model
+++ b/model/clusters_mgmt/v1/wif_config_type.model
@@ -36,6 +36,8 @@ struct WifGcp {
 	// The list of service accounts and their associated roles that will need to be
 	// configured on the user's GCP project.
 	ServiceAccounts []WifServiceAccount
+	// Defines the access configuration for support.
+	Support WifSupport
 	// The workload identity configuration data that will be used to create the
 	// workload identity pool on the user's account.
 	WorkloadIdentityPool WifPool

--- a/model/clusters_mgmt/v1/wif_support_type.model
+++ b/model/clusters_mgmt/v1/wif_support_type.model
@@ -14,32 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-struct WifServiceAccount {
-	AccessMethod WifAccessMethod
-	CredentialRequest WifCredentialRequest
-	ServiceAccountId String
-	OsdRole String
+struct WifSupport {
+	Principal String
 	Roles []WifRole
-}
-
-enum WifAccessMethod {
-	Impersonate
-	Vm
-	Wif
-}
-
-struct WifCredentialRequest {
-	SecretRef WifSecretRef
-	ServiceAccountNames []String
-}
-
-struct WifSecretRef {
-	Name String
-	Namespace String
-}
-
-struct WifRole {
-	RoleId String
-	Predefined Boolean
-	Permissions []String
 }

--- a/model/clusters_mgmt/v2alpha1/wif_config_type.model
+++ b/model/clusters_mgmt/v2alpha1/wif_config_type.model
@@ -32,6 +32,8 @@ struct WifGcp {
 	// The list of service accounts and their associated roles that will need to be
 	// configured on the user's GCP project.
 	ServiceAccounts []WifServiceAccount
+	// Defines the access configuration for support.
+	Support WifSupport
 	// The workload identity configuration data that will be used to create the
 	// workload identity pool on the user's account.
 	WorkloadIdentityPool WifPool

--- a/model/clusters_mgmt/v2alpha1/wif_service_account_type.model
+++ b/model/clusters_mgmt/v2alpha1/wif_service_account_type.model
@@ -24,6 +24,7 @@ struct WifServiceAccount {
 
 enum WifAccessMethod {
 	Impersonate
+	Vm
 	Wif
 }
 

--- a/model/clusters_mgmt/v2alpha1/wif_support_type.model
+++ b/model/clusters_mgmt/v2alpha1/wif_support_type.model
@@ -14,32 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-struct WifServiceAccount {
-	AccessMethod WifAccessMethod
-	CredentialRequest WifCredentialRequest
-	ServiceAccountId String
-	OsdRole String
+struct WifSupport {
+	Principal String
 	Roles []WifRole
-}
-
-enum WifAccessMethod {
-	Impersonate
-	Vm
-	Wif
-}
-
-struct WifCredentialRequest {
-	SecretRef WifSecretRef
-	ServiceAccountNames []String
-}
-
-struct WifSecretRef {
-	Name String
-	Namespace String
-}
-
-struct WifRole {
-	RoleId String
-	Predefined Boolean
-	Permissions []String
 }


### PR DESCRIPTION
* Added wif access method

   The "vm" access method is used by service accounts that will be attached to GCP virtual machine instances.

* Defined wif support

    The support group specifies the permissions the user needs to grant the
    SRE team in order to perform the SOPs needed to service OSD-GCP
    clusters. The granting of these permissions occurs on the client side
    after they have created a WifConfig resource.