### PR TITLE
feat: add azure managed identities requirements endpoints

### DIFF
--- a/clientapi/arohcp/v1alpha1/control_plane_operator_identity_builder.go
+++ b/clientapi/arohcp/v1alpha1/control_plane_operator_identity_builder.go
@@ -1,0 +1,117 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ControlPlaneOperatorIdentityBuilder contains the data and logic needed to build 'control_plane_operator_identity' objects.
+type ControlPlaneOperatorIdentityBuilder struct {
+	bitmap_             uint32
+	maxOpenShiftVersion string
+	minOpenShiftVersion string
+	operatorName        string
+	required            string
+	roleDefinitions     []*RoleDefinitionBuilder
+}
+
+// NewControlPlaneOperatorIdentity creates a new builder of 'control_plane_operator_identity' objects.
+func NewControlPlaneOperatorIdentity() *ControlPlaneOperatorIdentityBuilder {
+	return &ControlPlaneOperatorIdentityBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ControlPlaneOperatorIdentityBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// MaxOpenShiftVersion sets the value of the 'max_open_shift_version' attribute to the given value.
+func (b *ControlPlaneOperatorIdentityBuilder) MaxOpenShiftVersion(value string) *ControlPlaneOperatorIdentityBuilder {
+	b.maxOpenShiftVersion = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// MinOpenShiftVersion sets the value of the 'min_open_shift_version' attribute to the given value.
+func (b *ControlPlaneOperatorIdentityBuilder) MinOpenShiftVersion(value string) *ControlPlaneOperatorIdentityBuilder {
+	b.minOpenShiftVersion = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// OperatorName sets the value of the 'operator_name' attribute to the given value.
+func (b *ControlPlaneOperatorIdentityBuilder) OperatorName(value string) *ControlPlaneOperatorIdentityBuilder {
+	b.operatorName = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Required sets the value of the 'required' attribute to the given value.
+func (b *ControlPlaneOperatorIdentityBuilder) Required(value string) *ControlPlaneOperatorIdentityBuilder {
+	b.required = value
+	b.bitmap_ |= 8
+	return b
+}
+
+// RoleDefinitions sets the value of the 'role_definitions' attribute to the given values.
+func (b *ControlPlaneOperatorIdentityBuilder) RoleDefinitions(values ...*RoleDefinitionBuilder) *ControlPlaneOperatorIdentityBuilder {
+	b.roleDefinitions = make([]*RoleDefinitionBuilder, len(values))
+	copy(b.roleDefinitions, values)
+	b.bitmap_ |= 16
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ControlPlaneOperatorIdentityBuilder) Copy(object *ControlPlaneOperatorIdentity) *ControlPlaneOperatorIdentityBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.maxOpenShiftVersion = object.maxOpenShiftVersion
+	b.minOpenShiftVersion = object.minOpenShiftVersion
+	b.operatorName = object.operatorName
+	b.required = object.required
+	if object.roleDefinitions != nil {
+		b.roleDefinitions = make([]*RoleDefinitionBuilder, len(object.roleDefinitions))
+		for i, v := range object.roleDefinitions {
+			b.roleDefinitions[i] = NewRoleDefinition().Copy(v)
+		}
+	} else {
+		b.roleDefinitions = nil
+	}
+	return b
+}
+
+// Build creates a 'control_plane_operator_identity' object using the configuration stored in the builder.
+func (b *ControlPlaneOperatorIdentityBuilder) Build() (object *ControlPlaneOperatorIdentity, err error) {
+	object = new(ControlPlaneOperatorIdentity)
+	object.bitmap_ = b.bitmap_
+	object.maxOpenShiftVersion = b.maxOpenShiftVersion
+	object.minOpenShiftVersion = b.minOpenShiftVersion
+	object.operatorName = b.operatorName
+	object.required = b.required
+	if b.roleDefinitions != nil {
+		object.roleDefinitions = make([]*RoleDefinition, len(b.roleDefinitions))
+		for i, v := range b.roleDefinitions {
+			object.roleDefinitions[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/control_plane_operator_identity_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/control_plane_operator_identity_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ControlPlaneOperatorIdentityListBuilder contains the data and logic needed to build
+// 'control_plane_operator_identity' objects.
+type ControlPlaneOperatorIdentityListBuilder struct {
+	items []*ControlPlaneOperatorIdentityBuilder
+}
+
+// NewControlPlaneOperatorIdentityList creates a new builder of 'control_plane_operator_identity' objects.
+func NewControlPlaneOperatorIdentityList() *ControlPlaneOperatorIdentityListBuilder {
+	return new(ControlPlaneOperatorIdentityListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ControlPlaneOperatorIdentityListBuilder) Items(values ...*ControlPlaneOperatorIdentityBuilder) *ControlPlaneOperatorIdentityListBuilder {
+	b.items = make([]*ControlPlaneOperatorIdentityBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ControlPlaneOperatorIdentityListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ControlPlaneOperatorIdentityListBuilder) Copy(list *ControlPlaneOperatorIdentityList) *ControlPlaneOperatorIdentityListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ControlPlaneOperatorIdentityBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewControlPlaneOperatorIdentity().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'control_plane_operator_identity' objects using the
+// configuration stored in the builder.
+func (b *ControlPlaneOperatorIdentityListBuilder) Build() (list *ControlPlaneOperatorIdentityList, err error) {
+	items := make([]*ControlPlaneOperatorIdentity, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ControlPlaneOperatorIdentityList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/control_plane_operator_identity_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/control_plane_operator_identity_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalControlPlaneOperatorIdentityList writes a list of values of the 'control_plane_operator_identity' type to
+// the given writer.
+func MarshalControlPlaneOperatorIdentityList(list []*ControlPlaneOperatorIdentity, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteControlPlaneOperatorIdentityList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteControlPlaneOperatorIdentityList writes a list of value of the 'control_plane_operator_identity' type to
+// the given stream.
+func WriteControlPlaneOperatorIdentityList(list []*ControlPlaneOperatorIdentity, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteControlPlaneOperatorIdentity(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalControlPlaneOperatorIdentityList reads a list of values of the 'control_plane_operator_identity' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalControlPlaneOperatorIdentityList(source interface{}) (items []*ControlPlaneOperatorIdentity, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadControlPlaneOperatorIdentityList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadControlPlaneOperatorIdentityList reads list of values of the ”control_plane_operator_identity' type from
+// the given iterator.
+func ReadControlPlaneOperatorIdentityList(iterator *jsoniter.Iterator) []*ControlPlaneOperatorIdentity {
+	list := []*ControlPlaneOperatorIdentity{}
+	for iterator.ReadArray() {
+		item := ReadControlPlaneOperatorIdentity(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/control_plane_operator_identity_type.go
+++ b/clientapi/arohcp/v1alpha1/control_plane_operator_identity_type.go
@@ -1,0 +1,275 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ControlPlaneOperatorIdentity represents the values of the 'control_plane_operator_identity' type.
+type ControlPlaneOperatorIdentity struct {
+	bitmap_             uint32
+	maxOpenShiftVersion string
+	minOpenShiftVersion string
+	operatorName        string
+	required            string
+	roleDefinitions     []*RoleDefinition
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ControlPlaneOperatorIdentity) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// MaxOpenShiftVersion returns the value of the 'max_open_shift_version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The field is a string and it is of format X.Y.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// starting from min_openshift_version if min_openshift_version is defined.
+func (o *ControlPlaneOperatorIdentity) MaxOpenShiftVersion() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.maxOpenShiftVersion
+	}
+	return ""
+}
+
+// GetMaxOpenShiftVersion returns the value of the 'max_open_shift_version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The field is a string and it is of format X.Y.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// starting from min_openshift_version if min_openshift_version is defined.
+func (o *ControlPlaneOperatorIdentity) GetMaxOpenShiftVersion() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.maxOpenShiftVersion
+	}
+	return
+}
+
+// MinOpenShiftVersion returns the value of the 'min_open_shift_version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The field is a string and it is of format X.Y.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// or up to max_openshift_version, if defined.
+func (o *ControlPlaneOperatorIdentity) MinOpenShiftVersion() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.minOpenShiftVersion
+	}
+	return ""
+}
+
+// GetMinOpenShiftVersion returns the value of the 'min_open_shift_version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The field is a string and it is of format X.Y.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// or up to max_openshift_version, if defined.
+func (o *ControlPlaneOperatorIdentity) GetMinOpenShiftVersion() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.minOpenShiftVersion
+	}
+	return
+}
+
+// OperatorName returns the value of the 'operator_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The name of the control plane operator that needs the identity
+func (o *ControlPlaneOperatorIdentity) OperatorName() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.operatorName
+	}
+	return ""
+}
+
+// GetOperatorName returns the value of the 'operator_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The name of the control plane operator that needs the identity
+func (o *ControlPlaneOperatorIdentity) GetOperatorName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.operatorName
+	}
+	return
+}
+
+// Required returns the value of the 'required' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Indicates the whether the identity is always required or not.
+// "always" means that the identity is always required
+// "on_enablement" means that the identity is only required when a functionality
+// that leverages the operator is enabled.
+// Possible values are ("always", "on_enablement")
+func (o *ControlPlaneOperatorIdentity) Required() string {
+	if o != nil && o.bitmap_&8 != 0 {
+		return o.required
+	}
+	return ""
+}
+
+// GetRequired returns the value of the 'required' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Indicates the whether the identity is always required or not.
+// "always" means that the identity is always required
+// "on_enablement" means that the identity is only required when a functionality
+// that leverages the operator is enabled.
+// Possible values are ("always", "on_enablement")
+func (o *ControlPlaneOperatorIdentity) GetRequired() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&8 != 0
+	if ok {
+		value = o.required
+	}
+	return
+}
+
+// RoleDefinitions returns the value of the 'role_definitions' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A list of roles that are required by the operator
+func (o *ControlPlaneOperatorIdentity) RoleDefinitions() []*RoleDefinition {
+	if o != nil && o.bitmap_&16 != 0 {
+		return o.roleDefinitions
+	}
+	return nil
+}
+
+// GetRoleDefinitions returns the value of the 'role_definitions' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A list of roles that are required by the operator
+func (o *ControlPlaneOperatorIdentity) GetRoleDefinitions() (value []*RoleDefinition, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
+	if ok {
+		value = o.roleDefinitions
+	}
+	return
+}
+
+// ControlPlaneOperatorIdentityListKind is the name of the type used to represent list of objects of
+// type 'control_plane_operator_identity'.
+const ControlPlaneOperatorIdentityListKind = "ControlPlaneOperatorIdentityList"
+
+// ControlPlaneOperatorIdentityListLinkKind is the name of the type used to represent links to list
+// of objects of type 'control_plane_operator_identity'.
+const ControlPlaneOperatorIdentityListLinkKind = "ControlPlaneOperatorIdentityListLink"
+
+// ControlPlaneOperatorIdentityNilKind is the name of the type used to nil lists of objects of
+// type 'control_plane_operator_identity'.
+const ControlPlaneOperatorIdentityListNilKind = "ControlPlaneOperatorIdentityListNil"
+
+// ControlPlaneOperatorIdentityList is a list of values of the 'control_plane_operator_identity' type.
+type ControlPlaneOperatorIdentityList struct {
+	href  string
+	link  bool
+	items []*ControlPlaneOperatorIdentity
+}
+
+// Len returns the length of the list.
+func (l *ControlPlaneOperatorIdentityList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ControlPlaneOperatorIdentityList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ControlPlaneOperatorIdentityList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ControlPlaneOperatorIdentityList) SetItems(items []*ControlPlaneOperatorIdentity) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ControlPlaneOperatorIdentityList) Items() []*ControlPlaneOperatorIdentity {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ControlPlaneOperatorIdentityList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ControlPlaneOperatorIdentityList) Get(i int) *ControlPlaneOperatorIdentity {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ControlPlaneOperatorIdentityList) Slice() []*ControlPlaneOperatorIdentity {
+	var slice []*ControlPlaneOperatorIdentity
+	if l == nil {
+		slice = make([]*ControlPlaneOperatorIdentity, 0)
+	} else {
+		slice = make([]*ControlPlaneOperatorIdentity, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ControlPlaneOperatorIdentityList) Each(f func(item *ControlPlaneOperatorIdentity) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ControlPlaneOperatorIdentityList) Range(f func(index int, item *ControlPlaneOperatorIdentity) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/control_plane_operator_identity_type_json.go
+++ b/clientapi/arohcp/v1alpha1/control_plane_operator_identity_type_json.go
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalControlPlaneOperatorIdentity writes a value of the 'control_plane_operator_identity' type to the given writer.
+func MarshalControlPlaneOperatorIdentity(object *ControlPlaneOperatorIdentity, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteControlPlaneOperatorIdentity(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteControlPlaneOperatorIdentity writes a value of the 'control_plane_operator_identity' type to the given stream.
+func WriteControlPlaneOperatorIdentity(object *ControlPlaneOperatorIdentity, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("max_openshift_version")
+		stream.WriteString(object.maxOpenShiftVersion)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("min_openshift_version")
+		stream.WriteString(object.minOpenShiftVersion)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("operator_name")
+		stream.WriteString(object.operatorName)
+		count++
+	}
+	present_ = object.bitmap_&8 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("required")
+		stream.WriteString(object.required)
+		count++
+	}
+	present_ = object.bitmap_&16 != 0 && object.roleDefinitions != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("role_definitions")
+		WriteRoleDefinitionList(object.roleDefinitions, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalControlPlaneOperatorIdentity reads a value of the 'control_plane_operator_identity' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalControlPlaneOperatorIdentity(source interface{}) (object *ControlPlaneOperatorIdentity, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadControlPlaneOperatorIdentity(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadControlPlaneOperatorIdentity reads a value of the 'control_plane_operator_identity' type from the given iterator.
+func ReadControlPlaneOperatorIdentity(iterator *jsoniter.Iterator) *ControlPlaneOperatorIdentity {
+	object := &ControlPlaneOperatorIdentity{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "max_openshift_version":
+			value := iterator.ReadString()
+			object.maxOpenShiftVersion = value
+			object.bitmap_ |= 1
+		case "min_openshift_version":
+			value := iterator.ReadString()
+			object.minOpenShiftVersion = value
+			object.bitmap_ |= 2
+		case "operator_name":
+			value := iterator.ReadString()
+			object.operatorName = value
+			object.bitmap_ |= 4
+		case "required":
+			value := iterator.ReadString()
+			object.required = value
+			object.bitmap_ |= 8
+		case "role_definitions":
+			value := ReadRoleDefinitionList(iterator)
+			object.roleDefinitions = value
+			object.bitmap_ |= 16
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/data_plane_operator_identity_builder.go
+++ b/clientapi/arohcp/v1alpha1/data_plane_operator_identity_builder.go
@@ -1,0 +1,143 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// DataPlaneOperatorIdentityBuilder contains the data and logic needed to build 'data_plane_operator_identity' objects.
+type DataPlaneOperatorIdentityBuilder struct {
+	bitmap_             uint32
+	maxOpenShiftVersion string
+	minOpenShiftVersion string
+	operatorName        string
+	required            string
+	roleDefinitions     []*RoleDefinitionBuilder
+	serviceAccounts     []*IdentityServiceAccountBuilder
+}
+
+// NewDataPlaneOperatorIdentity creates a new builder of 'data_plane_operator_identity' objects.
+func NewDataPlaneOperatorIdentity() *DataPlaneOperatorIdentityBuilder {
+	return &DataPlaneOperatorIdentityBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *DataPlaneOperatorIdentityBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// MaxOpenShiftVersion sets the value of the 'max_open_shift_version' attribute to the given value.
+func (b *DataPlaneOperatorIdentityBuilder) MaxOpenShiftVersion(value string) *DataPlaneOperatorIdentityBuilder {
+	b.maxOpenShiftVersion = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// MinOpenShiftVersion sets the value of the 'min_open_shift_version' attribute to the given value.
+func (b *DataPlaneOperatorIdentityBuilder) MinOpenShiftVersion(value string) *DataPlaneOperatorIdentityBuilder {
+	b.minOpenShiftVersion = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// OperatorName sets the value of the 'operator_name' attribute to the given value.
+func (b *DataPlaneOperatorIdentityBuilder) OperatorName(value string) *DataPlaneOperatorIdentityBuilder {
+	b.operatorName = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Required sets the value of the 'required' attribute to the given value.
+func (b *DataPlaneOperatorIdentityBuilder) Required(value string) *DataPlaneOperatorIdentityBuilder {
+	b.required = value
+	b.bitmap_ |= 8
+	return b
+}
+
+// RoleDefinitions sets the value of the 'role_definitions' attribute to the given values.
+func (b *DataPlaneOperatorIdentityBuilder) RoleDefinitions(values ...*RoleDefinitionBuilder) *DataPlaneOperatorIdentityBuilder {
+	b.roleDefinitions = make([]*RoleDefinitionBuilder, len(values))
+	copy(b.roleDefinitions, values)
+	b.bitmap_ |= 16
+	return b
+}
+
+// ServiceAccounts sets the value of the 'service_accounts' attribute to the given values.
+func (b *DataPlaneOperatorIdentityBuilder) ServiceAccounts(values ...*IdentityServiceAccountBuilder) *DataPlaneOperatorIdentityBuilder {
+	b.serviceAccounts = make([]*IdentityServiceAccountBuilder, len(values))
+	copy(b.serviceAccounts, values)
+	b.bitmap_ |= 32
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *DataPlaneOperatorIdentityBuilder) Copy(object *DataPlaneOperatorIdentity) *DataPlaneOperatorIdentityBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.maxOpenShiftVersion = object.maxOpenShiftVersion
+	b.minOpenShiftVersion = object.minOpenShiftVersion
+	b.operatorName = object.operatorName
+	b.required = object.required
+	if object.roleDefinitions != nil {
+		b.roleDefinitions = make([]*RoleDefinitionBuilder, len(object.roleDefinitions))
+		for i, v := range object.roleDefinitions {
+			b.roleDefinitions[i] = NewRoleDefinition().Copy(v)
+		}
+	} else {
+		b.roleDefinitions = nil
+	}
+	if object.serviceAccounts != nil {
+		b.serviceAccounts = make([]*IdentityServiceAccountBuilder, len(object.serviceAccounts))
+		for i, v := range object.serviceAccounts {
+			b.serviceAccounts[i] = NewIdentityServiceAccount().Copy(v)
+		}
+	} else {
+		b.serviceAccounts = nil
+	}
+	return b
+}
+
+// Build creates a 'data_plane_operator_identity' object using the configuration stored in the builder.
+func (b *DataPlaneOperatorIdentityBuilder) Build() (object *DataPlaneOperatorIdentity, err error) {
+	object = new(DataPlaneOperatorIdentity)
+	object.bitmap_ = b.bitmap_
+	object.maxOpenShiftVersion = b.maxOpenShiftVersion
+	object.minOpenShiftVersion = b.minOpenShiftVersion
+	object.operatorName = b.operatorName
+	object.required = b.required
+	if b.roleDefinitions != nil {
+		object.roleDefinitions = make([]*RoleDefinition, len(b.roleDefinitions))
+		for i, v := range b.roleDefinitions {
+			object.roleDefinitions[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	if b.serviceAccounts != nil {
+		object.serviceAccounts = make([]*IdentityServiceAccount, len(b.serviceAccounts))
+		for i, v := range b.serviceAccounts {
+			object.serviceAccounts[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/data_plane_operator_identity_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/data_plane_operator_identity_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// DataPlaneOperatorIdentityListBuilder contains the data and logic needed to build
+// 'data_plane_operator_identity' objects.
+type DataPlaneOperatorIdentityListBuilder struct {
+	items []*DataPlaneOperatorIdentityBuilder
+}
+
+// NewDataPlaneOperatorIdentityList creates a new builder of 'data_plane_operator_identity' objects.
+func NewDataPlaneOperatorIdentityList() *DataPlaneOperatorIdentityListBuilder {
+	return new(DataPlaneOperatorIdentityListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *DataPlaneOperatorIdentityListBuilder) Items(values ...*DataPlaneOperatorIdentityBuilder) *DataPlaneOperatorIdentityListBuilder {
+	b.items = make([]*DataPlaneOperatorIdentityBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *DataPlaneOperatorIdentityListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *DataPlaneOperatorIdentityListBuilder) Copy(list *DataPlaneOperatorIdentityList) *DataPlaneOperatorIdentityListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*DataPlaneOperatorIdentityBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewDataPlaneOperatorIdentity().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'data_plane_operator_identity' objects using the
+// configuration stored in the builder.
+func (b *DataPlaneOperatorIdentityListBuilder) Build() (list *DataPlaneOperatorIdentityList, err error) {
+	items := make([]*DataPlaneOperatorIdentity, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(DataPlaneOperatorIdentityList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/data_plane_operator_identity_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/data_plane_operator_identity_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalDataPlaneOperatorIdentityList writes a list of values of the 'data_plane_operator_identity' type to
+// the given writer.
+func MarshalDataPlaneOperatorIdentityList(list []*DataPlaneOperatorIdentity, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteDataPlaneOperatorIdentityList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteDataPlaneOperatorIdentityList writes a list of value of the 'data_plane_operator_identity' type to
+// the given stream.
+func WriteDataPlaneOperatorIdentityList(list []*DataPlaneOperatorIdentity, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteDataPlaneOperatorIdentity(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalDataPlaneOperatorIdentityList reads a list of values of the 'data_plane_operator_identity' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalDataPlaneOperatorIdentityList(source interface{}) (items []*DataPlaneOperatorIdentity, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadDataPlaneOperatorIdentityList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadDataPlaneOperatorIdentityList reads list of values of the ”data_plane_operator_identity' type from
+// the given iterator.
+func ReadDataPlaneOperatorIdentityList(iterator *jsoniter.Iterator) []*DataPlaneOperatorIdentity {
+	list := []*DataPlaneOperatorIdentity{}
+	for iterator.ReadArray() {
+		item := ReadDataPlaneOperatorIdentity(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/data_plane_operator_identity_type.go
+++ b/clientapi/arohcp/v1alpha1/data_plane_operator_identity_type.go
@@ -1,0 +1,309 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// DataPlaneOperatorIdentity represents the values of the 'data_plane_operator_identity' type.
+type DataPlaneOperatorIdentity struct {
+	bitmap_             uint32
+	maxOpenShiftVersion string
+	minOpenShiftVersion string
+	operatorName        string
+	required            string
+	roleDefinitions     []*RoleDefinition
+	serviceAccounts     []*IdentityServiceAccount
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *DataPlaneOperatorIdentity) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// MaxOpenShiftVersion returns the value of the 'max_open_shift_version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and
+// minor segments of the OpenShift version respectively.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// starting from min_openshift_version if min_openshift_version is defined.
+func (o *DataPlaneOperatorIdentity) MaxOpenShiftVersion() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.maxOpenShiftVersion
+	}
+	return ""
+}
+
+// GetMaxOpenShiftVersion returns the value of the 'max_open_shift_version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and
+// minor segments of the OpenShift version respectively.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// starting from min_openshift_version if min_openshift_version is defined.
+func (o *DataPlaneOperatorIdentity) GetMaxOpenShiftVersion() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.maxOpenShiftVersion
+	}
+	return
+}
+
+// MinOpenShiftVersion returns the value of the 'min_open_shift_version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and
+// minor segments of the OpenShift version respectively.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// or up to max_openshift_version, if defined.
+func (o *DataPlaneOperatorIdentity) MinOpenShiftVersion() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.minOpenShiftVersion
+	}
+	return ""
+}
+
+// GetMinOpenShiftVersion returns the value of the 'min_open_shift_version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and
+// minor segments of the OpenShift version respectively.
+// Not specifying it indicates support for this operator in all Openshift versions,
+// or up to max_openshift_version, if defined.
+func (o *DataPlaneOperatorIdentity) GetMinOpenShiftVersion() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.minOpenShiftVersion
+	}
+	return
+}
+
+// OperatorName returns the value of the 'operator_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The name of the data plane operator that needs the identity
+func (o *DataPlaneOperatorIdentity) OperatorName() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.operatorName
+	}
+	return ""
+}
+
+// GetOperatorName returns the value of the 'operator_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The name of the data plane operator that needs the identity
+func (o *DataPlaneOperatorIdentity) GetOperatorName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.operatorName
+	}
+	return
+}
+
+// Required returns the value of the 'required' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Indicates the whether the identity is always required or not
+// "always" means that the identity is always required
+// "on_enablement" means that the identity is only required when a functionality
+// that leverages the operator is enabled.
+// Possible values are ("always", "on_enablement")
+func (o *DataPlaneOperatorIdentity) Required() string {
+	if o != nil && o.bitmap_&8 != 0 {
+		return o.required
+	}
+	return ""
+}
+
+// GetRequired returns the value of the 'required' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Indicates the whether the identity is always required or not
+// "always" means that the identity is always required
+// "on_enablement" means that the identity is only required when a functionality
+// that leverages the operator is enabled.
+// Possible values are ("always", "on_enablement")
+func (o *DataPlaneOperatorIdentity) GetRequired() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&8 != 0
+	if ok {
+		value = o.required
+	}
+	return
+}
+
+// RoleDefinitions returns the value of the 'role_definitions' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A list of roles that are required by the operator
+func (o *DataPlaneOperatorIdentity) RoleDefinitions() []*RoleDefinition {
+	if o != nil && o.bitmap_&16 != 0 {
+		return o.roleDefinitions
+	}
+	return nil
+}
+
+// GetRoleDefinitions returns the value of the 'role_definitions' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A list of roles that are required by the operator
+func (o *DataPlaneOperatorIdentity) GetRoleDefinitions() (value []*RoleDefinition, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
+	if ok {
+		value = o.roleDefinitions
+	}
+	return
+}
+
+// ServiceAccounts returns the value of the 'service_accounts' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// It is a list of K8s ServiceAccounts leveraged by the operator.
+// There must be at least a single service account specified.
+// This information is needed to federate a managed identity to a k8s subject.
+// There should be no duplicated "name:namespace" entries within this field.
+func (o *DataPlaneOperatorIdentity) ServiceAccounts() []*IdentityServiceAccount {
+	if o != nil && o.bitmap_&32 != 0 {
+		return o.serviceAccounts
+	}
+	return nil
+}
+
+// GetServiceAccounts returns the value of the 'service_accounts' attribute and
+// a flag indicating if the attribute has a value.
+//
+// It is a list of K8s ServiceAccounts leveraged by the operator.
+// There must be at least a single service account specified.
+// This information is needed to federate a managed identity to a k8s subject.
+// There should be no duplicated "name:namespace" entries within this field.
+func (o *DataPlaneOperatorIdentity) GetServiceAccounts() (value []*IdentityServiceAccount, ok bool) {
+	ok = o != nil && o.bitmap_&32 != 0
+	if ok {
+		value = o.serviceAccounts
+	}
+	return
+}
+
+// DataPlaneOperatorIdentityListKind is the name of the type used to represent list of objects of
+// type 'data_plane_operator_identity'.
+const DataPlaneOperatorIdentityListKind = "DataPlaneOperatorIdentityList"
+
+// DataPlaneOperatorIdentityListLinkKind is the name of the type used to represent links to list
+// of objects of type 'data_plane_operator_identity'.
+const DataPlaneOperatorIdentityListLinkKind = "DataPlaneOperatorIdentityListLink"
+
+// DataPlaneOperatorIdentityNilKind is the name of the type used to nil lists of objects of
+// type 'data_plane_operator_identity'.
+const DataPlaneOperatorIdentityListNilKind = "DataPlaneOperatorIdentityListNil"
+
+// DataPlaneOperatorIdentityList is a list of values of the 'data_plane_operator_identity' type.
+type DataPlaneOperatorIdentityList struct {
+	href  string
+	link  bool
+	items []*DataPlaneOperatorIdentity
+}
+
+// Len returns the length of the list.
+func (l *DataPlaneOperatorIdentityList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *DataPlaneOperatorIdentityList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *DataPlaneOperatorIdentityList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *DataPlaneOperatorIdentityList) SetItems(items []*DataPlaneOperatorIdentity) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *DataPlaneOperatorIdentityList) Items() []*DataPlaneOperatorIdentity {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *DataPlaneOperatorIdentityList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *DataPlaneOperatorIdentityList) Get(i int) *DataPlaneOperatorIdentity {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *DataPlaneOperatorIdentityList) Slice() []*DataPlaneOperatorIdentity {
+	var slice []*DataPlaneOperatorIdentity
+	if l == nil {
+		slice = make([]*DataPlaneOperatorIdentity, 0)
+	} else {
+		slice = make([]*DataPlaneOperatorIdentity, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *DataPlaneOperatorIdentityList) Each(f func(item *DataPlaneOperatorIdentity) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *DataPlaneOperatorIdentityList) Range(f func(index int, item *DataPlaneOperatorIdentity) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/data_plane_operator_identity_type_json.go
+++ b/clientapi/arohcp/v1alpha1/data_plane_operator_identity_type_json.go
@@ -1,0 +1,151 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalDataPlaneOperatorIdentity writes a value of the 'data_plane_operator_identity' type to the given writer.
+func MarshalDataPlaneOperatorIdentity(object *DataPlaneOperatorIdentity, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteDataPlaneOperatorIdentity(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteDataPlaneOperatorIdentity writes a value of the 'data_plane_operator_identity' type to the given stream.
+func WriteDataPlaneOperatorIdentity(object *DataPlaneOperatorIdentity, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("max_openshift_version")
+		stream.WriteString(object.maxOpenShiftVersion)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("min_openshift_version")
+		stream.WriteString(object.minOpenShiftVersion)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("operator_name")
+		stream.WriteString(object.operatorName)
+		count++
+	}
+	present_ = object.bitmap_&8 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("required")
+		stream.WriteString(object.required)
+		count++
+	}
+	present_ = object.bitmap_&16 != 0 && object.roleDefinitions != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("role_definitions")
+		WriteRoleDefinitionList(object.roleDefinitions, stream)
+		count++
+	}
+	present_ = object.bitmap_&32 != 0 && object.serviceAccounts != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("service_accounts")
+		WriteIdentityServiceAccountList(object.serviceAccounts, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalDataPlaneOperatorIdentity reads a value of the 'data_plane_operator_identity' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalDataPlaneOperatorIdentity(source interface{}) (object *DataPlaneOperatorIdentity, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadDataPlaneOperatorIdentity(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadDataPlaneOperatorIdentity reads a value of the 'data_plane_operator_identity' type from the given iterator.
+func ReadDataPlaneOperatorIdentity(iterator *jsoniter.Iterator) *DataPlaneOperatorIdentity {
+	object := &DataPlaneOperatorIdentity{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "max_openshift_version":
+			value := iterator.ReadString()
+			object.maxOpenShiftVersion = value
+			object.bitmap_ |= 1
+		case "min_openshift_version":
+			value := iterator.ReadString()
+			object.minOpenShiftVersion = value
+			object.bitmap_ |= 2
+		case "operator_name":
+			value := iterator.ReadString()
+			object.operatorName = value
+			object.bitmap_ |= 4
+		case "required":
+			value := iterator.ReadString()
+			object.required = value
+			object.bitmap_ |= 8
+		case "role_definitions":
+			value := ReadRoleDefinitionList(iterator)
+			object.roleDefinitions = value
+			object.bitmap_ |= 16
+		case "service_accounts":
+			value := ReadIdentityServiceAccountList(iterator)
+			object.serviceAccounts = value
+			object.bitmap_ |= 32
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/identity_service_account_builder.go
+++ b/clientapi/arohcp/v1alpha1/identity_service_account_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// IdentityServiceAccountBuilder contains the data and logic needed to build 'identity_service_account' objects.
+type IdentityServiceAccountBuilder struct {
+	bitmap_   uint32
+	name      string
+	namespace string
+}
+
+// NewIdentityServiceAccount creates a new builder of 'identity_service_account' objects.
+func NewIdentityServiceAccount() *IdentityServiceAccountBuilder {
+	return &IdentityServiceAccountBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *IdentityServiceAccountBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Name sets the value of the 'name' attribute to the given value.
+func (b *IdentityServiceAccountBuilder) Name(value string) *IdentityServiceAccountBuilder {
+	b.name = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Namespace sets the value of the 'namespace' attribute to the given value.
+func (b *IdentityServiceAccountBuilder) Namespace(value string) *IdentityServiceAccountBuilder {
+	b.namespace = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *IdentityServiceAccountBuilder) Copy(object *IdentityServiceAccount) *IdentityServiceAccountBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.name = object.name
+	b.namespace = object.namespace
+	return b
+}
+
+// Build creates a 'identity_service_account' object using the configuration stored in the builder.
+func (b *IdentityServiceAccountBuilder) Build() (object *IdentityServiceAccount, err error) {
+	object = new(IdentityServiceAccount)
+	object.bitmap_ = b.bitmap_
+	object.name = b.name
+	object.namespace = b.namespace
+	return
+}

--- a/clientapi/arohcp/v1alpha1/identity_service_account_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/identity_service_account_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// IdentityServiceAccountListBuilder contains the data and logic needed to build
+// 'identity_service_account' objects.
+type IdentityServiceAccountListBuilder struct {
+	items []*IdentityServiceAccountBuilder
+}
+
+// NewIdentityServiceAccountList creates a new builder of 'identity_service_account' objects.
+func NewIdentityServiceAccountList() *IdentityServiceAccountListBuilder {
+	return new(IdentityServiceAccountListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *IdentityServiceAccountListBuilder) Items(values ...*IdentityServiceAccountBuilder) *IdentityServiceAccountListBuilder {
+	b.items = make([]*IdentityServiceAccountBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *IdentityServiceAccountListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *IdentityServiceAccountListBuilder) Copy(list *IdentityServiceAccountList) *IdentityServiceAccountListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*IdentityServiceAccountBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewIdentityServiceAccount().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'identity_service_account' objects using the
+// configuration stored in the builder.
+func (b *IdentityServiceAccountListBuilder) Build() (list *IdentityServiceAccountList, err error) {
+	items := make([]*IdentityServiceAccount, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(IdentityServiceAccountList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/identity_service_account_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/identity_service_account_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalIdentityServiceAccountList writes a list of values of the 'identity_service_account' type to
+// the given writer.
+func MarshalIdentityServiceAccountList(list []*IdentityServiceAccount, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteIdentityServiceAccountList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteIdentityServiceAccountList writes a list of value of the 'identity_service_account' type to
+// the given stream.
+func WriteIdentityServiceAccountList(list []*IdentityServiceAccount, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteIdentityServiceAccount(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalIdentityServiceAccountList reads a list of values of the 'identity_service_account' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalIdentityServiceAccountList(source interface{}) (items []*IdentityServiceAccount, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadIdentityServiceAccountList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadIdentityServiceAccountList reads list of values of the ”identity_service_account' type from
+// the given iterator.
+func ReadIdentityServiceAccountList(iterator *jsoniter.Iterator) []*IdentityServiceAccount {
+	list := []*IdentityServiceAccount{}
+	for iterator.ReadArray() {
+		item := ReadIdentityServiceAccount(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/identity_service_account_type.go
+++ b/clientapi/arohcp/v1alpha1/identity_service_account_type.go
@@ -1,0 +1,187 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// IdentityServiceAccount represents the values of the 'identity_service_account' type.
+type IdentityServiceAccount struct {
+	bitmap_   uint32
+	name      string
+	namespace string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *IdentityServiceAccount) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Name returns the value of the 'name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The name of the service account to be leveraged by the operator
+func (o *IdentityServiceAccount) Name() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.name
+	}
+	return ""
+}
+
+// GetName returns the value of the 'name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The name of the service account to be leveraged by the operator
+func (o *IdentityServiceAccount) GetName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.name
+	}
+	return
+}
+
+// Namespace returns the value of the 'namespace' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The namespace of the service account to be leverage by the operator
+func (o *IdentityServiceAccount) Namespace() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.namespace
+	}
+	return ""
+}
+
+// GetNamespace returns the value of the 'namespace' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The namespace of the service account to be leverage by the operator
+func (o *IdentityServiceAccount) GetNamespace() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.namespace
+	}
+	return
+}
+
+// IdentityServiceAccountListKind is the name of the type used to represent list of objects of
+// type 'identity_service_account'.
+const IdentityServiceAccountListKind = "IdentityServiceAccountList"
+
+// IdentityServiceAccountListLinkKind is the name of the type used to represent links to list
+// of objects of type 'identity_service_account'.
+const IdentityServiceAccountListLinkKind = "IdentityServiceAccountListLink"
+
+// IdentityServiceAccountNilKind is the name of the type used to nil lists of objects of
+// type 'identity_service_account'.
+const IdentityServiceAccountListNilKind = "IdentityServiceAccountListNil"
+
+// IdentityServiceAccountList is a list of values of the 'identity_service_account' type.
+type IdentityServiceAccountList struct {
+	href  string
+	link  bool
+	items []*IdentityServiceAccount
+}
+
+// Len returns the length of the list.
+func (l *IdentityServiceAccountList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *IdentityServiceAccountList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *IdentityServiceAccountList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *IdentityServiceAccountList) SetItems(items []*IdentityServiceAccount) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *IdentityServiceAccountList) Items() []*IdentityServiceAccount {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *IdentityServiceAccountList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *IdentityServiceAccountList) Get(i int) *IdentityServiceAccount {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *IdentityServiceAccountList) Slice() []*IdentityServiceAccount {
+	var slice []*IdentityServiceAccount
+	if l == nil {
+		slice = make([]*IdentityServiceAccount, 0)
+	} else {
+		slice = make([]*IdentityServiceAccount, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *IdentityServiceAccountList) Each(f func(item *IdentityServiceAccount) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *IdentityServiceAccountList) Range(f func(index int, item *IdentityServiceAccount) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/identity_service_account_type_json.go
+++ b/clientapi/arohcp/v1alpha1/identity_service_account_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalIdentityServiceAccount writes a value of the 'identity_service_account' type to the given writer.
+func MarshalIdentityServiceAccount(object *IdentityServiceAccount, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteIdentityServiceAccount(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteIdentityServiceAccount writes a value of the 'identity_service_account' type to the given stream.
+func WriteIdentityServiceAccount(object *IdentityServiceAccount, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("name")
+		stream.WriteString(object.name)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("namespace")
+		stream.WriteString(object.namespace)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalIdentityServiceAccount reads a value of the 'identity_service_account' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalIdentityServiceAccount(source interface{}) (object *IdentityServiceAccount, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadIdentityServiceAccount(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadIdentityServiceAccount reads a value of the 'identity_service_account' type from the given iterator.
+func ReadIdentityServiceAccount(iterator *jsoniter.Iterator) *IdentityServiceAccount {
+	object := &IdentityServiceAccount{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "name":
+			value := iterator.ReadString()
+			object.name = value
+			object.bitmap_ |= 1
+		case "namespace":
+			value := iterator.ReadString()
+			object.namespace = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/managed_identities_requirements_builder.go
+++ b/clientapi/arohcp/v1alpha1/managed_identities_requirements_builder.go
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ManagedIdentitiesRequirementsBuilder contains the data and logic needed to build 'managed_identities_requirements' objects.
+//
+// Representation of managed identities requirements.
+// When creating ARO-HCP Clusters, the end-users will need to pre-create the set of Managed Identities
+// required by the clusters.
+// The set of Managed Identities that the end-users need to precreate is not static and depends on
+// several factors:
+// (1) The OpenShift version of the cluster being created.
+// (2) The functionalities that are being enabled for the cluster. Some Managed Identities are not
+// always required but become required if a given functionality is enabled.
+// Additionally, the Managed Identities that the end-users will need to precreate will have to have a
+// set of required permissions assigned to them which also have to be returned to the end users.
+type ManagedIdentitiesRequirementsBuilder struct {
+	bitmap_                         uint32
+	id                              string
+	href                            string
+	controlPlaneOperatorsIdentities []*ControlPlaneOperatorIdentityBuilder
+	dataPlaneOperatorsIdentities    []*DataPlaneOperatorIdentityBuilder
+}
+
+// NewManagedIdentitiesRequirements creates a new builder of 'managed_identities_requirements' objects.
+func NewManagedIdentitiesRequirements() *ManagedIdentitiesRequirementsBuilder {
+	return &ManagedIdentitiesRequirementsBuilder{}
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *ManagedIdentitiesRequirementsBuilder) Link(value bool) *ManagedIdentitiesRequirementsBuilder {
+	b.bitmap_ |= 1
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *ManagedIdentitiesRequirementsBuilder) ID(value string) *ManagedIdentitiesRequirementsBuilder {
+	b.id = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *ManagedIdentitiesRequirementsBuilder) HREF(value string) *ManagedIdentitiesRequirementsBuilder {
+	b.href = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ManagedIdentitiesRequirementsBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
+// ControlPlaneOperatorsIdentities sets the value of the 'control_plane_operators_identities' attribute to the given values.
+func (b *ManagedIdentitiesRequirementsBuilder) ControlPlaneOperatorsIdentities(values ...*ControlPlaneOperatorIdentityBuilder) *ManagedIdentitiesRequirementsBuilder {
+	b.controlPlaneOperatorsIdentities = make([]*ControlPlaneOperatorIdentityBuilder, len(values))
+	copy(b.controlPlaneOperatorsIdentities, values)
+	b.bitmap_ |= 8
+	return b
+}
+
+// DataPlaneOperatorsIdentities sets the value of the 'data_plane_operators_identities' attribute to the given values.
+func (b *ManagedIdentitiesRequirementsBuilder) DataPlaneOperatorsIdentities(values ...*DataPlaneOperatorIdentityBuilder) *ManagedIdentitiesRequirementsBuilder {
+	b.dataPlaneOperatorsIdentities = make([]*DataPlaneOperatorIdentityBuilder, len(values))
+	copy(b.dataPlaneOperatorsIdentities, values)
+	b.bitmap_ |= 16
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ManagedIdentitiesRequirementsBuilder) Copy(object *ManagedIdentitiesRequirements) *ManagedIdentitiesRequirementsBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.id = object.id
+	b.href = object.href
+	if object.controlPlaneOperatorsIdentities != nil {
+		b.controlPlaneOperatorsIdentities = make([]*ControlPlaneOperatorIdentityBuilder, len(object.controlPlaneOperatorsIdentities))
+		for i, v := range object.controlPlaneOperatorsIdentities {
+			b.controlPlaneOperatorsIdentities[i] = NewControlPlaneOperatorIdentity().Copy(v)
+		}
+	} else {
+		b.controlPlaneOperatorsIdentities = nil
+	}
+	if object.dataPlaneOperatorsIdentities != nil {
+		b.dataPlaneOperatorsIdentities = make([]*DataPlaneOperatorIdentityBuilder, len(object.dataPlaneOperatorsIdentities))
+		for i, v := range object.dataPlaneOperatorsIdentities {
+			b.dataPlaneOperatorsIdentities[i] = NewDataPlaneOperatorIdentity().Copy(v)
+		}
+	} else {
+		b.dataPlaneOperatorsIdentities = nil
+	}
+	return b
+}
+
+// Build creates a 'managed_identities_requirements' object using the configuration stored in the builder.
+func (b *ManagedIdentitiesRequirementsBuilder) Build() (object *ManagedIdentitiesRequirements, err error) {
+	object = new(ManagedIdentitiesRequirements)
+	object.id = b.id
+	object.href = b.href
+	object.bitmap_ = b.bitmap_
+	if b.controlPlaneOperatorsIdentities != nil {
+		object.controlPlaneOperatorsIdentities = make([]*ControlPlaneOperatorIdentity, len(b.controlPlaneOperatorsIdentities))
+		for i, v := range b.controlPlaneOperatorsIdentities {
+			object.controlPlaneOperatorsIdentities[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	if b.dataPlaneOperatorsIdentities != nil {
+		object.dataPlaneOperatorsIdentities = make([]*DataPlaneOperatorIdentity, len(b.dataPlaneOperatorsIdentities))
+		for i, v := range b.dataPlaneOperatorsIdentities {
+			object.dataPlaneOperatorsIdentities[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/managed_identities_requirements_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/managed_identities_requirements_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ManagedIdentitiesRequirementsListBuilder contains the data and logic needed to build
+// 'managed_identities_requirements' objects.
+type ManagedIdentitiesRequirementsListBuilder struct {
+	items []*ManagedIdentitiesRequirementsBuilder
+}
+
+// NewManagedIdentitiesRequirementsList creates a new builder of 'managed_identities_requirements' objects.
+func NewManagedIdentitiesRequirementsList() *ManagedIdentitiesRequirementsListBuilder {
+	return new(ManagedIdentitiesRequirementsListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ManagedIdentitiesRequirementsListBuilder) Items(values ...*ManagedIdentitiesRequirementsBuilder) *ManagedIdentitiesRequirementsListBuilder {
+	b.items = make([]*ManagedIdentitiesRequirementsBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ManagedIdentitiesRequirementsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ManagedIdentitiesRequirementsListBuilder) Copy(list *ManagedIdentitiesRequirementsList) *ManagedIdentitiesRequirementsListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ManagedIdentitiesRequirementsBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewManagedIdentitiesRequirements().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'managed_identities_requirements' objects using the
+// configuration stored in the builder.
+func (b *ManagedIdentitiesRequirementsListBuilder) Build() (list *ManagedIdentitiesRequirementsList, err error) {
+	items := make([]*ManagedIdentitiesRequirements, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ManagedIdentitiesRequirementsList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/managed_identities_requirements_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/managed_identities_requirements_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalManagedIdentitiesRequirementsList writes a list of values of the 'managed_identities_requirements' type to
+// the given writer.
+func MarshalManagedIdentitiesRequirementsList(list []*ManagedIdentitiesRequirements, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteManagedIdentitiesRequirementsList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteManagedIdentitiesRequirementsList writes a list of value of the 'managed_identities_requirements' type to
+// the given stream.
+func WriteManagedIdentitiesRequirementsList(list []*ManagedIdentitiesRequirements, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteManagedIdentitiesRequirements(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalManagedIdentitiesRequirementsList reads a list of values of the 'managed_identities_requirements' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalManagedIdentitiesRequirementsList(source interface{}) (items []*ManagedIdentitiesRequirements, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadManagedIdentitiesRequirementsList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadManagedIdentitiesRequirementsList reads list of values of the ”managed_identities_requirements' type from
+// the given iterator.
+func ReadManagedIdentitiesRequirementsList(iterator *jsoniter.Iterator) []*ManagedIdentitiesRequirements {
+	list := []*ManagedIdentitiesRequirements{}
+	for iterator.ReadArray() {
+		item := ReadManagedIdentitiesRequirements(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/managed_identities_requirements_type.go
+++ b/clientapi/arohcp/v1alpha1/managed_identities_requirements_type.go
@@ -1,0 +1,298 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ManagedIdentitiesRequirementsKind is the name of the type used to represent objects
+// of type 'managed_identities_requirements'.
+const ManagedIdentitiesRequirementsKind = "ManagedIdentitiesRequirements"
+
+// ManagedIdentitiesRequirementsLinkKind is the name of the type used to represent links
+// to objects of type 'managed_identities_requirements'.
+const ManagedIdentitiesRequirementsLinkKind = "ManagedIdentitiesRequirementsLink"
+
+// ManagedIdentitiesRequirementsNilKind is the name of the type used to nil references
+// to objects of type 'managed_identities_requirements'.
+const ManagedIdentitiesRequirementsNilKind = "ManagedIdentitiesRequirementsNil"
+
+// ManagedIdentitiesRequirements represents the values of the 'managed_identities_requirements' type.
+//
+// Representation of managed identities requirements.
+// When creating ARO-HCP Clusters, the end-users will need to pre-create the set of Managed Identities
+// required by the clusters.
+// The set of Managed Identities that the end-users need to precreate is not static and depends on
+// several factors:
+// (1) The OpenShift version of the cluster being created.
+// (2) The functionalities that are being enabled for the cluster. Some Managed Identities are not
+// always required but become required if a given functionality is enabled.
+// Additionally, the Managed Identities that the end-users will need to precreate will have to have a
+// set of required permissions assigned to them which also have to be returned to the end users.
+type ManagedIdentitiesRequirements struct {
+	bitmap_                         uint32
+	id                              string
+	href                            string
+	controlPlaneOperatorsIdentities []*ControlPlaneOperatorIdentity
+	dataPlaneOperatorsIdentities    []*DataPlaneOperatorIdentity
+}
+
+// Kind returns the name of the type of the object.
+func (o *ManagedIdentitiesRequirements) Kind() string {
+	if o == nil {
+		return ManagedIdentitiesRequirementsNilKind
+	}
+	if o.bitmap_&1 != 0 {
+		return ManagedIdentitiesRequirementsLinkKind
+	}
+	return ManagedIdentitiesRequirementsKind
+}
+
+// Link returns true if this is a link.
+func (o *ManagedIdentitiesRequirements) Link() bool {
+	return o != nil && o.bitmap_&1 != 0
+}
+
+// ID returns the identifier of the object.
+func (o *ManagedIdentitiesRequirements) ID() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *ManagedIdentitiesRequirements) GetID() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *ManagedIdentitiesRequirements) HREF() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *ManagedIdentitiesRequirements) GetHREF() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ManagedIdentitiesRequirements) Empty() bool {
+	return o == nil || o.bitmap_&^1 == 0
+}
+
+// ControlPlaneOperatorsIdentities returns the value of the 'control_plane_operators_identities' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The control plane operators managed identities requirements
+func (o *ManagedIdentitiesRequirements) ControlPlaneOperatorsIdentities() []*ControlPlaneOperatorIdentity {
+	if o != nil && o.bitmap_&8 != 0 {
+		return o.controlPlaneOperatorsIdentities
+	}
+	return nil
+}
+
+// GetControlPlaneOperatorsIdentities returns the value of the 'control_plane_operators_identities' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The control plane operators managed identities requirements
+func (o *ManagedIdentitiesRequirements) GetControlPlaneOperatorsIdentities() (value []*ControlPlaneOperatorIdentity, ok bool) {
+	ok = o != nil && o.bitmap_&8 != 0
+	if ok {
+		value = o.controlPlaneOperatorsIdentities
+	}
+	return
+}
+
+// DataPlaneOperatorsIdentities returns the value of the 'data_plane_operators_identities' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The data plane operators managed identities requires
+func (o *ManagedIdentitiesRequirements) DataPlaneOperatorsIdentities() []*DataPlaneOperatorIdentity {
+	if o != nil && o.bitmap_&16 != 0 {
+		return o.dataPlaneOperatorsIdentities
+	}
+	return nil
+}
+
+// GetDataPlaneOperatorsIdentities returns the value of the 'data_plane_operators_identities' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The data plane operators managed identities requires
+func (o *ManagedIdentitiesRequirements) GetDataPlaneOperatorsIdentities() (value []*DataPlaneOperatorIdentity, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
+	if ok {
+		value = o.dataPlaneOperatorsIdentities
+	}
+	return
+}
+
+// ManagedIdentitiesRequirementsListKind is the name of the type used to represent list of objects of
+// type 'managed_identities_requirements'.
+const ManagedIdentitiesRequirementsListKind = "ManagedIdentitiesRequirementsList"
+
+// ManagedIdentitiesRequirementsListLinkKind is the name of the type used to represent links to list
+// of objects of type 'managed_identities_requirements'.
+const ManagedIdentitiesRequirementsListLinkKind = "ManagedIdentitiesRequirementsListLink"
+
+// ManagedIdentitiesRequirementsNilKind is the name of the type used to nil lists of objects of
+// type 'managed_identities_requirements'.
+const ManagedIdentitiesRequirementsListNilKind = "ManagedIdentitiesRequirementsListNil"
+
+// ManagedIdentitiesRequirementsList is a list of values of the 'managed_identities_requirements' type.
+type ManagedIdentitiesRequirementsList struct {
+	href  string
+	link  bool
+	items []*ManagedIdentitiesRequirements
+}
+
+// Kind returns the name of the type of the object.
+func (l *ManagedIdentitiesRequirementsList) Kind() string {
+	if l == nil {
+		return ManagedIdentitiesRequirementsListNilKind
+	}
+	if l.link {
+		return ManagedIdentitiesRequirementsListLinkKind
+	}
+	return ManagedIdentitiesRequirementsListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ManagedIdentitiesRequirementsList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ManagedIdentitiesRequirementsList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ManagedIdentitiesRequirementsList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *ManagedIdentitiesRequirementsList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ManagedIdentitiesRequirementsList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ManagedIdentitiesRequirementsList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ManagedIdentitiesRequirementsList) SetItems(items []*ManagedIdentitiesRequirements) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ManagedIdentitiesRequirementsList) Items() []*ManagedIdentitiesRequirements {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ManagedIdentitiesRequirementsList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ManagedIdentitiesRequirementsList) Get(i int) *ManagedIdentitiesRequirements {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ManagedIdentitiesRequirementsList) Slice() []*ManagedIdentitiesRequirements {
+	var slice []*ManagedIdentitiesRequirements
+	if l == nil {
+		slice = make([]*ManagedIdentitiesRequirements, 0)
+	} else {
+		slice = make([]*ManagedIdentitiesRequirements, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ManagedIdentitiesRequirementsList) Each(f func(item *ManagedIdentitiesRequirements) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ManagedIdentitiesRequirementsList) Range(f func(index int, item *ManagedIdentitiesRequirements) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/managed_identities_requirements_type_json.go
+++ b/clientapi/arohcp/v1alpha1/managed_identities_requirements_type_json.go
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalManagedIdentitiesRequirements writes a value of the 'managed_identities_requirements' type to the given writer.
+func MarshalManagedIdentitiesRequirements(object *ManagedIdentitiesRequirements, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteManagedIdentitiesRequirements(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteManagedIdentitiesRequirements writes a value of the 'managed_identities_requirements' type to the given stream.
+func WriteManagedIdentitiesRequirements(object *ManagedIdentitiesRequirements, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	stream.WriteObjectField("kind")
+	if object.bitmap_&1 != 0 {
+		stream.WriteString(ManagedIdentitiesRequirementsLinkKind)
+	} else {
+		stream.WriteString(ManagedIdentitiesRequirementsKind)
+	}
+	count++
+	if object.bitmap_&2 != 0 {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	if object.bitmap_&4 != 0 {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
+	var present_ bool
+	present_ = object.bitmap_&8 != 0 && object.controlPlaneOperatorsIdentities != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("control_plane_operators_identities")
+		WriteControlPlaneOperatorIdentityList(object.controlPlaneOperatorsIdentities, stream)
+		count++
+	}
+	present_ = object.bitmap_&16 != 0 && object.dataPlaneOperatorsIdentities != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("data_plane_operators_identities")
+		WriteDataPlaneOperatorIdentityList(object.dataPlaneOperatorsIdentities, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalManagedIdentitiesRequirements reads a value of the 'managed_identities_requirements' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalManagedIdentitiesRequirements(source interface{}) (object *ManagedIdentitiesRequirements, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadManagedIdentitiesRequirements(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadManagedIdentitiesRequirements reads a value of the 'managed_identities_requirements' type from the given iterator.
+func ReadManagedIdentitiesRequirements(iterator *jsoniter.Iterator) *ManagedIdentitiesRequirements {
+	object := &ManagedIdentitiesRequirements{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "kind":
+			value := iterator.ReadString()
+			if value == ManagedIdentitiesRequirementsLinkKind {
+				object.bitmap_ |= 1
+			}
+		case "id":
+			object.id = iterator.ReadString()
+			object.bitmap_ |= 2
+		case "href":
+			object.href = iterator.ReadString()
+			object.bitmap_ |= 4
+		case "control_plane_operators_identities":
+			value := ReadControlPlaneOperatorIdentityList(iterator)
+			object.controlPlaneOperatorsIdentities = value
+			object.bitmap_ |= 8
+		case "data_plane_operators_identities":
+			value := ReadDataPlaneOperatorIdentityList(iterator)
+			object.dataPlaneOperatorsIdentities = value
+			object.bitmap_ |= 16
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/role_definition_builder.go
+++ b/clientapi/arohcp/v1alpha1/role_definition_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// RoleDefinitionBuilder contains the data and logic needed to build 'role_definition' objects.
+type RoleDefinitionBuilder struct {
+	bitmap_    uint32
+	name       string
+	resourceId string
+}
+
+// NewRoleDefinition creates a new builder of 'role_definition' objects.
+func NewRoleDefinition() *RoleDefinitionBuilder {
+	return &RoleDefinitionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *RoleDefinitionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Name sets the value of the 'name' attribute to the given value.
+func (b *RoleDefinitionBuilder) Name(value string) *RoleDefinitionBuilder {
+	b.name = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// ResourceId sets the value of the 'resource_id' attribute to the given value.
+func (b *RoleDefinitionBuilder) ResourceId(value string) *RoleDefinitionBuilder {
+	b.resourceId = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *RoleDefinitionBuilder) Copy(object *RoleDefinition) *RoleDefinitionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.name = object.name
+	b.resourceId = object.resourceId
+	return b
+}
+
+// Build creates a 'role_definition' object using the configuration stored in the builder.
+func (b *RoleDefinitionBuilder) Build() (object *RoleDefinition, err error) {
+	object = new(RoleDefinition)
+	object.bitmap_ = b.bitmap_
+	object.name = b.name
+	object.resourceId = b.resourceId
+	return
+}

--- a/clientapi/arohcp/v1alpha1/role_definition_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/role_definition_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// RoleDefinitionListBuilder contains the data and logic needed to build
+// 'role_definition' objects.
+type RoleDefinitionListBuilder struct {
+	items []*RoleDefinitionBuilder
+}
+
+// NewRoleDefinitionList creates a new builder of 'role_definition' objects.
+func NewRoleDefinitionList() *RoleDefinitionListBuilder {
+	return new(RoleDefinitionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *RoleDefinitionListBuilder) Items(values ...*RoleDefinitionBuilder) *RoleDefinitionListBuilder {
+	b.items = make([]*RoleDefinitionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *RoleDefinitionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *RoleDefinitionListBuilder) Copy(list *RoleDefinitionList) *RoleDefinitionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*RoleDefinitionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewRoleDefinition().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'role_definition' objects using the
+// configuration stored in the builder.
+func (b *RoleDefinitionListBuilder) Build() (list *RoleDefinitionList, err error) {
+	items := make([]*RoleDefinition, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(RoleDefinitionList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/role_definition_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/role_definition_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalRoleDefinitionList writes a list of values of the 'role_definition' type to
+// the given writer.
+func MarshalRoleDefinitionList(list []*RoleDefinition, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteRoleDefinitionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteRoleDefinitionList writes a list of value of the 'role_definition' type to
+// the given stream.
+func WriteRoleDefinitionList(list []*RoleDefinition, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteRoleDefinition(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalRoleDefinitionList reads a list of values of the 'role_definition' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalRoleDefinitionList(source interface{}) (items []*RoleDefinition, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadRoleDefinitionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadRoleDefinitionList reads list of values of the ”role_definition' type from
+// the given iterator.
+func ReadRoleDefinitionList(iterator *jsoniter.Iterator) []*RoleDefinition {
+	list := []*RoleDefinition{}
+	for iterator.ReadArray() {
+		item := ReadRoleDefinition(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/role_definition_type.go
+++ b/clientapi/arohcp/v1alpha1/role_definition_type.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// RoleDefinition represents the values of the 'role_definition' type.
+type RoleDefinition struct {
+	bitmap_    uint32
+	name       string
+	resourceId string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *RoleDefinition) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Name returns the value of the 'name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The official name of the Role defined in resource_id.
+// It is purely a friendly/descriptive name.
+func (o *RoleDefinition) Name() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.name
+	}
+	return ""
+}
+
+// GetName returns the value of the 'name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The official name of the Role defined in resource_id.
+// It is purely a friendly/descriptive name.
+func (o *RoleDefinition) GetName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.name
+	}
+	return
+}
+
+// ResourceId returns the value of the 'resource_id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A string representing the Resource ID of an Azure Role Definition.
+// The role definition indicates what permissions are needed by the operator
+func (o *RoleDefinition) ResourceId() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.resourceId
+	}
+	return ""
+}
+
+// GetResourceId returns the value of the 'resource_id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A string representing the Resource ID of an Azure Role Definition.
+// The role definition indicates what permissions are needed by the operator
+func (o *RoleDefinition) GetResourceId() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.resourceId
+	}
+	return
+}
+
+// RoleDefinitionListKind is the name of the type used to represent list of objects of
+// type 'role_definition'.
+const RoleDefinitionListKind = "RoleDefinitionList"
+
+// RoleDefinitionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'role_definition'.
+const RoleDefinitionListLinkKind = "RoleDefinitionListLink"
+
+// RoleDefinitionNilKind is the name of the type used to nil lists of objects of
+// type 'role_definition'.
+const RoleDefinitionListNilKind = "RoleDefinitionListNil"
+
+// RoleDefinitionList is a list of values of the 'role_definition' type.
+type RoleDefinitionList struct {
+	href  string
+	link  bool
+	items []*RoleDefinition
+}
+
+// Len returns the length of the list.
+func (l *RoleDefinitionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *RoleDefinitionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *RoleDefinitionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *RoleDefinitionList) SetItems(items []*RoleDefinition) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *RoleDefinitionList) Items() []*RoleDefinition {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *RoleDefinitionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *RoleDefinitionList) Get(i int) *RoleDefinition {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *RoleDefinitionList) Slice() []*RoleDefinition {
+	var slice []*RoleDefinition
+	if l == nil {
+		slice = make([]*RoleDefinition, 0)
+	} else {
+		slice = make([]*RoleDefinition, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *RoleDefinitionList) Each(f func(item *RoleDefinition) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *RoleDefinitionList) Range(f func(index int, item *RoleDefinition) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/role_definition_type_json.go
+++ b/clientapi/arohcp/v1alpha1/role_definition_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalRoleDefinition writes a value of the 'role_definition' type to the given writer.
+func MarshalRoleDefinition(object *RoleDefinition, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteRoleDefinition(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteRoleDefinition writes a value of the 'role_definition' type to the given stream.
+func WriteRoleDefinition(object *RoleDefinition, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("name")
+		stream.WriteString(object.name)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("resource_id")
+		stream.WriteString(object.resourceId)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalRoleDefinition reads a value of the 'role_definition' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalRoleDefinition(source interface{}) (object *RoleDefinition, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadRoleDefinition(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadRoleDefinition reads a value of the 'role_definition' type from the given iterator.
+func ReadRoleDefinition(iterator *jsoniter.Iterator) *RoleDefinition {
+	object := &RoleDefinition{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "name":
+			value := iterator.ReadString()
+			object.name = value
+			object.bitmap_ |= 1
+		case "resource_id":
+			value := iterator.ReadString()
+			object.resourceId = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/model/aro_hcp/v1alpha1/managed_identities_requirements_resource.model
+++ b/model/aro_hcp/v1alpha1/managed_identities_requirements_resource.model
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the ManagedIdentitiesRequirements resource.
+resource ManagedIdentitiesRequirements {
+	// Retrieves an ManagedIdentitiesRequirements by version query param.
+	method Get {
+		// Get the managed identities requirements by OpenShift version.
+		// The query parameter is optional, but when supplied it needs to be 
+		// in the format X.Y (e.g 4.18) where X and Y are major and minor segments of 
+		// the OpenShift version respectively.
+		// When supplied, the returned response will include all the control plane 
+		// and data plane operators requirements for the given version. 
+		// If not supplied, the OpenShift version constraint won't be taken onto account 
+		// when returning the managed identities requirements.
+		in Version String
+
+		// Get the managed identities requirements depending on when they are required.
+		// The query parameter is optional, it needs to be either ("always" or "on_enablement"). 
+		// When not supplied, this enablement constraint won't be taken onto account.
+		// When supplied and among the accepted values, the query parameter will be used to return all managed identities requirements
+		// that matches the value given in the query parameter.
+		// When supplied but the value is invalid, an error is going to be returned.
+		in Required String
+
+		// ManagedIdentitiesRequirements status response.
+		out Body ManagedIdentitiesRequirements
+	}
+}

--- a/model/aro_hcp/v1alpha1/managed_identities_requirements_type.model
+++ b/model/aro_hcp/v1alpha1/managed_identities_requirements_type.model
@@ -1,0 +1,110 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of managed identities requirements.
+// When creating ARO-HCP Clusters, the end-users will need to pre-create the set of Managed Identities
+// required by the clusters.
+// The set of Managed Identities that the end-users need to precreate is not static and depends on 
+// several factors:
+// (1) The OpenShift version of the cluster being created. 
+// (2) The functionalities that are being enabled for the cluster. Some Managed Identities are not
+// always required but become required if a given functionality is enabled.
+// Additionally, the Managed Identities that the end-users will need to precreate will have to have a 
+// set of required permissions assigned to them which also have to be returned to the end users.
+class ManagedIdentitiesRequirements {
+  // The control plane operators managed identities requirements
+  ControlPlaneOperatorsIdentities []ControlPlaneOperatorIdentity
+  // The data plane operators managed identities requires
+  DataPlaneOperatorsIdentities []DataPlaneOperatorIdentity
+}
+
+struct ControlPlaneOperatorIdentity {
+  // Indicates the whether the identity is always required or not.
+  // "always" means that the identity is always required
+  // "on_enablement" means that the identity is only required when a functionality 
+  // that leverages the operator is enabled. 
+  // Possible values are ("always", "on_enablement")
+  Required String
+
+  // The name of the control plane operator that needs the identity
+  OperatorName String
+
+  // The field is a string and it is of format X.Y.
+  // Not specifying it indicates support for this operator in all Openshift versions,
+  // starting from min_openshift_version if min_openshift_version is defined. 
+  @json(name="max_openshift_version")
+  MaxOpenShiftVersion String
+
+  // The field is a string and it is of format X.Y.
+  // Not specifying it indicates support for this operator in all Openshift versions,
+  // or up to max_openshift_version, if defined. 
+  @json(name="min_openshift_version")
+  MinOpenShiftVersion String   
+
+  // A list of roles that are required by the operator 
+  RoleDefinitions []RoleDefinition
+}
+
+struct DataPlaneOperatorIdentity {
+   // Indicates the whether the identity is always required or not
+   // "always" means that the identity is always required
+   // "on_enablement" means that the identity is only required when a functionality 
+   // that leverages the operator is enabled.
+   // Possible values are ("always", "on_enablement")
+   Required String
+
+   // The name of the data plane operator that needs the identity
+   OperatorName String
+
+   // The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and 
+   // minor segments of the OpenShift version respectively.
+   // Not specifying it indicates support for this operator in all Openshift versions,
+   // starting from min_openshift_version if min_openshift_version is defined. 
+   @json(name="max_openshift_version")
+   MaxOpenShiftVersion String
+
+   // The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and 
+   // minor segments of the OpenShift version respectively.
+   // Not specifying it indicates support for this operator in all Openshift versions,
+   // or up to max_openshift_version, if defined. 
+   @json(name="min_openshift_version")
+   MinOpenShiftVersion String
+
+   // It is a list of K8s ServiceAccounts leveraged by the operator.
+   // There must be at least a single service account specified.
+   // This information is needed to federate a managed identity to a k8s subject.
+   // There should be no duplicated "name:namespace" entries within this field. 
+   ServiceAccounts []IdentityServiceAccount
+
+   // A list of roles that are required by the operator 
+   RoleDefinitions []RoleDefinition
+}
+
+struct IdentityServiceAccount {
+  // The name of the service account to be leveraged by the operator
+  Name String
+  // The namespace of the service account to be leverage by the operator
+  Namespace String
+}
+
+struct RoleDefinition {
+  // The official name of the Role defined in resource_id. 
+  // It is purely a friendly/descriptive name.
+  Name String
+  // A string representing the Resource ID of an Azure Role Definition. 
+  // The role definition indicates what permissions are needed by the operator
+  ResourceId String
+}

--- a/model/aro_hcp/v1alpha1/root_resource.model
+++ b/model/aro_hcp/v1alpha1/root_resource.model
@@ -22,4 +22,7 @@ resource Root {
     locator Versions {
         target Versions
     }
+	locator ManagedIdentitiesRequirements {
+		target ManagedIdentitiesRequirements
+	}
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -772,6 +772,51 @@
         }
       }
     },
+    "/api/aro_hcp/v1alpha1/managed_identities_requirements": {
+      "get": {
+        "description": "Retrieves an ManagedIdentitiesRequirements by version query param.",
+        "parameters": [
+          {
+            "name": "required",
+            "description": "Get the managed identities requirements depending on when they are required.\nThe query parameter is optional, it needs to be either (\"always\" or \"on_enablement\"). \nWhen not supplied, this enablement constraint won't be taken onto account.\nWhen supplied and among the accepted values, the query parameter will be used to return all managed identities requirements\nthat matches the value given in the query parameter.\nWhen supplied but the value is invalid, an error is going to be returned.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "version",
+            "description": "Get the managed identities requirements by OpenShift version.\nThe query parameter is optional, but when supplied it needs to be \nin the format X.Y (e.g 4.18) where X and Y are major and minor segments of \nthe OpenShift version respectively.\nWhen supplied, the returned response will include all the control plane \nand data plane operators requirements for the given version. \nIf not supplied, the OpenShift version constraint won't be taken onto account \nwhen returning the managed identities requirements.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ManagedIdentitiesRequirements"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/aro_hcp/v1alpha1/versions": {
       "get": {
         "description": "Retrieves a list of versions.",
@@ -2181,6 +2226,67 @@
           }
         }
       },
+      "ControlPlaneOperatorIdentity": {
+        "properties": {
+          "max_openshift_version": {
+            "description": "The field is a string and it is of format X.Y.\nNot specifying it indicates support for this operator in all Openshift versions,\nstarting from min_openshift_version if min_openshift_version is defined. ",
+            "type": "string"
+          },
+          "min_openshift_version": {
+            "description": "The field is a string and it is of format X.Y.\nNot specifying it indicates support for this operator in all Openshift versions,\nor up to max_openshift_version, if defined. ",
+            "type": "string"
+          },
+          "operator_name": {
+            "description": "The name of the control plane operator that needs the identity",
+            "type": "string"
+          },
+          "required": {
+            "description": "Indicates the whether the identity is always required or not.\n\"always\" means that the identity is always required\n\"on_enablement\" means that the identity is only required when a functionality \nthat leverages the operator is enabled. \nPossible values are (\"always\", \"on_enablement\")",
+            "type": "string"
+          },
+          "role_definitions": {
+            "description": "A list of roles that are required by the operator ",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoleDefinition"
+            }
+          }
+        }
+      },
+      "DataPlaneOperatorIdentity": {
+        "properties": {
+          "max_openshift_version": {
+            "description": "The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and \nminor segments of the OpenShift version respectively.\nNot specifying it indicates support for this operator in all Openshift versions,\nstarting from min_openshift_version if min_openshift_version is defined. ",
+            "type": "string"
+          },
+          "min_openshift_version": {
+            "description": "The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and \nminor segments of the OpenShift version respectively.\nNot specifying it indicates support for this operator in all Openshift versions,\nor up to max_openshift_version, if defined. ",
+            "type": "string"
+          },
+          "operator_name": {
+            "description": "The name of the data plane operator that needs the identity",
+            "type": "string"
+          },
+          "required": {
+            "description": "Indicates the whether the identity is always required or not\n\"always\" means that the identity is always required\n\"on_enablement\" means that the identity is only required when a functionality \nthat leverages the operator is enabled.\nPossible values are (\"always\", \"on_enablement\")",
+            "type": "string"
+          },
+          "role_definitions": {
+            "description": "A list of roles that are required by the operator ",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoleDefinition"
+            }
+          },
+          "service_accounts": {
+            "description": "It is a list of K8s ServiceAccounts leveraged by the operator.\nThere must be at least a single service account specified.\nThis information is needed to federate a managed identity to a k8s subject.\nThere should be no duplicated \"name:namespace\" entries within this field. ",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IdentityServiceAccount"
+            }
+          }
+        }
+      },
       "DeleteProtection": {
         "description": "DeleteProtection configuration.",
         "properties": {
@@ -2280,6 +2386,18 @@
           "enabled": {
             "description": "Boolean flag indicating if the cluster should be creating using _Hypershift_.\n\nBy default this is `false`.\n\nTo enable it the cluster needs to be ROSA cluster and the organization of the user needs\nto have the `hypershift` capability enabled.",
             "type": "boolean"
+          }
+        }
+      },
+      "IdentityServiceAccount": {
+        "properties": {
+          "name": {
+            "description": "The name of the service account to be leveraged by the operator",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "The namespace of the service account to be leverage by the operator",
+            "type": "string"
           }
         }
       },
@@ -2522,6 +2640,37 @@
           "medium",
           "small"
         ]
+      },
+      "ManagedIdentitiesRequirements": {
+        "description": "Representation of managed identities requirements.\nWhen creating ARO-HCP Clusters, the end-users will need to pre-create the set of Managed Identities\nrequired by the clusters.\nThe set of Managed Identities that the end-users need to precreate is not static and depends on \nseveral factors:\n(1) The OpenShift version of the cluster being created. \n(2) The functionalities that are being enabled for the cluster. Some Managed Identities are not\nalways required but become required if a given functionality is enabled.\nAdditionally, the Managed Identities that the end-users will need to precreate will have to have a \nset of required permissions assigned to them which also have to be returned to the end users.",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'ManagedIdentitiesRequirements' if this is a complete object or 'ManagedIdentitiesRequirementsLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "control_plane_operators_identities": {
+            "description": "The control plane operators managed identities requirements",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ControlPlaneOperatorIdentity"
+            }
+          },
+          "data_plane_operators_identities": {
+            "description": "The data plane operators managed identities requires",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataPlaneOperatorIdentity"
+            }
+          }
+        }
       },
       "ManagedService": {
         "description": "Contains the necessary attributes to support role-based authentication on AWS.",
@@ -3063,6 +3212,18 @@
           "multi": {
             "description": "Multi will contain the reference for the multi image which will be used for cluster deployments",
             "$ref": "#/components/schemas/ReleaseImageDetails"
+          }
+        }
+      },
+      "RoleDefinition": {
+        "properties": {
+          "name": {
+            "description": "The official name of the Role defined in resource_id. \nIt is purely a friendly/descriptive name.",
+            "type": "string"
+          },
+          "resource_id": {
+            "description": "A string representing the Resource ID of an Azure Role Definition. \nThe role definition indicates what permissions are needed by the operator",
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
The design doc of the API can be found in the [ARO-15234](https://issues.redhat.com//browse/ARO-15234) card. 

The proposed API looks like below from CS side.

```shell
GET /api/aro_hcp/v1alpha1/managed_identities_requirements
{
  "control_plane_operators_identities": [
    {
      "operator_name": "cp-operator-name1",
      "role_definitions": [
        {
          "name": "Role Definition Name",
          "resource_id": "/providers/Microsoft.Authorization/roleDefinitions/<roleDefinition-guid>"
        }
      ],
      "required": "awlays|on_enablement",
      "max_openshift_version": "4.18",
      "min_openshift_version": "4.17"
    },
    {
      "operator_name": "cp-operator-name2",
      "role_definitions": [
        {
          "name": "Role Definition Name",
          "resource_id": "/providers/Microsoft.Authorization/roleDefinitions/<roleDefinition-guid>"
        }
      ],
      "required": "awlays|on_enablement",
      "max_openshift_version": "4.17",
      "min_openshift_version": "4.18"
    }
  ],
  "data_plane_operators_identities": [
    {
      "operator_name": "dp-operator-name1",
      "role_definitions": [
        {
          "name": "Role Definition Name",
          "resource_id": "/providers/Microsoft.Authorization/roleDefinitions/<roleDefinition-guid>"
        }
      ],
      "required": "awlays|on_enablement",
      "max_openshift_version": "4.17",
      "min_openshift_version": "4.18"
    },
    {
      "operator_name": "dp-operator-name1",
      "role_definitions": [
        {
          "name": "Role Definition Name",
          "resource_id": "/providers/Microsoft.Authorization/roleDefinitions/<roleDefinition-guid>"
        }
      ],
      "required": "awlays|on_enablement",
      "max_openshift_version": "4.17",
      "min_openshift_version": "4.18"
    }
  ]
}
```

The API can optionally take in two query parameters;

- `version`: the version of the openshift in semver. If the version is invalid, a 400 is returned. if valid, all managed identities requirements for the given version will be returned; only the major and minor segment will be used when returning the info. If the version is not provided, it won't be considered
- `required` an optional parameter which when provided will return all the managed identities requirements matching the value provided. e.g when required=always, it'll return all the operators requirements for operators that are always required. If not provided, it won't be considered i.e there is no default value. If provided, the values must be either `always|on_enablement` otherwise an error is returned.

**The user flow during cluster creation**

The below section shows how the flow of configuring managed identities would like; please note that the complexity might be hidden from the end user by tooling e.g az cli

1. When the user wants to create an openshift version e.g 4.18, they make a call to this endpoint

```
GET /api/aro_hcp/v1alpha1/managed_identities_requirements?version=4.18
```

The endpoint will return all the MI requirements for the 4.18.

2. Then user then creates the MIs that are are always required. As well as creating the MIs that required when they've enabled a specific optional feature that requires them. 

3.  For each of the MIs for a given operator,  the user needs to figure out what role(s) to configure as a role assignment. That information is also returned as part of the call to the endpoint made in early step. It is the `roles_definitions` slice. 

4. For each of the MIs, the user creates role(s) assignment(s) on the MI using the role(s) retrieved in step(3)

5. Once the role(s) assignment(s) is done, the user sends an ARO-HCP Cluster creation request against CS API and in the payload the user specifies the MIs resource Ids. If it is the control plane, it'll go in the control plane MIs section of the cluster payload. And if it is the data plane one it'll go in the data plane MIs section of the cluster paylod.