### PR TITLE
Fix naming of async methods in SDK

### DIFF
--- a/model/aro_hcp/v1alpha1/node_pool_resource.model
+++ b/model/aro_hcp/v1alpha1/node_pool_resource.model
@@ -22,11 +22,13 @@ resource NodePool {
 	}
 
 	// Updates the node pool.
+	@go(name="Update")
 	method AsyncUpdate {
 		in out Body NodePool
 	}
 
 	// Deletes the node pool.
+	@go(name="Delete")
 	method AsyncDelete {
 	}
 


### PR DESCRIPTION
This changes the signature of the generated go method to be Update instead of AsyncUpdate. In the SDK the `NodePoolClient` will call to `.Update()`, instead to `.AsyncUpdate()`.

![image](https://github.com/user-attachments/assets/39009981-dbea-474d-9a87-ccd8d979eb9b)
