### PR TITLE
New release 0.0.410

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.410 Jan 31 2025
+
+- Add `ClusterStatus` type to aro_hcp
+- Add `ClusterStatus` resources to aro_hcp
+- Update metamodel version to v0.0.65
+
 ## 0.0.409 Jan 22 2025
 - Update `ClusterMigrationState` value to be a struct
 


### PR DESCRIPTION
## 0.0.410 Jan 31 2025

- Add `ClusterStatus` type to aro_hcp
- Add `ClusterStatus` resources to aro_hcp
- Update metamodel version to v0.0.65