### PR TITLE
OSD-25124: new WIFOnly flag on version gates

### DIFF
--- a/model/clusters_mgmt/v1/version_gate_type.model
+++ b/model/clusters_mgmt/v1/version_gate_type.model
@@ -37,6 +37,9 @@ class VersionGate {
   // STSOnly indicates if this version gate is for STS clusters only
   STSOnly Boolean
 
+  // WIFOnly indicates if this version gate is for WIF clusters only
+  WIFOnly Boolean
+
   // CreationTimestamp is the date and time when the version gate was created,
   // format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].
   CreationTimestamp Date


### PR DESCRIPTION
This flag will be used to filter out version gates applying on OSD (managed) clusters running on GCP provider with WIF (Workload Identity Federation) enabled.