### PR TITLE
ARO-17598: add arohcp versions model

### DIFF
--- a/model/aro_hcp/v1alpha1/version_resource.model
+++ b/model/aro_hcp/v1alpha1/version_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2025 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Root of the tree of resources of the aro_hcp service.
-resource Root {
-	locator Clusters {
-		target Clusters
+// Manages a specific version.
+resource Version {
+	// Retrieves the details of the version.
+	method Get {
+		out Body Version
 	}
-    locator Versions {
-        target Versions
-    }
 }
+

--- a/model/aro_hcp/v1alpha1/version_type.model
+++ b/model/aro_hcp/v1alpha1/version_type.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2025 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Root of the tree of resources of the aro_hcp service.
-resource Root {
-	locator Clusters {
-		target Clusters
-	}
-    locator Versions {
-        target Versions
-    }
+@ref(path = "/clusters_mgmt/v1/version")
+class Version {
 }

--- a/model/aro_hcp/v1alpha1/versions_resource.model
+++ b/model/aro_hcp/v1alpha1/versions_resource.model
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of versions.
+resource Versions {
+
+	// Retrieves a list of versions.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		//
+		// Default value is `100`.
+		in out Size Integer = 100
+
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the version instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// versions that are enabled:
+		//
+		// ```sql
+		// enabled = 't'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the versions
+		// that the user has permission to see will be returned.
+		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the version instead of
+		// the names of the columns of a table. For example, in order to sort the versions
+		// descending by identifier the value should be:
+		//
+		// ```sql
+		// id desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
+
+		// Retrieved list of versions.
+		out Items []Version
+	}
+
+	// Reference to the resource that manages a specific version.
+	locator Version {
+		target Version
+		variable ID
+	}
+}


### PR DESCRIPTION
This adds the newly introduced versions endpoints to arohcp. The models
are re-used from the management endpoints.

This also bumps the metamodel version to get a bugfix for the reuse of a
model.

Signed-off-by: Thomas Jungblut <tjungblu@redhat.com>