### PR TITLE
Add aro_hcp v1alpha1 Root resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,35 @@ would be the following:
 /api/clusters_mgmt/v1/clusters/123/credentials
 ```
 
+### Class references using @ref annotation
+One can define a class reference inside a service such that it will inherit its content from
+another service using the special `@ref` annotation, for example:
+
+```
+// In /aro_hcp/v1_alpha1/cluster_type.model
+@ref(path = "/clusters_mgmt/v1/cluster")
+class Cluster {
+}
+```
+
+The above decelaration will inherit its content from the `Cluster` class under the `/clusters_mgmt/v1` service.
+This means that any changes made in `Cluster` class will be reflected under this derived type as well.
+
+Links to other resources are preserved as they are.
+
+If one wishes to **override** a type she can create a class inside `/aro_hcp/v1_alpha1/` in order to override any nested types defined.
+For example the following type declaration will override the `NodePools` link inside `Cluster` under `/aro_hcp/v1`:
+
+```
+// In /aro_hcp/v1_alpha1/node_pool_type.model
+@ref(path = "/clusters_mgmt/v1/node_pool")
+class NodePool {
+}
+```
+
+This means that now under `Cluster` the `NodePools` field type is linked to the one defined in `/aro_hcp/v1_alpha1` (i.e. `v1alpha.NodePool`) which itself
+references and derived from the `NodePool` type under `/clusters_mgmt/v1`.
+
 ## Documentation
 
 The Go language supports adding documentation in the code itself, using the

--- a/model/aro_hcp/v1alpha1/cluster_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_resource.model
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific cluster.
+resource Cluster {
+	// Retrieves the details of the cluster.
+	method Get {
+		out Body Cluster
+	}
+
+	// Updates the cluster.
+	method Update {
+		in out Body Cluster
+	}
+
+	// Deletes the cluster.
+	method Delete {
+		// Dry run flag is used to check if the operation can be completed, but won't delete.
+		in DryRun Boolean = false
+
+		// BestEffort flag is used to check if the cluster deletion should be best-effort mode or not.
+		in BestEffort Boolean = false
+	}
+}

--- a/model/aro_hcp/v1alpha1/cluster_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_type.model
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@ref(path = "/clusters_mgmt/v1/cluster")
+class Cluster {
+}

--- a/model/aro_hcp/v1alpha1/clusters_resource.model
+++ b/model/aro_hcp/v1alpha1/clusters_resource.model
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of aro_hcp clusters.
+resource Clusters {
+	// Retrieves the list of clusters.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Search criteria.
+		// 
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the cluster instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// clusters with a name starting with `my` in the `us-east-1` region the value
+		// should be:
+		//
+		// ```sql
+		// name like 'my%' and region.id = 'us-east-1'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// clusters that the user has permission to see will be returned.
+		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the cluster instead of
+		// the names of the columns of a table. For example, in order to sort the clusters
+		// descending by region identifier the value should be:
+		//
+		// ```sql
+		// region.id desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
+
+		// Retrieved list of clusters.
+		out Items []Cluster
+	}
+
+	// Provision a new cluster and add it to the collection of clusters.
+	// 
+	// See the `register_cluster` method for adding an existing cluster.
+	method Add {
+		// Description of the cluster.
+		in out Body Cluster
+	}
+
+	// Returns a reference to the service that manages an specific cluster.
+	locator Cluster {
+		target Cluster
+		variable ID
+	}
+}

--- a/model/aro_hcp/v1alpha1/root_resource.model
+++ b/model/aro_hcp/v1alpha1/root_resource.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Root of the tree of resources of the aro_hcp service.
+resource Root {
+	locator Clusters {
+		target Clusters
+	}
+}


### PR DESCRIPTION
Create a new root resource for the `/aro_hcp` service and add a locator with reference to the `/clusters_mgmt/v1/clusters` locator.

This PR is depending on https://github.com/openshift-online/ocm-api-metamodel/pull/210.