### PR TITLE
OCM-11393 & OSD-25124: generic conditions for version gates

### DIFF
--- a/model/clusters_mgmt/v1/version_gate_type.model
+++ b/model/clusters_mgmt/v1/version_gate_type.model
@@ -34,8 +34,13 @@ class VersionGate {
   // DocumentationURL is the URL for the documentation of the version gate.
   DocumentationURL String
 
-  // STSOnly indicates if this version gate is for STS clusters only
+  // STSOnly indicates if this version gate is for STS clusters only,
+  // deprecated: to be replaced with ClusterCondition
   STSOnly Boolean
+
+  // ClusterCondition aims at selecting the clusters targeted by this version gate,
+  // ignored if STSOnly is true
+  ClusterCondition String
 
   // CreationTimestamp is the date and time when the version gate was created,
   // format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].


### PR DESCRIPTION
Replaces this PR which was adding a WIF specific solution for filtering clusters: https://github.com/openshift-online/ocm-api-model/pull/985

Example of use of this new field:
```
"cluster_condition": "product.id = 'osd'"
```

This field is expected to contain the same kind of expressions that the ones passed to the `search` field of the following API endpoint: [GET /api/clusters_mgmt/v1/clusters](https://api.openshift.com/#/default/get_api_clusters_mgmt_v1_clusters)