### PR TITLE
update gh setup-python to latest version

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         cache: 'pip'


### PR DESCRIPTION
Cache service was recently decommissioned [[link](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts)]. 

This makes old versions of action that uses cache to fail (see metamodel action [result](https://github.com/openshift-online/ocm-api-metamodel/actions/runs/15412875097) ). 

According to this [issue](https://github.com/orgs/community/discussions/160793) it is recommended to keep the actions up to date.

>For others seeing this message, please ensure that your packages, and the dependencies of those packages, are all using an up-to-date version of the cache service.