### PR TITLE
capture the optional managed identities proposal using API Model.

### DIFF
--- a/model/clusters_mgmt/v1/azure_type.model
+++ b/model/clusters_mgmt/v1/azure_type.model
@@ -97,10 +97,13 @@ struct Azure {
 	// Immutable.
 	NetworkSecurityGroupResourceID String
 
+    // This is renamed to 'required_operators_authentication'.
+	// It brings concerns of; what if one of the operators stop being required anymore all the time?
+	// How do people see the design considering the future evolutions concerns?
 	// Defines how the operators of the cluster authenticate to Azure.
 	// Required during creation.
 	// Immutable.
-	OperatorsAuthentication AzureOperatorsAuthentication
+	RequiredOperatorsAuthentication AzureOperatorsAuthentication
 
 	// NodesOutboundConnectivity defines how the network outbound
 	// configuration of the Cluster's Node Pool's Nodes is performed.

--- a/model/clusters_mgmt/v1/cluster_image_registry_type.model
+++ b/model/clusters_mgmt/v1/cluster_image_registry_type.model
@@ -1,0 +1,4 @@
+struct ClusterImageRegistry {
+	ControlPlaneIdentity AzureControlPlaneManagedIdentity
+	DataPlaneIdentity AzureDataPlaneManagedIdentity
+}

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -247,5 +247,11 @@ class Cluster {
 	RegistryConfig ClusterRegistryConfig
 
 	// OpenShift Cluster Capabilities configuration
-	Capabilities ClusterCapabilities
+	// Commented because it'll be removed from the API as par the proposal in the DDR
+	// Capabilities ClusterCapabilities
+
+    // At the moment it is top level at the cluster's spec.
+	// We could move it to the .Azure field as it contains Azure specific things.
+	// This is the one point we want to solve
+	ImageRegistry ClusterImageRegistry
 }


### PR DESCRIPTION
```
{
 ...rest of cluster spec
 "azure": {
   "required_operators_authentication": {
     "managed_identities": {
       "managed_identities_data_plane_identity_url": "https://dummyhost.identity.azure.net",
       "control_plane_operators_managed_identities": {
         "operator1": {
           "resource_id": "example_resource_id"
         },
       },
       "data_plane_operators_managed_identities": {
         "example_operator": {
           "resource_id": "example_resource_id"
         }
       },
       "service_managed_identity": {
         "resource_id": "example_resource_id"
       }
     }
   },
   "image_registry": {
     "control_plane_identity": {
       "resource_id": "example_resource_id"
       },
     "data_plane_identity": {
       "resource_id": "example_resource_id"
     }
   }
 }
}
```

The PR captures the above proposal as stated out in the DDR around optional managed identities.
However, there are a few challenges with the current proposal;
- if in the future an operator becomes not required all the time anymore, it'll be an API breaking change as we'll have to move  from the `required_operators_authentication` section to its own section as par the current proposal. How do we people see a better design to future proof ourselves? This is the case we're having now with the image registry operator taken as an example. 
- How are generic optional features that requires Managed/Workload identities designed across different clouds? 
The proposal above designs it as `cluster.image_registry` however, the concept of managed identities is tied to Azure. 
Other clouds have different concepts / naming. An alternative to the proposal above will be to have `cluster.azure.image_registry` and `cluster.aws.image_registry` i.e each cloud section in the cluster's spec will have its own type defining of the feature. However, this duplicates the feature definition across different clouds.

Another alternative is  `cluster.image_registry.aws` and `cluster.image_registry.azure` i.e on the feature itself, have configurations per cloud. This duplicates the cloud platform everywhere.

I am opening this discussion so that we can iterate on the design and come up with a solid one to captured  in the DDR and adopted across offerings and specifically for aro-hcp optional features design.

@tzvatot @vkareh @miguelsorianod @deads2k @flavianmissi

