### PR TITLE
chore: Release v0.0.406

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.406 Dec 18 2024
+- Expose the GCP Shielded VM secure boot setting at the machine pool level
 
 ## 0.0.405 Dec 15 2024
 - Add aro_hcp v1alpha1 Root resource

--- a/model/clusters_mgmt/v1/gcp_machine_pool_type.model
+++ b/model/clusters_mgmt/v1/gcp_machine_pool_type.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of gcp machine pool specific parameters.
+struct GCPMachinePool {
+	// Determines whether the Shielded VM's SecureBoot feature should be
+	// enabled for the nodes of the machine pool. If SecureBoot is not
+	// specified, the value of this attribute will remain unspecified and the
+	// SecureBoot's value specified in the `.gcp.security.secure_boot`
+	// attribute of the parent Cluster will be the one applied to the nodes of
+	// the machine pool.
+	// Immutable.
+	SecureBoot Boolean
+}

--- a/model/clusters_mgmt/v1/machine_pool_type.model
+++ b/model/clusters_mgmt/v1/machine_pool_type.model
@@ -42,6 +42,9 @@ class MachinePool {
 	// AWS specific parameters (Optional).
 	AWS AWSMachinePool
 
+	// GCP specific parameters (Optional).
+	GCP GCPMachinePool
+
 	// List of security groups to be applied to MachinePool (Optional)
 	SecurityGroupFilters []MachinePoolSecurityGroupFilter
 


### PR DESCRIPTION
In this release, the GCP Shielded VM setting is made available at the machine pool level .