### PR TITLE
OCM-10871: Expose hcp_namespace field for Hypershift Model

### DIFF
--- a/model/clusters_mgmt/v1/hypershift_config_type.model
+++ b/model/clusters_mgmt/v1/hypershift_config_type.model
@@ -27,4 +27,8 @@ struct HypershiftConfig {
 	// Contains the name of the current management cluster for this Hypershift cluster.
 	// Empty for non Hypershift clusters.
 	ManagementCluster String
+
+	// Contains the name of the hcp namespace for this Hypershift cluster.
+	// Empty for non Hypershift clusters.
+	HCPNamespace String
 }

--- a/model/clusters_mgmt/v2alpha1/hypershift_config_type.model
+++ b/model/clusters_mgmt/v2alpha1/hypershift_config_type.model
@@ -27,4 +27,8 @@ struct HypershiftConfig {
 	// Contains the name of the current management cluster for this Hypershift cluster.
 	// Empty for non Hypershift clusters.
 	ManagementCluster String
+
+	// Contains the name of the hcp namespace for this Hypershift cluster.
+	// Empty for non Hypershift clusters.
+	HCPNamespace String
 }


### PR DESCRIPTION
This PR updates the model to expose `hcp_namespace` field in the Hypershift model which is not available in SDK but can be queried via the API using the  `ocm get cluster $CLUSTER_ID/hypershift `endpoint