### PR TITLE
add verify target and OWNERS in preparation for prow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,9 @@ metamodel_version:=v0.0.67
 metamodel_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-$(UNAME)-amd64
 metamodel_sha1_url:=https://github.com/openshift-online/ocm-api-metamodel/releases/download/$(metamodel_version)/metamodel-$(UNAME)-amd64.sha256
 
+verify: check
+.PHONY: verify
+
 .PHONY: check
 check: metamodel
 	./metamodel check --model=model

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,31 @@
+# DO NOT EDIT; this file is auto-generated using https://github.com/openshift/ci-tools.
+# Fetched from https://github.com/openshift-online/ocm-service-common root OWNERS
+# If the repo had OWNERS_ALIASES then the aliases were expanded
+# Logins who are not members of 'openshift' organization were filtered out
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+# to be significantly reduced once top-level architects decide API review shape
+approvers:
+- ahitacat
+- ciaranRoche
+- davidleerh
+- gdbranco
+- lucasponce
+- machi1990
+- miguelsorianod
+- oriAdler
+- renan-campos
+- vkareh
+- zgalor
+reviewers:
+- ahitacat
+- ciaranRoche
+- davidleerh
+- gdbranco
+- lucasponce
+- machi1990
+- miguelsorianod
+- oriAdler
+- renan-campos
+- vkareh
+- zgalor


### PR DESCRIPTION
Also, it appears that `make lint` isn't currently enforced because its failing.  I left it out of this initial pull.