### PR TITLE
XCMSTRAT-574: add support for external_auth to the aro hcp v1alpha1 api

### DIFF
--- a/clientapi/arohcp/v1alpha1/client_component_builder.go
+++ b/clientapi/arohcp/v1alpha1/client_component_builder.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClientComponentBuilder contains the data and logic needed to build 'client_component' objects.
+//
+// The reference of a component that will consume the client configuration.
+type ClientComponentBuilder struct {
+	bitmap_   uint32
+	name      string
+	namespace string
+}
+
+// NewClientComponent creates a new builder of 'client_component' objects.
+func NewClientComponent() *ClientComponentBuilder {
+	return &ClientComponentBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClientComponentBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Name sets the value of the 'name' attribute to the given value.
+func (b *ClientComponentBuilder) Name(value string) *ClientComponentBuilder {
+	b.name = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Namespace sets the value of the 'namespace' attribute to the given value.
+func (b *ClientComponentBuilder) Namespace(value string) *ClientComponentBuilder {
+	b.namespace = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ClientComponentBuilder) Copy(object *ClientComponent) *ClientComponentBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.name = object.name
+	b.namespace = object.namespace
+	return b
+}
+
+// Build creates a 'client_component' object using the configuration stored in the builder.
+func (b *ClientComponentBuilder) Build() (object *ClientComponent, err error) {
+	object = new(ClientComponent)
+	object.bitmap_ = b.bitmap_
+	object.name = b.name
+	object.namespace = b.namespace
+	return
+}

--- a/clientapi/arohcp/v1alpha1/client_component_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/client_component_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClientComponentListBuilder contains the data and logic needed to build
+// 'client_component' objects.
+type ClientComponentListBuilder struct {
+	items []*ClientComponentBuilder
+}
+
+// NewClientComponentList creates a new builder of 'client_component' objects.
+func NewClientComponentList() *ClientComponentListBuilder {
+	return new(ClientComponentListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ClientComponentListBuilder) Items(values ...*ClientComponentBuilder) *ClientComponentListBuilder {
+	b.items = make([]*ClientComponentBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ClientComponentListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ClientComponentListBuilder) Copy(list *ClientComponentList) *ClientComponentListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ClientComponentBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewClientComponent().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'client_component' objects using the
+// configuration stored in the builder.
+func (b *ClientComponentListBuilder) Build() (list *ClientComponentList, err error) {
+	items := make([]*ClientComponent, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClientComponentList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/client_component_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/client_component_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClientComponentList writes a list of values of the 'client_component' type to
+// the given writer.
+func MarshalClientComponentList(list []*ClientComponent, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClientComponentList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClientComponentList writes a list of value of the 'client_component' type to
+// the given stream.
+func WriteClientComponentList(list []*ClientComponent, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteClientComponent(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalClientComponentList reads a list of values of the 'client_component' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalClientComponentList(source interface{}) (items []*ClientComponent, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadClientComponentList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClientComponentList reads list of values of the ”client_component' type from
+// the given iterator.
+func ReadClientComponentList(iterator *jsoniter.Iterator) []*ClientComponent {
+	list := []*ClientComponent{}
+	for iterator.ReadArray() {
+		item := ReadClientComponent(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/client_component_type.go
+++ b/clientapi/arohcp/v1alpha1/client_component_type.go
@@ -1,0 +1,189 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClientComponent represents the values of the 'client_component' type.
+//
+// The reference of a component that will consume the client configuration.
+type ClientComponent struct {
+	bitmap_   uint32
+	name      string
+	namespace string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClientComponent) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Name returns the value of the 'name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The name of the component.
+func (o *ClientComponent) Name() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.name
+	}
+	return ""
+}
+
+// GetName returns the value of the 'name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The name of the component.
+func (o *ClientComponent) GetName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.name
+	}
+	return
+}
+
+// Namespace returns the value of the 'namespace' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The namespace of the component.
+func (o *ClientComponent) Namespace() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.namespace
+	}
+	return ""
+}
+
+// GetNamespace returns the value of the 'namespace' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The namespace of the component.
+func (o *ClientComponent) GetNamespace() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.namespace
+	}
+	return
+}
+
+// ClientComponentListKind is the name of the type used to represent list of objects of
+// type 'client_component'.
+const ClientComponentListKind = "ClientComponentList"
+
+// ClientComponentListLinkKind is the name of the type used to represent links to list
+// of objects of type 'client_component'.
+const ClientComponentListLinkKind = "ClientComponentListLink"
+
+// ClientComponentNilKind is the name of the type used to nil lists of objects of
+// type 'client_component'.
+const ClientComponentListNilKind = "ClientComponentListNil"
+
+// ClientComponentList is a list of values of the 'client_component' type.
+type ClientComponentList struct {
+	href  string
+	link  bool
+	items []*ClientComponent
+}
+
+// Len returns the length of the list.
+func (l *ClientComponentList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ClientComponentList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ClientComponentList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ClientComponentList) SetItems(items []*ClientComponent) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ClientComponentList) Items() []*ClientComponent {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ClientComponentList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClientComponentList) Get(i int) *ClientComponent {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ClientComponentList) Slice() []*ClientComponent {
+	var slice []*ClientComponent
+	if l == nil {
+		slice = make([]*ClientComponent, 0)
+	} else {
+		slice = make([]*ClientComponent, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ClientComponentList) Each(f func(item *ClientComponent) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ClientComponentList) Range(f func(index int, item *ClientComponent) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/client_component_type_json.go
+++ b/clientapi/arohcp/v1alpha1/client_component_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClientComponent writes a value of the 'client_component' type to the given writer.
+func MarshalClientComponent(object *ClientComponent, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClientComponent(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClientComponent writes a value of the 'client_component' type to the given stream.
+func WriteClientComponent(object *ClientComponent, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("name")
+		stream.WriteString(object.name)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("namespace")
+		stream.WriteString(object.namespace)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalClientComponent reads a value of the 'client_component' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalClientComponent(source interface{}) (object *ClientComponent, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadClientComponent(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClientComponent reads a value of the 'client_component' type from the given iterator.
+func ReadClientComponent(iterator *jsoniter.Iterator) *ClientComponent {
+	object := &ClientComponent{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "name":
+			value := iterator.ReadString()
+			object.name = value
+			object.bitmap_ |= 1
+		case "namespace":
+			value := iterator.ReadString()
+			object.namespace = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/cluster_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_builder.go
@@ -421,7 +421,7 @@ func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 
 // ExternalAuthConfig sets the value of the 'external_auth_config' attribute to the given value.
 //
-// ExternalAuthConfig configuration
+// Represents an external authentication configuration
 func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *ClusterBuilder {
 	b.externalAuthConfig = value
 	if value != nil {

--- a/clientapi/arohcp/v1alpha1/cluster_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type.go
@@ -795,7 +795,10 @@ func (o *Cluster) GetExternalID() (value string, ok bool) {
 // ExternalAuthConfig returns the value of the 'external_auth_config' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// External authentication configuration
+// External authentication configuration.
+//
+// For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
+// For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 	if o != nil && o.bitmap_&268435456 != 0 {
 		return o.externalAuthConfig
@@ -806,7 +809,10 @@ func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 // GetExternalAuthConfig returns the value of the 'external_auth_config' attribute and
 // a flag indicating if the attribute has a value.
 //
-// External authentication configuration
+// External authentication configuration.
+//
+// For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
+// For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
 	ok = o != nil && o.bitmap_&268435456 != 0
 	if ok {

--- a/clientapi/arohcp/v1alpha1/external_auth_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_builder.go
@@ -29,6 +29,7 @@ type ExternalAuthBuilder struct {
 	claim   *ExternalAuthClaimBuilder
 	clients []*ExternalAuthClientConfigBuilder
 	issuer  *TokenIssuerBuilder
+	status  *ExternalAuthStatusBuilder
 }
 
 // NewExternalAuth creates a new builder of 'external_auth' objects.
@@ -95,6 +96,19 @@ func (b *ExternalAuthBuilder) Issuer(value *TokenIssuerBuilder) *ExternalAuthBui
 	return b
 }
 
+// Status sets the value of the 'status' attribute to the given value.
+//
+// Representation of the status of an external authentication provider.
+func (b *ExternalAuthBuilder) Status(value *ExternalAuthStatusBuilder) *ExternalAuthBuilder {
+	b.status = value
+	if value != nil {
+		b.bitmap_ |= 64
+	} else {
+		b.bitmap_ &^= 64
+	}
+	return b
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *ExternalAuthBuilder) Copy(object *ExternalAuth) *ExternalAuthBuilder {
 	if object == nil {
@@ -120,6 +134,11 @@ func (b *ExternalAuthBuilder) Copy(object *ExternalAuth) *ExternalAuthBuilder {
 		b.issuer = NewTokenIssuer().Copy(object.issuer)
 	} else {
 		b.issuer = nil
+	}
+	if object.status != nil {
+		b.status = NewExternalAuthStatus().Copy(object.status)
+	} else {
+		b.status = nil
 	}
 	return b
 }
@@ -147,6 +166,12 @@ func (b *ExternalAuthBuilder) Build() (object *ExternalAuth, err error) {
 	}
 	if b.issuer != nil {
 		object.issuer, err = b.issuer.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.status != nil {
+		object.status, err = b.status.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/arohcp/v1alpha1/external_auth_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_builder.go
@@ -1,0 +1,155 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthBuilder contains the data and logic needed to build 'external_auth' objects.
+//
+// Representation of an external authentication provider.
+type ExternalAuthBuilder struct {
+	bitmap_ uint32
+	id      string
+	href    string
+	claim   *ExternalAuthClaimBuilder
+	clients []*ExternalAuthClientConfigBuilder
+	issuer  *TokenIssuerBuilder
+}
+
+// NewExternalAuth creates a new builder of 'external_auth' objects.
+func NewExternalAuth() *ExternalAuthBuilder {
+	return &ExternalAuthBuilder{}
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *ExternalAuthBuilder) Link(value bool) *ExternalAuthBuilder {
+	b.bitmap_ |= 1
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *ExternalAuthBuilder) ID(value string) *ExternalAuthBuilder {
+	b.id = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *ExternalAuthBuilder) HREF(value string) *ExternalAuthBuilder {
+	b.href = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthBuilder) Empty() bool {
+	return b == nil || b.bitmap_&^1 == 0
+}
+
+// Claim sets the value of the 'claim' attribute to the given value.
+//
+// The claims and validation rules used in the configuration of the external authentication.
+func (b *ExternalAuthBuilder) Claim(value *ExternalAuthClaimBuilder) *ExternalAuthBuilder {
+	b.claim = value
+	if value != nil {
+		b.bitmap_ |= 8
+	} else {
+		b.bitmap_ &^= 8
+	}
+	return b
+}
+
+// Clients sets the value of the 'clients' attribute to the given values.
+func (b *ExternalAuthBuilder) Clients(values ...*ExternalAuthClientConfigBuilder) *ExternalAuthBuilder {
+	b.clients = make([]*ExternalAuthClientConfigBuilder, len(values))
+	copy(b.clients, values)
+	b.bitmap_ |= 16
+	return b
+}
+
+// Issuer sets the value of the 'issuer' attribute to the given value.
+//
+// Representation of a token issuer used in an external authentication.
+func (b *ExternalAuthBuilder) Issuer(value *TokenIssuerBuilder) *ExternalAuthBuilder {
+	b.issuer = value
+	if value != nil {
+		b.bitmap_ |= 32
+	} else {
+		b.bitmap_ &^= 32
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthBuilder) Copy(object *ExternalAuth) *ExternalAuthBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.id = object.id
+	b.href = object.href
+	if object.claim != nil {
+		b.claim = NewExternalAuthClaim().Copy(object.claim)
+	} else {
+		b.claim = nil
+	}
+	if object.clients != nil {
+		b.clients = make([]*ExternalAuthClientConfigBuilder, len(object.clients))
+		for i, v := range object.clients {
+			b.clients[i] = NewExternalAuthClientConfig().Copy(v)
+		}
+	} else {
+		b.clients = nil
+	}
+	if object.issuer != nil {
+		b.issuer = NewTokenIssuer().Copy(object.issuer)
+	} else {
+		b.issuer = nil
+	}
+	return b
+}
+
+// Build creates a 'external_auth' object using the configuration stored in the builder.
+func (b *ExternalAuthBuilder) Build() (object *ExternalAuth, err error) {
+	object = new(ExternalAuth)
+	object.id = b.id
+	object.href = b.href
+	object.bitmap_ = b.bitmap_
+	if b.claim != nil {
+		object.claim, err = b.claim.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.clients != nil {
+		object.clients = make([]*ExternalAuthClientConfig, len(b.clients))
+		for i, v := range b.clients {
+			object.clients[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	if b.issuer != nil {
+		object.issuer, err = b.issuer.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_claim_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_claim_builder.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClaimBuilder contains the data and logic needed to build 'external_auth_claim' objects.
+//
+// The claims and validation rules used in the configuration of the external authentication.
+type ExternalAuthClaimBuilder struct {
+	bitmap_         uint32
+	mappings        *TokenClaimMappingsBuilder
+	validationRules []*TokenClaimValidationRuleBuilder
+}
+
+// NewExternalAuthClaim creates a new builder of 'external_auth_claim' objects.
+func NewExternalAuthClaim() *ExternalAuthClaimBuilder {
+	return &ExternalAuthClaimBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthClaimBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Mappings sets the value of the 'mappings' attribute to the given value.
+//
+// The claim mappings defined for users and groups.
+func (b *ExternalAuthClaimBuilder) Mappings(value *TokenClaimMappingsBuilder) *ExternalAuthClaimBuilder {
+	b.mappings = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// ValidationRules sets the value of the 'validation_rules' attribute to the given values.
+func (b *ExternalAuthClaimBuilder) ValidationRules(values ...*TokenClaimValidationRuleBuilder) *ExternalAuthClaimBuilder {
+	b.validationRules = make([]*TokenClaimValidationRuleBuilder, len(values))
+	copy(b.validationRules, values)
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthClaimBuilder) Copy(object *ExternalAuthClaim) *ExternalAuthClaimBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.mappings != nil {
+		b.mappings = NewTokenClaimMappings().Copy(object.mappings)
+	} else {
+		b.mappings = nil
+	}
+	if object.validationRules != nil {
+		b.validationRules = make([]*TokenClaimValidationRuleBuilder, len(object.validationRules))
+		for i, v := range object.validationRules {
+			b.validationRules[i] = NewTokenClaimValidationRule().Copy(v)
+		}
+	} else {
+		b.validationRules = nil
+	}
+	return b
+}
+
+// Build creates a 'external_auth_claim' object using the configuration stored in the builder.
+func (b *ExternalAuthClaimBuilder) Build() (object *ExternalAuthClaim, err error) {
+	object = new(ExternalAuthClaim)
+	object.bitmap_ = b.bitmap_
+	if b.mappings != nil {
+		object.mappings, err = b.mappings.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.validationRules != nil {
+		object.validationRules = make([]*TokenClaimValidationRule, len(b.validationRules))
+		for i, v := range b.validationRules {
+			object.validationRules[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_claim_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_claim_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClaimListBuilder contains the data and logic needed to build
+// 'external_auth_claim' objects.
+type ExternalAuthClaimListBuilder struct {
+	items []*ExternalAuthClaimBuilder
+}
+
+// NewExternalAuthClaimList creates a new builder of 'external_auth_claim' objects.
+func NewExternalAuthClaimList() *ExternalAuthClaimListBuilder {
+	return new(ExternalAuthClaimListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthClaimListBuilder) Items(values ...*ExternalAuthClaimBuilder) *ExternalAuthClaimListBuilder {
+	b.items = make([]*ExternalAuthClaimBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthClaimListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthClaimListBuilder) Copy(list *ExternalAuthClaimList) *ExternalAuthClaimListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthClaimBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuthClaim().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth_claim' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthClaimListBuilder) Build() (list *ExternalAuthClaimList, err error) {
+	items := make([]*ExternalAuthClaim, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthClaimList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_claim_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_claim_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthClaimList writes a list of values of the 'external_auth_claim' type to
+// the given writer.
+func MarshalExternalAuthClaimList(list []*ExternalAuthClaim, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthClaimList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthClaimList writes a list of value of the 'external_auth_claim' type to
+// the given stream.
+func WriteExternalAuthClaimList(list []*ExternalAuthClaim, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuthClaim(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthClaimList reads a list of values of the 'external_auth_claim' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthClaimList(source interface{}) (items []*ExternalAuthClaim, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthClaimList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthClaimList reads list of values of the ”external_auth_claim' type from
+// the given iterator.
+func ReadExternalAuthClaimList(iterator *jsoniter.Iterator) []*ExternalAuthClaim {
+	list := []*ExternalAuthClaim{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuthClaim(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_claim_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_claim_type.go
@@ -1,0 +1,189 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClaim represents the values of the 'external_auth_claim' type.
+//
+// The claims and validation rules used in the configuration of the external authentication.
+type ExternalAuthClaim struct {
+	bitmap_         uint32
+	mappings        *TokenClaimMappings
+	validationRules []*TokenClaimValidationRule
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuthClaim) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Mappings returns the value of the 'mappings' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Mapping describes rules on how to transform information from an ID token into a cluster identity.
+func (o *ExternalAuthClaim) Mappings() *TokenClaimMappings {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.mappings
+	}
+	return nil
+}
+
+// GetMappings returns the value of the 'mappings' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Mapping describes rules on how to transform information from an ID token into a cluster identity.
+func (o *ExternalAuthClaim) GetMappings() (value *TokenClaimMappings, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.mappings
+	}
+	return
+}
+
+// ValidationRules returns the value of the 'validation_rules' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// ValidationRules are rules that are applied to validate token claims to authenticate users.
+func (o *ExternalAuthClaim) ValidationRules() []*TokenClaimValidationRule {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.validationRules
+	}
+	return nil
+}
+
+// GetValidationRules returns the value of the 'validation_rules' attribute and
+// a flag indicating if the attribute has a value.
+//
+// ValidationRules are rules that are applied to validate token claims to authenticate users.
+func (o *ExternalAuthClaim) GetValidationRules() (value []*TokenClaimValidationRule, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.validationRules
+	}
+	return
+}
+
+// ExternalAuthClaimListKind is the name of the type used to represent list of objects of
+// type 'external_auth_claim'.
+const ExternalAuthClaimListKind = "ExternalAuthClaimList"
+
+// ExternalAuthClaimListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth_claim'.
+const ExternalAuthClaimListLinkKind = "ExternalAuthClaimListLink"
+
+// ExternalAuthClaimNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth_claim'.
+const ExternalAuthClaimListNilKind = "ExternalAuthClaimListNil"
+
+// ExternalAuthClaimList is a list of values of the 'external_auth_claim' type.
+type ExternalAuthClaimList struct {
+	href  string
+	link  bool
+	items []*ExternalAuthClaim
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthClaimList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthClaimList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthClaimList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthClaimList) SetItems(items []*ExternalAuthClaim) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthClaimList) Items() []*ExternalAuthClaim {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthClaimList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthClaimList) Get(i int) *ExternalAuthClaim {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthClaimList) Slice() []*ExternalAuthClaim {
+	var slice []*ExternalAuthClaim
+	if l == nil {
+		slice = make([]*ExternalAuthClaim, 0)
+	} else {
+		slice = make([]*ExternalAuthClaim, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthClaimList) Each(f func(item *ExternalAuthClaim) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthClaimList) Range(f func(index int, item *ExternalAuthClaim) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_claim_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_claim_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthClaim writes a value of the 'external_auth_claim' type to the given writer.
+func MarshalExternalAuthClaim(object *ExternalAuthClaim, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthClaim(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthClaim writes a value of the 'external_auth_claim' type to the given stream.
+func WriteExternalAuthClaim(object *ExternalAuthClaim, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.mappings != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("mappings")
+		WriteTokenClaimMappings(object.mappings, stream)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.validationRules != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("validation_rules")
+		WriteTokenClaimValidationRuleList(object.validationRules, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalExternalAuthClaim reads a value of the 'external_auth_claim' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalExternalAuthClaim(source interface{}) (object *ExternalAuthClaim, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadExternalAuthClaim(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthClaim reads a value of the 'external_auth_claim' type from the given iterator.
+func ReadExternalAuthClaim(iterator *jsoniter.Iterator) *ExternalAuthClaim {
+	object := &ExternalAuthClaim{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "mappings":
+			value := ReadTokenClaimMappings(iterator)
+			object.mappings = value
+			object.bitmap_ |= 1
+		case "validation_rules":
+			value := ReadTokenClaimValidationRuleList(iterator)
+			object.validationRules = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_builder.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClientConfigBuilder contains the data and logic needed to build 'external_auth_client_config' objects.
+//
+// ExternalAuthClientConfig contains configuration for the platform's clients that
+// need to request tokens from the issuer.
+type ExternalAuthClientConfigBuilder struct {
+	bitmap_     uint32
+	id          string
+	component   *ClientComponentBuilder
+	extraScopes []string
+	secret      string
+}
+
+// NewExternalAuthClientConfig creates a new builder of 'external_auth_client_config' objects.
+func NewExternalAuthClientConfig() *ExternalAuthClientConfigBuilder {
+	return &ExternalAuthClientConfigBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthClientConfigBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// ID sets the value of the 'ID' attribute to the given value.
+func (b *ExternalAuthClientConfigBuilder) ID(value string) *ExternalAuthClientConfigBuilder {
+	b.id = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Component sets the value of the 'component' attribute to the given value.
+//
+// The reference of a component that will consume the client configuration.
+func (b *ExternalAuthClientConfigBuilder) Component(value *ClientComponentBuilder) *ExternalAuthClientConfigBuilder {
+	b.component = value
+	if value != nil {
+		b.bitmap_ |= 2
+	} else {
+		b.bitmap_ &^= 2
+	}
+	return b
+}
+
+// ExtraScopes sets the value of the 'extra_scopes' attribute to the given values.
+func (b *ExternalAuthClientConfigBuilder) ExtraScopes(values ...string) *ExternalAuthClientConfigBuilder {
+	b.extraScopes = make([]string, len(values))
+	copy(b.extraScopes, values)
+	b.bitmap_ |= 4
+	return b
+}
+
+// Secret sets the value of the 'secret' attribute to the given value.
+func (b *ExternalAuthClientConfigBuilder) Secret(value string) *ExternalAuthClientConfigBuilder {
+	b.secret = value
+	b.bitmap_ |= 8
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthClientConfigBuilder) Copy(object *ExternalAuthClientConfig) *ExternalAuthClientConfigBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.id = object.id
+	if object.component != nil {
+		b.component = NewClientComponent().Copy(object.component)
+	} else {
+		b.component = nil
+	}
+	if object.extraScopes != nil {
+		b.extraScopes = make([]string, len(object.extraScopes))
+		copy(b.extraScopes, object.extraScopes)
+	} else {
+		b.extraScopes = nil
+	}
+	b.secret = object.secret
+	return b
+}
+
+// Build creates a 'external_auth_client_config' object using the configuration stored in the builder.
+func (b *ExternalAuthClientConfigBuilder) Build() (object *ExternalAuthClientConfig, err error) {
+	object = new(ExternalAuthClientConfig)
+	object.bitmap_ = b.bitmap_
+	object.id = b.id
+	if b.component != nil {
+		object.component, err = b.component.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.extraScopes != nil {
+		object.extraScopes = make([]string, len(b.extraScopes))
+		copy(object.extraScopes, b.extraScopes)
+	}
+	object.secret = b.secret
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_builder.go
@@ -29,6 +29,7 @@ type ExternalAuthClientConfigBuilder struct {
 	component   *ClientComponentBuilder
 	extraScopes []string
 	secret      string
+	type_       ExternalAuthClientType
 }
 
 // NewExternalAuthClientConfig creates a new builder of 'external_auth_client_config' objects.
@@ -76,6 +77,15 @@ func (b *ExternalAuthClientConfigBuilder) Secret(value string) *ExternalAuthClie
 	return b
 }
 
+// Type sets the value of the 'type' attribute to the given value.
+//
+// Representation of the possible values of an external authentication client's type
+func (b *ExternalAuthClientConfigBuilder) Type(value ExternalAuthClientType) *ExternalAuthClientConfigBuilder {
+	b.type_ = value
+	b.bitmap_ |= 16
+	return b
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *ExternalAuthClientConfigBuilder) Copy(object *ExternalAuthClientConfig) *ExternalAuthClientConfigBuilder {
 	if object == nil {
@@ -95,6 +105,7 @@ func (b *ExternalAuthClientConfigBuilder) Copy(object *ExternalAuthClientConfig)
 		b.extraScopes = nil
 	}
 	b.secret = object.secret
+	b.type_ = object.type_
 	return b
 }
 
@@ -114,5 +125,6 @@ func (b *ExternalAuthClientConfigBuilder) Build() (object *ExternalAuthClientCon
 		copy(object.extraScopes, b.extraScopes)
 	}
 	object.secret = b.secret
+	object.type_ = b.type_
 	return
 }

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClientConfigListBuilder contains the data and logic needed to build
+// 'external_auth_client_config' objects.
+type ExternalAuthClientConfigListBuilder struct {
+	items []*ExternalAuthClientConfigBuilder
+}
+
+// NewExternalAuthClientConfigList creates a new builder of 'external_auth_client_config' objects.
+func NewExternalAuthClientConfigList() *ExternalAuthClientConfigListBuilder {
+	return new(ExternalAuthClientConfigListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthClientConfigListBuilder) Items(values ...*ExternalAuthClientConfigBuilder) *ExternalAuthClientConfigListBuilder {
+	b.items = make([]*ExternalAuthClientConfigBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthClientConfigListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthClientConfigListBuilder) Copy(list *ExternalAuthClientConfigList) *ExternalAuthClientConfigListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthClientConfigBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuthClientConfig().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth_client_config' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthClientConfigListBuilder) Build() (list *ExternalAuthClientConfigList, err error) {
+	items := make([]*ExternalAuthClientConfig, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthClientConfigList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthClientConfigList writes a list of values of the 'external_auth_client_config' type to
+// the given writer.
+func MarshalExternalAuthClientConfigList(list []*ExternalAuthClientConfig, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthClientConfigList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthClientConfigList writes a list of value of the 'external_auth_client_config' type to
+// the given stream.
+func WriteExternalAuthClientConfigList(list []*ExternalAuthClientConfig, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuthClientConfig(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthClientConfigList reads a list of values of the 'external_auth_client_config' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthClientConfigList(source interface{}) (items []*ExternalAuthClientConfig, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthClientConfigList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthClientConfigList reads list of values of the ”external_auth_client_config' type from
+// the given iterator.
+func ReadExternalAuthClientConfigList(iterator *jsoniter.Iterator) []*ExternalAuthClientConfig {
+	list := []*ExternalAuthClientConfig{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuthClientConfig(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_type.go
@@ -41,6 +41,8 @@ func (o *ExternalAuthClientConfig) Empty() bool {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The identifier of the OIDC client from the OIDC provider.
+// This is required.
+// Must be at least one character length.
 func (o *ExternalAuthClientConfig) ID() string {
 	if o != nil && o.bitmap_&1 != 0 {
 		return o.id
@@ -52,6 +54,8 @@ func (o *ExternalAuthClientConfig) ID() string {
 // a flag indicating if the attribute has a value.
 //
 // The identifier of the OIDC client from the OIDC provider.
+// This is required.
+// Must be at least one character length.
 func (o *ExternalAuthClientConfig) GetID() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&1 != 0
 	if ok {
@@ -140,7 +144,7 @@ func (o *ExternalAuthClientConfig) GetSecret() (value string, ok bool) {
 //
 // Determines the OIDC provider client type.
 //
-// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+// This is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.
 //
 // For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
 // 'secret' property in the client configuration.
@@ -158,7 +162,7 @@ func (o *ExternalAuthClientConfig) Type() ExternalAuthClientType {
 //
 // Determines the OIDC provider client type.
 //
-// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+// This is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.
 //
 // For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
 // 'secret' property in the client configuration.

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_type.go
@@ -1,0 +1,238 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClientConfig represents the values of the 'external_auth_client_config' type.
+//
+// ExternalAuthClientConfig contains configuration for the platform's clients that
+// need to request tokens from the issuer.
+type ExternalAuthClientConfig struct {
+	bitmap_     uint32
+	id          string
+	component   *ClientComponent
+	extraScopes []string
+	secret      string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuthClientConfig) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// ID returns the value of the 'ID' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The identifier of the OIDC client from the OIDC provider.
+func (o *ExternalAuthClientConfig) ID() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the value of the 'ID' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The identifier of the OIDC client from the OIDC provider.
+func (o *ExternalAuthClientConfig) GetID() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// Component returns the value of the 'component' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The component that is supposed to consume this client configuration.
+func (o *ExternalAuthClientConfig) Component() *ClientComponent {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.component
+	}
+	return nil
+}
+
+// GetComponent returns the value of the 'component' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The component that is supposed to consume this client configuration.
+func (o *ExternalAuthClientConfig) GetComponent() (value *ClientComponent, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.component
+	}
+	return
+}
+
+// ExtraScopes returns the value of the 'extra_scopes' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// ExtraScopes is an optional set of scopes to request tokens with.
+func (o *ExternalAuthClientConfig) ExtraScopes() []string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.extraScopes
+	}
+	return nil
+}
+
+// GetExtraScopes returns the value of the 'extra_scopes' attribute and
+// a flag indicating if the attribute has a value.
+//
+// ExtraScopes is an optional set of scopes to request tokens with.
+func (o *ExternalAuthClientConfig) GetExtraScopes() (value []string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.extraScopes
+	}
+	return
+}
+
+// Secret returns the value of the 'secret' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The secret of the OIDC client from the OIDC provider.
+func (o *ExternalAuthClientConfig) Secret() string {
+	if o != nil && o.bitmap_&8 != 0 {
+		return o.secret
+	}
+	return ""
+}
+
+// GetSecret returns the value of the 'secret' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The secret of the OIDC client from the OIDC provider.
+func (o *ExternalAuthClientConfig) GetSecret() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&8 != 0
+	if ok {
+		value = o.secret
+	}
+	return
+}
+
+// ExternalAuthClientConfigListKind is the name of the type used to represent list of objects of
+// type 'external_auth_client_config'.
+const ExternalAuthClientConfigListKind = "ExternalAuthClientConfigList"
+
+// ExternalAuthClientConfigListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth_client_config'.
+const ExternalAuthClientConfigListLinkKind = "ExternalAuthClientConfigListLink"
+
+// ExternalAuthClientConfigNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth_client_config'.
+const ExternalAuthClientConfigListNilKind = "ExternalAuthClientConfigListNil"
+
+// ExternalAuthClientConfigList is a list of values of the 'external_auth_client_config' type.
+type ExternalAuthClientConfigList struct {
+	href  string
+	link  bool
+	items []*ExternalAuthClientConfig
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthClientConfigList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthClientConfigList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthClientConfigList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthClientConfigList) SetItems(items []*ExternalAuthClientConfig) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthClientConfigList) Items() []*ExternalAuthClientConfig {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthClientConfigList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthClientConfigList) Get(i int) *ExternalAuthClientConfig {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthClientConfigList) Slice() []*ExternalAuthClientConfig {
+	var slice []*ExternalAuthClientConfig
+	if l == nil {
+		slice = make([]*ExternalAuthClientConfig, 0)
+	} else {
+		slice = make([]*ExternalAuthClientConfig, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthClientConfigList) Each(f func(item *ExternalAuthClientConfig) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthClientConfigList) Range(f func(index int, item *ExternalAuthClientConfig) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_type.go
@@ -29,6 +29,7 @@ type ExternalAuthClientConfig struct {
 	component   *ClientComponent
 	extraScopes []string
 	secret      string
+	type_       ExternalAuthClientType
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -109,6 +110,9 @@ func (o *ExternalAuthClientConfig) GetExtraScopes() (value []string, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The secret of the OIDC client from the OIDC provider.
+// The client is considered 'public' if no secret is specified. Otherwise, it is considered
+// as a 'confidential' client.
+// This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
 func (o *ExternalAuthClientConfig) Secret() string {
 	if o != nil && o.bitmap_&8 != 0 {
 		return o.secret
@@ -120,10 +124,50 @@ func (o *ExternalAuthClientConfig) Secret() string {
 // a flag indicating if the attribute has a value.
 //
 // The secret of the OIDC client from the OIDC provider.
+// The client is considered 'public' if no secret is specified. Otherwise, it is considered
+// as a 'confidential' client.
+// This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
 func (o *ExternalAuthClientConfig) GetSecret() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&8 != 0
 	if ok {
 		value = o.secret
+	}
+	return
+}
+
+// Type returns the value of the 'type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Determines the OIDC provider client type.
+//
+// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+//
+// For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
+// 'secret' property in the client configuration.
+//   - If the 'secret' property is set, the type of the client is 'confidential.
+//   - If the 'secret' property is not set, the type of the client is 'public.
+func (o *ExternalAuthClientConfig) Type() ExternalAuthClientType {
+	if o != nil && o.bitmap_&16 != 0 {
+		return o.type_
+	}
+	return ExternalAuthClientType("")
+}
+
+// GetType returns the value of the 'type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Determines the OIDC provider client type.
+//
+// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+//
+// For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
+// 'secret' property in the client configuration.
+//   - If the 'secret' property is set, the type of the client is 'confidential.
+//   - If the 'secret' property is not set, the type of the client is 'public.
+func (o *ExternalAuthClientConfig) GetType() (value ExternalAuthClientType, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
+	if ok {
+		value = o.type_
 	}
 	return
 }

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_type_json.go
@@ -76,6 +76,15 @@ func WriteExternalAuthClientConfig(object *ExternalAuthClientConfig, stream *jso
 		}
 		stream.WriteObjectField("secret")
 		stream.WriteString(object.secret)
+		count++
+	}
+	present_ = object.bitmap_&16 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("type")
+		stream.WriteString(string(object.type_))
 	}
 	stream.WriteObjectEnd()
 }
@@ -117,6 +126,11 @@ func ReadExternalAuthClientConfig(iterator *jsoniter.Iterator) *ExternalAuthClie
 			value := iterator.ReadString()
 			object.secret = value
 			object.bitmap_ |= 8
+		case "type":
+			text := iterator.ReadString()
+			value := ExternalAuthClientType(text)
+			object.type_ = value
+			object.bitmap_ |= 16
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_config_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_config_type_json.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthClientConfig writes a value of the 'external_auth_client_config' type to the given writer.
+func MarshalExternalAuthClientConfig(object *ExternalAuthClientConfig, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthClientConfig(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthClientConfig writes a value of the 'external_auth_client_config' type to the given stream.
+func WriteExternalAuthClientConfig(object *ExternalAuthClientConfig, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.component != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("component")
+		WriteClientComponent(object.component, stream)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0 && object.extraScopes != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("extra_scopes")
+		WriteStringList(object.extraScopes, stream)
+		count++
+	}
+	present_ = object.bitmap_&8 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("secret")
+		stream.WriteString(object.secret)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalExternalAuthClientConfig reads a value of the 'external_auth_client_config' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalExternalAuthClientConfig(source interface{}) (object *ExternalAuthClientConfig, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadExternalAuthClientConfig(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthClientConfig reads a value of the 'external_auth_client_config' type from the given iterator.
+func ReadExternalAuthClientConfig(iterator *jsoniter.Iterator) *ExternalAuthClientConfig {
+	object := &ExternalAuthClientConfig{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "id":
+			value := iterator.ReadString()
+			object.id = value
+			object.bitmap_ |= 1
+		case "component":
+			value := ReadClientComponent(iterator)
+			object.component = value
+			object.bitmap_ |= 2
+		case "extra_scopes":
+			value := ReadStringList(iterator)
+			object.extraScopes = value
+			object.bitmap_ |= 4
+		case "secret":
+			value := iterator.ReadString()
+			object.secret = value
+			object.bitmap_ |= 8
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_type_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_type_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthClientTypeList writes a list of values of the 'external_auth_client_type' type to
+// the given writer.
+func MarshalExternalAuthClientTypeList(list []ExternalAuthClientType, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthClientTypeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthClientTypeList writes a list of value of the 'external_auth_client_type' type to
+// the given stream.
+func WriteExternalAuthClientTypeList(list []ExternalAuthClientType, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthClientTypeList reads a list of values of the 'external_auth_client_type' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthClientTypeList(source interface{}) (items []ExternalAuthClientType, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthClientTypeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthClientTypeList reads list of values of the ”external_auth_client_type' type from
+// the given iterator.
+func ReadExternalAuthClientTypeList(iterator *jsoniter.Iterator) []ExternalAuthClientType {
+	list := []ExternalAuthClientType{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := ExternalAuthClientType(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_client_type_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_type_type.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthClientType represents the values of the 'external_auth_client_type' enumerated type.
+type ExternalAuthClientType string
+
+const (
+	// Indicates that the client is confidential.
+	//
+	// Confidential clients must provide a client secret.
+	// For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
+	// in the 'secret' property of the client configuration.
+	// For those belonging to an ARO HCP cluster, the secret should be provided within the cluster itself.
+	ExternalAuthClientTypeConfidential ExternalAuthClientType = "confidential"
+	// Indicates that the client is public
+	//
+	// Public clients must not provide a client secret
+	ExternalAuthClientTypePublic ExternalAuthClientType = "public"
+)

--- a/clientapi/arohcp/v1alpha1/external_auth_client_type_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_client_type_type.go
@@ -28,7 +28,7 @@ const (
 	// Confidential clients must provide a client secret.
 	// For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
 	// in the 'secret' property of the client configuration.
-	// For those belonging to an ARO HCP cluster, the secret should be provided within the cluster itself.
+	// For those belonging to an ARO-HCP cluster, the secret should be provided within the cluster itself.
 	ExternalAuthClientTypeConfidential ExternalAuthClientType = "confidential"
 	// Indicates that the client is public
 	//

--- a/clientapi/arohcp/v1alpha1/external_auth_config_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_config_builder.go
@@ -19,16 +19,15 @@ limitations under the License.
 
 package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
 
-import (
-	v1 "github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1"
-)
-
 // ExternalAuthConfigBuilder contains the data and logic needed to build 'external_auth_config' objects.
 //
-// ExternalAuthConfig configuration
+// Represents an external authentication configuration
 type ExternalAuthConfigBuilder struct {
 	bitmap_       uint32
-	externalAuths *v1.ExternalAuthListBuilder
+	id            string
+	href          string
+	externalAuths *ExternalAuthListBuilder
+	state         ExternalAuthConfigState
 	enabled       bool
 }
 
@@ -37,22 +36,51 @@ func NewExternalAuthConfig() *ExternalAuthConfigBuilder {
 	return &ExternalAuthConfigBuilder{}
 }
 
+// Link sets the flag that indicates if this is a link.
+func (b *ExternalAuthConfigBuilder) Link(value bool) *ExternalAuthConfigBuilder {
+	b.bitmap_ |= 1
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *ExternalAuthConfigBuilder) ID(value string) *ExternalAuthConfigBuilder {
+	b.id = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *ExternalAuthConfigBuilder) HREF(value string) *ExternalAuthConfigBuilder {
+	b.href = value
+	b.bitmap_ |= 4
+	return b
+}
+
 // Empty returns true if the builder is empty, i.e. no attribute has a value.
 func (b *ExternalAuthConfigBuilder) Empty() bool {
-	return b == nil || b.bitmap_ == 0
+	return b == nil || b.bitmap_&^1 == 0
 }
 
 // Enabled sets the value of the 'enabled' attribute to the given value.
 func (b *ExternalAuthConfigBuilder) Enabled(value bool) *ExternalAuthConfigBuilder {
 	b.enabled = value
-	b.bitmap_ |= 1
+	b.bitmap_ |= 8
 	return b
 }
 
 // ExternalAuths sets the value of the 'external_auths' attribute to the given values.
-func (b *ExternalAuthConfigBuilder) ExternalAuths(value *v1.ExternalAuthListBuilder) *ExternalAuthConfigBuilder {
+func (b *ExternalAuthConfigBuilder) ExternalAuths(value *ExternalAuthListBuilder) *ExternalAuthConfigBuilder {
 	b.externalAuths = value
-	b.bitmap_ |= 2
+	b.bitmap_ |= 16
+	return b
+}
+
+// State sets the value of the 'state' attribute to the given value.
+//
+// Representation of the possible values for the state field of an external authentication configuration
+func (b *ExternalAuthConfigBuilder) State(value ExternalAuthConfigState) *ExternalAuthConfigBuilder {
+	b.state = value
+	b.bitmap_ |= 32
 	return b
 }
 
@@ -62,18 +90,23 @@ func (b *ExternalAuthConfigBuilder) Copy(object *ExternalAuthConfig) *ExternalAu
 		return b
 	}
 	b.bitmap_ = object.bitmap_
+	b.id = object.id
+	b.href = object.href
 	b.enabled = object.enabled
 	if object.externalAuths != nil {
-		b.externalAuths = v1.NewExternalAuthList().Copy(object.externalAuths)
+		b.externalAuths = NewExternalAuthList().Copy(object.externalAuths)
 	} else {
 		b.externalAuths = nil
 	}
+	b.state = object.state
 	return b
 }
 
 // Build creates a 'external_auth_config' object using the configuration stored in the builder.
 func (b *ExternalAuthConfigBuilder) Build() (object *ExternalAuthConfig, err error) {
 	object = new(ExternalAuthConfig)
+	object.id = b.id
+	object.href = b.href
 	object.bitmap_ = b.bitmap_
 	object.enabled = b.enabled
 	if b.externalAuths != nil {
@@ -82,5 +115,6 @@ func (b *ExternalAuthConfigBuilder) Build() (object *ExternalAuthConfig, err err
 			return
 		}
 	}
+	object.state = b.state
 	return
 }

--- a/clientapi/arohcp/v1alpha1/external_auth_config_state_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_config_state_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthConfigStateList writes a list of values of the 'external_auth_config_state' type to
+// the given writer.
+func MarshalExternalAuthConfigStateList(list []ExternalAuthConfigState, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthConfigStateList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthConfigStateList writes a list of value of the 'external_auth_config_state' type to
+// the given stream.
+func WriteExternalAuthConfigStateList(list []ExternalAuthConfigState, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthConfigStateList reads a list of values of the 'external_auth_config_state' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthConfigStateList(source interface{}) (items []ExternalAuthConfigState, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthConfigStateList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthConfigStateList reads list of values of the ”external_auth_config_state' type from
+// the given iterator.
+func ReadExternalAuthConfigStateList(iterator *jsoniter.Iterator) []ExternalAuthConfigState {
+	list := []ExternalAuthConfigState{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := ExternalAuthConfigState(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_config_state_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_config_state_type.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthConfigState represents the values of the 'external_auth_config_state' enumerated type.
+type ExternalAuthConfigState string
+
+const (
+	// Indicates that the cluster does not support configuration of external authentication providers
+	ExternalAuthConfigStateDisabled ExternalAuthConfigState = "disabled"
+	// Indicates that the cluster supports configuration of external authentication providers
+	ExternalAuthConfigStateEnabled ExternalAuthConfigState = "enabled"
+)

--- a/clientapi/arohcp/v1alpha1/external_auth_config_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_config_type.go
@@ -19,35 +19,100 @@ limitations under the License.
 
 package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
 
-import (
-	v1 "github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1"
-)
+// ExternalAuthConfigKind is the name of the type used to represent objects
+// of type 'external_auth_config'.
+const ExternalAuthConfigKind = "ExternalAuthConfig"
+
+// ExternalAuthConfigLinkKind is the name of the type used to represent links
+// to objects of type 'external_auth_config'.
+const ExternalAuthConfigLinkKind = "ExternalAuthConfigLink"
+
+// ExternalAuthConfigNilKind is the name of the type used to nil references
+// to objects of type 'external_auth_config'.
+const ExternalAuthConfigNilKind = "ExternalAuthConfigNil"
 
 // ExternalAuthConfig represents the values of the 'external_auth_config' type.
 //
-// ExternalAuthConfig configuration
+// Represents an external authentication configuration
 type ExternalAuthConfig struct {
 	bitmap_       uint32
-	externalAuths *v1.ExternalAuthList
+	id            string
+	href          string
+	externalAuths *ExternalAuthList
+	state         ExternalAuthConfigState
 	enabled       bool
+}
+
+// Kind returns the name of the type of the object.
+func (o *ExternalAuthConfig) Kind() string {
+	if o == nil {
+		return ExternalAuthConfigNilKind
+	}
+	if o.bitmap_&1 != 0 {
+		return ExternalAuthConfigLinkKind
+	}
+	return ExternalAuthConfigKind
+}
+
+// Link returns true if this is a link.
+func (o *ExternalAuthConfig) Link() bool {
+	return o != nil && o.bitmap_&1 != 0
+}
+
+// ID returns the identifier of the object.
+func (o *ExternalAuthConfig) ID() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *ExternalAuthConfig) GetID() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *ExternalAuthConfig) HREF() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *ExternalAuthConfig) GetHREF() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.href
+	}
+	return
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
 func (o *ExternalAuthConfig) Empty() bool {
-	return o == nil || o.bitmap_ == 0
+	return o == nil || o.bitmap_&^1 == 0
 }
 
 // Enabled returns the value of the 'enabled' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// Boolean flag indicating if the cluster should use an external authentication configuration.
+// Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
 //
 // By default this is false.
 //
 // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
 // to have the `external-authentication` feature toggle enabled.
+//
+// For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
 func (o *ExternalAuthConfig) Enabled() bool {
-	if o != nil && o.bitmap_&1 != 0 {
+	if o != nil && o.bitmap_&8 != 0 {
 		return o.enabled
 	}
 	return false
@@ -56,14 +121,16 @@ func (o *ExternalAuthConfig) Enabled() bool {
 // GetEnabled returns the value of the 'enabled' attribute and
 // a flag indicating if the attribute has a value.
 //
-// Boolean flag indicating if the cluster should use an external authentication configuration.
+// Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
 //
 // By default this is false.
 //
 // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
 // to have the `external-authentication` feature toggle enabled.
+//
+// For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
 func (o *ExternalAuthConfig) GetEnabled() (value bool, ok bool) {
-	ok = o != nil && o.bitmap_&1 != 0
+	ok = o != nil && o.bitmap_&8 != 0
 	if ok {
 		value = o.enabled
 	}
@@ -72,8 +139,12 @@ func (o *ExternalAuthConfig) GetEnabled() (value bool, ok bool) {
 
 // ExternalAuths returns the value of the 'external_auths' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
-func (o *ExternalAuthConfig) ExternalAuths() *v1.ExternalAuthList {
-	if o != nil && o.bitmap_&2 != 0 {
+//
+// A list of external authentication providers configured for the cluster.
+//
+// Only one external authentication provider can be configured.
+func (o *ExternalAuthConfig) ExternalAuths() *ExternalAuthList {
+	if o != nil && o.bitmap_&16 != 0 {
 		return o.externalAuths
 	}
 	return nil
@@ -81,10 +152,45 @@ func (o *ExternalAuthConfig) ExternalAuths() *v1.ExternalAuthList {
 
 // GetExternalAuths returns the value of the 'external_auths' attribute and
 // a flag indicating if the attribute has a value.
-func (o *ExternalAuthConfig) GetExternalAuths() (value *v1.ExternalAuthList, ok bool) {
-	ok = o != nil && o.bitmap_&2 != 0
+//
+// A list of external authentication providers configured for the cluster.
+//
+// Only one external authentication provider can be configured.
+func (o *ExternalAuthConfig) GetExternalAuths() (value *ExternalAuthList, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
 	if ok {
 		value = o.externalAuths
+	}
+	return
+}
+
+// State returns the value of the 'state' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+//
+// For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+//
+// FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+func (o *ExternalAuthConfig) State() ExternalAuthConfigState {
+	if o != nil && o.bitmap_&32 != 0 {
+		return o.state
+	}
+	return ExternalAuthConfigState("")
+}
+
+// GetState returns the value of the 'state' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+//
+// For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+//
+// FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+func (o *ExternalAuthConfig) GetState() (value ExternalAuthConfigState, ok bool) {
+	ok = o != nil && o.bitmap_&32 != 0
+	if ok {
+		value = o.state
 	}
 	return
 }
@@ -106,6 +212,40 @@ type ExternalAuthConfigList struct {
 	href  string
 	link  bool
 	items []*ExternalAuthConfig
+}
+
+// Kind returns the name of the type of the object.
+func (l *ExternalAuthConfigList) Kind() string {
+	if l == nil {
+		return ExternalAuthConfigListNilKind
+	}
+	if l.link {
+		return ExternalAuthConfigListLinkKind
+	}
+	return ExternalAuthConfigListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ExternalAuthConfigList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ExternalAuthConfigList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ExternalAuthConfigList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/clientapi/arohcp/v1alpha1/external_auth_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthListBuilder contains the data and logic needed to build
+// 'external_auth' objects.
+type ExternalAuthListBuilder struct {
+	items []*ExternalAuthBuilder
+}
+
+// NewExternalAuthList creates a new builder of 'external_auth' objects.
+func NewExternalAuthList() *ExternalAuthListBuilder {
+	return new(ExternalAuthListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthListBuilder) Items(values ...*ExternalAuthBuilder) *ExternalAuthListBuilder {
+	b.items = make([]*ExternalAuthBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthListBuilder) Copy(list *ExternalAuthList) *ExternalAuthListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuth().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthListBuilder) Build() (list *ExternalAuthList, err error) {
+	items := make([]*ExternalAuth, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthList writes a list of values of the 'external_auth' type to
+// the given writer.
+func MarshalExternalAuthList(list []*ExternalAuth, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthList writes a list of value of the 'external_auth' type to
+// the given stream.
+func WriteExternalAuthList(list []*ExternalAuth, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuth(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthList reads a list of values of the 'external_auth' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthList(source interface{}) (items []*ExternalAuth, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthList reads list of values of the ”external_auth' type from
+// the given iterator.
+func ReadExternalAuthList(iterator *jsoniter.Iterator) []*ExternalAuth {
+	list := []*ExternalAuth{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuth(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_state_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_state_builder.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	time "time"
+)
+
+// ExternalAuthStateBuilder contains the data and logic needed to build 'external_auth_state' objects.
+//
+// Representation of the state of an external authentication provider.
+type ExternalAuthStateBuilder struct {
+	bitmap_              uint32
+	lastUpdatedTimestamp time.Time
+	value                string
+}
+
+// NewExternalAuthState creates a new builder of 'external_auth_state' objects.
+func NewExternalAuthState() *ExternalAuthStateBuilder {
+	return &ExternalAuthStateBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthStateBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// LastUpdatedTimestamp sets the value of the 'last_updated_timestamp' attribute to the given value.
+func (b *ExternalAuthStateBuilder) LastUpdatedTimestamp(value time.Time) *ExternalAuthStateBuilder {
+	b.lastUpdatedTimestamp = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Value sets the value of the 'value' attribute to the given value.
+func (b *ExternalAuthStateBuilder) Value(value string) *ExternalAuthStateBuilder {
+	b.value = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthStateBuilder) Copy(object *ExternalAuthState) *ExternalAuthStateBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.lastUpdatedTimestamp = object.lastUpdatedTimestamp
+	b.value = object.value
+	return b
+}
+
+// Build creates a 'external_auth_state' object using the configuration stored in the builder.
+func (b *ExternalAuthStateBuilder) Build() (object *ExternalAuthState, err error) {
+	object = new(ExternalAuthState)
+	object.bitmap_ = b.bitmap_
+	object.lastUpdatedTimestamp = b.lastUpdatedTimestamp
+	object.value = b.value
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_state_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_state_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthStateListBuilder contains the data and logic needed to build
+// 'external_auth_state' objects.
+type ExternalAuthStateListBuilder struct {
+	items []*ExternalAuthStateBuilder
+}
+
+// NewExternalAuthStateList creates a new builder of 'external_auth_state' objects.
+func NewExternalAuthStateList() *ExternalAuthStateListBuilder {
+	return new(ExternalAuthStateListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthStateListBuilder) Items(values ...*ExternalAuthStateBuilder) *ExternalAuthStateListBuilder {
+	b.items = make([]*ExternalAuthStateBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthStateListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthStateListBuilder) Copy(list *ExternalAuthStateList) *ExternalAuthStateListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthStateBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuthState().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth_state' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthStateListBuilder) Build() (list *ExternalAuthStateList, err error) {
+	items := make([]*ExternalAuthState, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthStateList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_state_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_state_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthStateList writes a list of values of the 'external_auth_state' type to
+// the given writer.
+func MarshalExternalAuthStateList(list []*ExternalAuthState, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthStateList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthStateList writes a list of value of the 'external_auth_state' type to
+// the given stream.
+func WriteExternalAuthStateList(list []*ExternalAuthState, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuthState(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthStateList reads a list of values of the 'external_auth_state' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthStateList(source interface{}) (items []*ExternalAuthState, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthStateList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthStateList reads list of values of the ”external_auth_state' type from
+// the given iterator.
+func ReadExternalAuthStateList(iterator *jsoniter.Iterator) []*ExternalAuthState {
+	list := []*ExternalAuthState{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuthState(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_state_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_state_type.go
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	time "time"
+)
+
+// ExternalAuthState represents the values of the 'external_auth_state' type.
+//
+// Representation of the state of an external authentication provider.
+type ExternalAuthState struct {
+	bitmap_              uint32
+	lastUpdatedTimestamp time.Time
+	value                string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuthState) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// LastUpdatedTimestamp returns the value of the 'last_updated_timestamp' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The date and time when the external authentication provider state was last updated.
+func (o *ExternalAuthState) LastUpdatedTimestamp() time.Time {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.lastUpdatedTimestamp
+	}
+	return time.Time{}
+}
+
+// GetLastUpdatedTimestamp returns the value of the 'last_updated_timestamp' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The date and time when the external authentication provider state was last updated.
+func (o *ExternalAuthState) GetLastUpdatedTimestamp() (value time.Time, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.lastUpdatedTimestamp
+	}
+	return
+}
+
+// Value returns the value of the 'value' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A string value representing the external authentication provider's current state.
+func (o *ExternalAuthState) Value() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.value
+	}
+	return ""
+}
+
+// GetValue returns the value of the 'value' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A string value representing the external authentication provider's current state.
+func (o *ExternalAuthState) GetValue() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.value
+	}
+	return
+}
+
+// ExternalAuthStateListKind is the name of the type used to represent list of objects of
+// type 'external_auth_state'.
+const ExternalAuthStateListKind = "ExternalAuthStateList"
+
+// ExternalAuthStateListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth_state'.
+const ExternalAuthStateListLinkKind = "ExternalAuthStateListLink"
+
+// ExternalAuthStateNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth_state'.
+const ExternalAuthStateListNilKind = "ExternalAuthStateListNil"
+
+// ExternalAuthStateList is a list of values of the 'external_auth_state' type.
+type ExternalAuthStateList struct {
+	href  string
+	link  bool
+	items []*ExternalAuthState
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthStateList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStateList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStateList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStateList) SetItems(items []*ExternalAuthState) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthStateList) Items() []*ExternalAuthState {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthStateList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthStateList) Get(i int) *ExternalAuthState {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthStateList) Slice() []*ExternalAuthState {
+	var slice []*ExternalAuthState
+	if l == nil {
+		slice = make([]*ExternalAuthState, 0)
+	} else {
+		slice = make([]*ExternalAuthState, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthStateList) Each(f func(item *ExternalAuthState) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthStateList) Range(f func(index int, item *ExternalAuthState) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_state_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_state_type_json.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthState writes a value of the 'external_auth_state' type to the given writer.
+func MarshalExternalAuthState(object *ExternalAuthState, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthState(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthState writes a value of the 'external_auth_state' type to the given stream.
+func WriteExternalAuthState(object *ExternalAuthState, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("last_updated_timestamp")
+		stream.WriteString((object.lastUpdatedTimestamp).Format(time.RFC3339))
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("value")
+		stream.WriteString(object.value)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalExternalAuthState reads a value of the 'external_auth_state' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalExternalAuthState(source interface{}) (object *ExternalAuthState, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadExternalAuthState(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthState reads a value of the 'external_auth_state' type from the given iterator.
+func ReadExternalAuthState(iterator *jsoniter.Iterator) *ExternalAuthState {
+	object := &ExternalAuthState{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "last_updated_timestamp":
+			text := iterator.ReadString()
+			value, err := time.Parse(time.RFC3339, text)
+			if err != nil {
+				iterator.ReportError("", err.Error())
+			}
+			object.lastUpdatedTimestamp = value
+			object.bitmap_ |= 1
+		case "value":
+			value := iterator.ReadString()
+			object.value = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_status_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_status_builder.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthStatusBuilder contains the data and logic needed to build 'external_auth_status' objects.
+//
+// Representation of the status of an external authentication provider.
+type ExternalAuthStatusBuilder struct {
+	bitmap_ uint32
+	message string
+	state   *ExternalAuthStateBuilder
+}
+
+// NewExternalAuthStatus creates a new builder of 'external_auth_status' objects.
+func NewExternalAuthStatus() *ExternalAuthStatusBuilder {
+	return &ExternalAuthStatusBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthStatusBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Message sets the value of the 'message' attribute to the given value.
+func (b *ExternalAuthStatusBuilder) Message(value string) *ExternalAuthStatusBuilder {
+	b.message = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// State sets the value of the 'state' attribute to the given value.
+//
+// Representation of the state of an external authentication provider.
+func (b *ExternalAuthStatusBuilder) State(value *ExternalAuthStateBuilder) *ExternalAuthStatusBuilder {
+	b.state = value
+	if value != nil {
+		b.bitmap_ |= 2
+	} else {
+		b.bitmap_ &^= 2
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthStatusBuilder) Copy(object *ExternalAuthStatus) *ExternalAuthStatusBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.message = object.message
+	if object.state != nil {
+		b.state = NewExternalAuthState().Copy(object.state)
+	} else {
+		b.state = nil
+	}
+	return b
+}
+
+// Build creates a 'external_auth_status' object using the configuration stored in the builder.
+func (b *ExternalAuthStatusBuilder) Build() (object *ExternalAuthStatus, err error) {
+	object = new(ExternalAuthStatus)
+	object.bitmap_ = b.bitmap_
+	object.message = b.message
+	if b.state != nil {
+		object.state, err = b.state.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_status_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_status_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthStatusListBuilder contains the data and logic needed to build
+// 'external_auth_status' objects.
+type ExternalAuthStatusListBuilder struct {
+	items []*ExternalAuthStatusBuilder
+}
+
+// NewExternalAuthStatusList creates a new builder of 'external_auth_status' objects.
+func NewExternalAuthStatusList() *ExternalAuthStatusListBuilder {
+	return new(ExternalAuthStatusListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthStatusListBuilder) Items(values ...*ExternalAuthStatusBuilder) *ExternalAuthStatusListBuilder {
+	b.items = make([]*ExternalAuthStatusBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthStatusListBuilder) Copy(list *ExternalAuthStatusList) *ExternalAuthStatusListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthStatusBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuthStatus().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth_status' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthStatusListBuilder) Build() (list *ExternalAuthStatusList, err error) {
+	items := make([]*ExternalAuthStatus, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthStatusList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_status_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_status_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthStatusList writes a list of values of the 'external_auth_status' type to
+// the given writer.
+func MarshalExternalAuthStatusList(list []*ExternalAuthStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthStatusList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthStatusList writes a list of value of the 'external_auth_status' type to
+// the given stream.
+func WriteExternalAuthStatusList(list []*ExternalAuthStatus, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuthStatus(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthStatusList reads a list of values of the 'external_auth_status' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthStatusList(source interface{}) (items []*ExternalAuthStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthStatusList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthStatusList reads list of values of the ”external_auth_status' type from
+// the given iterator.
+func ReadExternalAuthStatusList(iterator *jsoniter.Iterator) []*ExternalAuthStatus {
+	list := []*ExternalAuthStatus{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuthStatus(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_status_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_status_type.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthStatus represents the values of the 'external_auth_status' type.
+//
+// Representation of the status of an external authentication provider.
+type ExternalAuthStatus struct {
+	bitmap_ uint32
+	message string
+	state   *ExternalAuthState
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuthStatus) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Message returns the value of the 'message' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A descriptive message providing additional context about the current
+// state of the external authentication provider.
+func (o *ExternalAuthStatus) Message() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.message
+	}
+	return ""
+}
+
+// GetMessage returns the value of the 'message' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A descriptive message providing additional context about the current
+// state of the external authentication provider.
+func (o *ExternalAuthStatus) GetMessage() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.message
+	}
+	return
+}
+
+// State returns the value of the 'state' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The current state of the external authentication provider.
+func (o *ExternalAuthStatus) State() *ExternalAuthState {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.state
+	}
+	return nil
+}
+
+// GetState returns the value of the 'state' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The current state of the external authentication provider.
+func (o *ExternalAuthStatus) GetState() (value *ExternalAuthState, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.state
+	}
+	return
+}
+
+// ExternalAuthStatusListKind is the name of the type used to represent list of objects of
+// type 'external_auth_status'.
+const ExternalAuthStatusListKind = "ExternalAuthStatusList"
+
+// ExternalAuthStatusListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth_status'.
+const ExternalAuthStatusListLinkKind = "ExternalAuthStatusListLink"
+
+// ExternalAuthStatusNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth_status'.
+const ExternalAuthStatusListNilKind = "ExternalAuthStatusListNil"
+
+// ExternalAuthStatusList is a list of values of the 'external_auth_status' type.
+type ExternalAuthStatusList struct {
+	href  string
+	link  bool
+	items []*ExternalAuthStatus
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthStatusList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStatusList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStatusList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStatusList) SetItems(items []*ExternalAuthStatus) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthStatusList) Items() []*ExternalAuthStatus {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthStatusList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthStatusList) Get(i int) *ExternalAuthStatus {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthStatusList) Slice() []*ExternalAuthStatus {
+	var slice []*ExternalAuthStatus
+	if l == nil {
+		slice = make([]*ExternalAuthStatus, 0)
+	} else {
+		slice = make([]*ExternalAuthStatus, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthStatusList) Each(f func(item *ExternalAuthStatus) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthStatusList) Range(f func(index int, item *ExternalAuthStatus) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_status_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_status_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthStatus writes a value of the 'external_auth_status' type to the given writer.
+func MarshalExternalAuthStatus(object *ExternalAuthStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthStatus(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthStatus writes a value of the 'external_auth_status' type to the given stream.
+func WriteExternalAuthStatus(object *ExternalAuthStatus, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("message")
+		stream.WriteString(object.message)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.state != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("state")
+		WriteExternalAuthState(object.state, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalExternalAuthStatus reads a value of the 'external_auth_status' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalExternalAuthStatus(source interface{}) (object *ExternalAuthStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadExternalAuthStatus(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthStatus reads a value of the 'external_auth_status' type from the given iterator.
+func ReadExternalAuthStatus(iterator *jsoniter.Iterator) *ExternalAuthStatus {
+	object := &ExternalAuthStatus{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "message":
+			value := iterator.ReadString()
+			object.message = value
+			object.bitmap_ |= 1
+		case "state":
+			value := ReadExternalAuthState(iterator)
+			object.state = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_type.go
@@ -1,0 +1,313 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ExternalAuthKind is the name of the type used to represent objects
+// of type 'external_auth'.
+const ExternalAuthKind = "ExternalAuth"
+
+// ExternalAuthLinkKind is the name of the type used to represent links
+// to objects of type 'external_auth'.
+const ExternalAuthLinkKind = "ExternalAuthLink"
+
+// ExternalAuthNilKind is the name of the type used to nil references
+// to objects of type 'external_auth'.
+const ExternalAuthNilKind = "ExternalAuthNil"
+
+// ExternalAuth represents the values of the 'external_auth' type.
+//
+// Representation of an external authentication provider.
+type ExternalAuth struct {
+	bitmap_ uint32
+	id      string
+	href    string
+	claim   *ExternalAuthClaim
+	clients []*ExternalAuthClientConfig
+	issuer  *TokenIssuer
+}
+
+// Kind returns the name of the type of the object.
+func (o *ExternalAuth) Kind() string {
+	if o == nil {
+		return ExternalAuthNilKind
+	}
+	if o.bitmap_&1 != 0 {
+		return ExternalAuthLinkKind
+	}
+	return ExternalAuthKind
+}
+
+// Link returns true if this is a link.
+func (o *ExternalAuth) Link() bool {
+	return o != nil && o.bitmap_&1 != 0
+}
+
+// ID returns the identifier of the object.
+func (o *ExternalAuth) ID() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *ExternalAuth) GetID() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *ExternalAuth) HREF() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *ExternalAuth) GetHREF() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuth) Empty() bool {
+	return o == nil || o.bitmap_&^1 == 0
+}
+
+// Claim returns the value of the 'claim' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The rules on how to transform information from an ID token into a cluster identity.
+func (o *ExternalAuth) Claim() *ExternalAuthClaim {
+	if o != nil && o.bitmap_&8 != 0 {
+		return o.claim
+	}
+	return nil
+}
+
+// GetClaim returns the value of the 'claim' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The rules on how to transform information from an ID token into a cluster identity.
+func (o *ExternalAuth) GetClaim() (value *ExternalAuthClaim, ok bool) {
+	ok = o != nil && o.bitmap_&8 != 0
+	if ok {
+		value = o.claim
+	}
+	return
+}
+
+// Clients returns the value of the 'clients' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The list of the platform's clients that need to request tokens from the issuer.
+func (o *ExternalAuth) Clients() []*ExternalAuthClientConfig {
+	if o != nil && o.bitmap_&16 != 0 {
+		return o.clients
+	}
+	return nil
+}
+
+// GetClients returns the value of the 'clients' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The list of the platform's clients that need to request tokens from the issuer.
+func (o *ExternalAuth) GetClients() (value []*ExternalAuthClientConfig, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
+	if ok {
+		value = o.clients
+	}
+	return
+}
+
+// Issuer returns the value of the 'issuer' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The issuer describes the attributes of the OIDC token issuer.
+func (o *ExternalAuth) Issuer() *TokenIssuer {
+	if o != nil && o.bitmap_&32 != 0 {
+		return o.issuer
+	}
+	return nil
+}
+
+// GetIssuer returns the value of the 'issuer' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The issuer describes the attributes of the OIDC token issuer.
+func (o *ExternalAuth) GetIssuer() (value *TokenIssuer, ok bool) {
+	ok = o != nil && o.bitmap_&32 != 0
+	if ok {
+		value = o.issuer
+	}
+	return
+}
+
+// ExternalAuthListKind is the name of the type used to represent list of objects of
+// type 'external_auth'.
+const ExternalAuthListKind = "ExternalAuthList"
+
+// ExternalAuthListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth'.
+const ExternalAuthListLinkKind = "ExternalAuthListLink"
+
+// ExternalAuthNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth'.
+const ExternalAuthListNilKind = "ExternalAuthListNil"
+
+// ExternalAuthList is a list of values of the 'external_auth' type.
+type ExternalAuthList struct {
+	href  string
+	link  bool
+	items []*ExternalAuth
+}
+
+// Kind returns the name of the type of the object.
+func (l *ExternalAuthList) Kind() string {
+	if l == nil {
+		return ExternalAuthListNilKind
+	}
+	if l.link {
+		return ExternalAuthListLinkKind
+	}
+	return ExternalAuthListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ExternalAuthList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ExternalAuthList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ExternalAuthList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthList) SetItems(items []*ExternalAuth) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthList) Items() []*ExternalAuth {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthList) Get(i int) *ExternalAuth {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthList) Slice() []*ExternalAuth {
+	var slice []*ExternalAuth
+	if l == nil {
+		slice = make([]*ExternalAuth, 0)
+	} else {
+		slice = make([]*ExternalAuth, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthList) Each(f func(item *ExternalAuth) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthList) Range(f func(index int, item *ExternalAuth) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/external_auth_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_type.go
@@ -174,6 +174,7 @@ func (o *ExternalAuth) GetIssuer() (value *TokenIssuer, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The status describes the current state of the external authentication provider.
+// This is read-only.
 func (o *ExternalAuth) Status() *ExternalAuthStatus {
 	if o != nil && o.bitmap_&64 != 0 {
 		return o.status
@@ -185,6 +186,7 @@ func (o *ExternalAuth) Status() *ExternalAuthStatus {
 // a flag indicating if the attribute has a value.
 //
 // The status describes the current state of the external authentication provider.
+// This is read-only.
 func (o *ExternalAuth) GetStatus() (value *ExternalAuthStatus, ok bool) {
 	ok = o != nil && o.bitmap_&64 != 0
 	if ok {

--- a/clientapi/arohcp/v1alpha1/external_auth_type.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_type.go
@@ -41,6 +41,7 @@ type ExternalAuth struct {
 	claim   *ExternalAuthClaim
 	clients []*ExternalAuthClientConfig
 	issuer  *TokenIssuer
+	status  *ExternalAuthStatus
 }
 
 // Kind returns the name of the type of the object.
@@ -165,6 +166,29 @@ func (o *ExternalAuth) GetIssuer() (value *TokenIssuer, ok bool) {
 	ok = o != nil && o.bitmap_&32 != 0
 	if ok {
 		value = o.issuer
+	}
+	return
+}
+
+// Status returns the value of the 'status' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The status describes the current state of the external authentication provider.
+func (o *ExternalAuth) Status() *ExternalAuthStatus {
+	if o != nil && o.bitmap_&64 != 0 {
+		return o.status
+	}
+	return nil
+}
+
+// GetStatus returns the value of the 'status' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The status describes the current state of the external authentication provider.
+func (o *ExternalAuth) GetStatus() (value *ExternalAuthStatus, ok bool) {
+	ok = o != nil && o.bitmap_&64 != 0
+	if ok {
+		value = o.status
 	}
 	return
 }

--- a/clientapi/arohcp/v1alpha1/external_auth_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_type_json.go
@@ -26,10 +26,10 @@ import (
 	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
 )
 
-// MarshalExternalAuthConfig writes a value of the 'external_auth_config' type to the given writer.
-func MarshalExternalAuthConfig(object *ExternalAuthConfig, writer io.Writer) error {
+// MarshalExternalAuth writes a value of the 'external_auth' type to the given writer.
+func MarshalExternalAuth(object *ExternalAuth, writer io.Writer) error {
 	stream := helpers.NewStream(writer)
-	WriteExternalAuthConfig(object, stream)
+	WriteExternalAuth(object, stream)
 	err := stream.Flush()
 	if err != nil {
 		return err
@@ -37,15 +37,15 @@ func MarshalExternalAuthConfig(object *ExternalAuthConfig, writer io.Writer) err
 	return stream.Error
 }
 
-// WriteExternalAuthConfig writes a value of the 'external_auth_config' type to the given stream.
-func WriteExternalAuthConfig(object *ExternalAuthConfig, stream *jsoniter.Stream) {
+// WriteExternalAuth writes a value of the 'external_auth' type to the given stream.
+func WriteExternalAuth(object *ExternalAuth, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
 	stream.WriteObjectField("kind")
 	if object.bitmap_&1 != 0 {
-		stream.WriteString(ExternalAuthConfigLinkKind)
+		stream.WriteString(ExternalAuthLinkKind)
 	} else {
-		stream.WriteString(ExternalAuthConfigKind)
+		stream.WriteString(ExternalAuthKind)
 	}
 	count++
 	if object.bitmap_&2 != 0 {
@@ -65,53 +65,50 @@ func WriteExternalAuthConfig(object *ExternalAuthConfig, stream *jsoniter.Stream
 		count++
 	}
 	var present_ bool
-	present_ = object.bitmap_&8 != 0
+	present_ = object.bitmap_&8 != 0 && object.claim != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("enabled")
-		stream.WriteBool(object.enabled)
+		stream.WriteObjectField("claim")
+		WriteExternalAuthClaim(object.claim, stream)
 		count++
 	}
-	present_ = object.bitmap_&16 != 0 && object.externalAuths != nil
+	present_ = object.bitmap_&16 != 0 && object.clients != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("external_auths")
-		stream.WriteObjectStart()
-		stream.WriteObjectField("items")
-		WriteExternalAuthList(object.externalAuths.Items(), stream)
-		stream.WriteObjectEnd()
+		stream.WriteObjectField("clients")
+		WriteExternalAuthClientConfigList(object.clients, stream)
 		count++
 	}
-	present_ = object.bitmap_&32 != 0
+	present_ = object.bitmap_&32 != 0 && object.issuer != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("state")
-		stream.WriteString(string(object.state))
+		stream.WriteObjectField("issuer")
+		WriteTokenIssuer(object.issuer, stream)
 	}
 	stream.WriteObjectEnd()
 }
 
-// UnmarshalExternalAuthConfig reads a value of the 'external_auth_config' type from the given
+// UnmarshalExternalAuth reads a value of the 'external_auth' type from the given
 // source, which can be an slice of bytes, a string or a reader.
-func UnmarshalExternalAuthConfig(source interface{}) (object *ExternalAuthConfig, err error) {
+func UnmarshalExternalAuth(source interface{}) (object *ExternalAuth, err error) {
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return
 	}
-	object = ReadExternalAuthConfig(iterator)
+	object = ReadExternalAuth(iterator)
 	err = iterator.Error
 	return
 }
 
-// ReadExternalAuthConfig reads a value of the 'external_auth_config' type from the given iterator.
-func ReadExternalAuthConfig(iterator *jsoniter.Iterator) *ExternalAuthConfig {
-	object := &ExternalAuthConfig{}
+// ReadExternalAuth reads a value of the 'external_auth' type from the given iterator.
+func ReadExternalAuth(iterator *jsoniter.Iterator) *ExternalAuth {
+	object := &ExternalAuth{}
 	for {
 		field := iterator.ReadObject()
 		if field == "" {
@@ -120,7 +117,7 @@ func ReadExternalAuthConfig(iterator *jsoniter.Iterator) *ExternalAuthConfig {
 		switch field {
 		case "kind":
 			value := iterator.ReadString()
-			if value == ExternalAuthConfigLinkKind {
+			if value == ExternalAuthLinkKind {
 				object.bitmap_ |= 1
 			}
 		case "id":
@@ -129,35 +126,17 @@ func ReadExternalAuthConfig(iterator *jsoniter.Iterator) *ExternalAuthConfig {
 		case "href":
 			object.href = iterator.ReadString()
 			object.bitmap_ |= 4
-		case "enabled":
-			value := iterator.ReadBool()
-			object.enabled = value
+		case "claim":
+			value := ReadExternalAuthClaim(iterator)
+			object.claim = value
 			object.bitmap_ |= 8
-		case "external_auths":
-			value := &ExternalAuthList{}
-			for {
-				field := iterator.ReadObject()
-				if field == "" {
-					break
-				}
-				switch field {
-				case "kind":
-					text := iterator.ReadString()
-					value.SetLink(text == ExternalAuthListLinkKind)
-				case "href":
-					value.SetHREF(iterator.ReadString())
-				case "items":
-					value.SetItems(ReadExternalAuthList(iterator))
-				default:
-					iterator.ReadAny()
-				}
-			}
-			object.externalAuths = value
+		case "clients":
+			value := ReadExternalAuthClientConfigList(iterator)
+			object.clients = value
 			object.bitmap_ |= 16
-		case "state":
-			text := iterator.ReadString()
-			value := ExternalAuthConfigState(text)
-			object.state = value
+		case "issuer":
+			value := ReadTokenIssuer(iterator)
+			object.issuer = value
 			object.bitmap_ |= 32
 		default:
 			iterator.ReadAny()

--- a/clientapi/arohcp/v1alpha1/external_auth_type_json.go
+++ b/clientapi/arohcp/v1alpha1/external_auth_type_json.go
@@ -90,6 +90,15 @@ func WriteExternalAuth(object *ExternalAuth, stream *jsoniter.Stream) {
 		}
 		stream.WriteObjectField("issuer")
 		WriteTokenIssuer(object.issuer, stream)
+		count++
+	}
+	present_ = object.bitmap_&64 != 0 && object.status != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("status")
+		WriteExternalAuthStatus(object.status, stream)
 	}
 	stream.WriteObjectEnd()
 }
@@ -138,6 +147,10 @@ func ReadExternalAuth(iterator *jsoniter.Iterator) *ExternalAuth {
 			value := ReadTokenIssuer(iterator)
 			object.issuer = value
 			object.bitmap_ |= 32
+		case "status":
+			value := ReadExternalAuthStatus(iterator)
+			object.status = value
+			object.bitmap_ |= 64
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/arohcp/v1alpha1/groups_claim_builder.go
+++ b/clientapi/arohcp/v1alpha1/groups_claim_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// GroupsClaimBuilder contains the data and logic needed to build 'groups_claim' objects.
+type GroupsClaimBuilder struct {
+	bitmap_ uint32
+	claim   string
+	prefix  string
+}
+
+// NewGroupsClaim creates a new builder of 'groups_claim' objects.
+func NewGroupsClaim() *GroupsClaimBuilder {
+	return &GroupsClaimBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GroupsClaimBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Claim sets the value of the 'claim' attribute to the given value.
+func (b *GroupsClaimBuilder) Claim(value string) *GroupsClaimBuilder {
+	b.claim = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Prefix sets the value of the 'prefix' attribute to the given value.
+func (b *GroupsClaimBuilder) Prefix(value string) *GroupsClaimBuilder {
+	b.prefix = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GroupsClaimBuilder) Copy(object *GroupsClaim) *GroupsClaimBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.claim = object.claim
+	b.prefix = object.prefix
+	return b
+}
+
+// Build creates a 'groups_claim' object using the configuration stored in the builder.
+func (b *GroupsClaimBuilder) Build() (object *GroupsClaim, err error) {
+	object = new(GroupsClaim)
+	object.bitmap_ = b.bitmap_
+	object.claim = b.claim
+	object.prefix = b.prefix
+	return
+}

--- a/clientapi/arohcp/v1alpha1/groups_claim_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/groups_claim_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// GroupsClaimListBuilder contains the data and logic needed to build
+// 'groups_claim' objects.
+type GroupsClaimListBuilder struct {
+	items []*GroupsClaimBuilder
+}
+
+// NewGroupsClaimList creates a new builder of 'groups_claim' objects.
+func NewGroupsClaimList() *GroupsClaimListBuilder {
+	return new(GroupsClaimListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GroupsClaimListBuilder) Items(values ...*GroupsClaimBuilder) *GroupsClaimListBuilder {
+	b.items = make([]*GroupsClaimBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GroupsClaimListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GroupsClaimListBuilder) Copy(list *GroupsClaimList) *GroupsClaimListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GroupsClaimBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGroupsClaim().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'groups_claim' objects using the
+// configuration stored in the builder.
+func (b *GroupsClaimListBuilder) Build() (list *GroupsClaimList, err error) {
+	items := make([]*GroupsClaim, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GroupsClaimList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/groups_claim_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/groups_claim_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGroupsClaimList writes a list of values of the 'groups_claim' type to
+// the given writer.
+func MarshalGroupsClaimList(list []*GroupsClaim, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGroupsClaimList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGroupsClaimList writes a list of value of the 'groups_claim' type to
+// the given stream.
+func WriteGroupsClaimList(list []*GroupsClaim, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGroupsClaim(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGroupsClaimList reads a list of values of the 'groups_claim' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGroupsClaimList(source interface{}) (items []*GroupsClaim, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGroupsClaimList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGroupsClaimList reads list of values of the ”groups_claim' type from
+// the given iterator.
+func ReadGroupsClaimList(iterator *jsoniter.Iterator) []*GroupsClaim {
+	list := []*GroupsClaim{}
+	for iterator.ReadArray() {
+		item := ReadGroupsClaim(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/groups_claim_type.go
+++ b/clientapi/arohcp/v1alpha1/groups_claim_type.go
@@ -1,0 +1,187 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// GroupsClaim represents the values of the 'groups_claim' type.
+type GroupsClaim struct {
+	bitmap_ uint32
+	claim   string
+	prefix  string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GroupsClaim) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Claim returns the value of the 'claim' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The claim used in the token.
+func (o *GroupsClaim) Claim() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.claim
+	}
+	return ""
+}
+
+// GetClaim returns the value of the 'claim' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The claim used in the token.
+func (o *GroupsClaim) GetClaim() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.claim
+	}
+	return
+}
+
+// Prefix returns the value of the 'prefix' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A prefix contatenated in the claim (Optional).
+func (o *GroupsClaim) Prefix() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.prefix
+	}
+	return ""
+}
+
+// GetPrefix returns the value of the 'prefix' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A prefix contatenated in the claim (Optional).
+func (o *GroupsClaim) GetPrefix() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.prefix
+	}
+	return
+}
+
+// GroupsClaimListKind is the name of the type used to represent list of objects of
+// type 'groups_claim'.
+const GroupsClaimListKind = "GroupsClaimList"
+
+// GroupsClaimListLinkKind is the name of the type used to represent links to list
+// of objects of type 'groups_claim'.
+const GroupsClaimListLinkKind = "GroupsClaimListLink"
+
+// GroupsClaimNilKind is the name of the type used to nil lists of objects of
+// type 'groups_claim'.
+const GroupsClaimListNilKind = "GroupsClaimListNil"
+
+// GroupsClaimList is a list of values of the 'groups_claim' type.
+type GroupsClaimList struct {
+	href  string
+	link  bool
+	items []*GroupsClaim
+}
+
+// Len returns the length of the list.
+func (l *GroupsClaimList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GroupsClaimList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GroupsClaimList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GroupsClaimList) SetItems(items []*GroupsClaim) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GroupsClaimList) Items() []*GroupsClaim {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GroupsClaimList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GroupsClaimList) Get(i int) *GroupsClaim {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GroupsClaimList) Slice() []*GroupsClaim {
+	var slice []*GroupsClaim
+	if l == nil {
+		slice = make([]*GroupsClaim, 0)
+	} else {
+		slice = make([]*GroupsClaim, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GroupsClaimList) Each(f func(item *GroupsClaim) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GroupsClaimList) Range(f func(index int, item *GroupsClaim) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/groups_claim_type_json.go
+++ b/clientapi/arohcp/v1alpha1/groups_claim_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGroupsClaim writes a value of the 'groups_claim' type to the given writer.
+func MarshalGroupsClaim(object *GroupsClaim, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGroupsClaim(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGroupsClaim writes a value of the 'groups_claim' type to the given stream.
+func WriteGroupsClaim(object *GroupsClaim, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("claim")
+		stream.WriteString(object.claim)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("prefix")
+		stream.WriteString(object.prefix)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalGroupsClaim reads a value of the 'groups_claim' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalGroupsClaim(source interface{}) (object *GroupsClaim, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadGroupsClaim(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGroupsClaim reads a value of the 'groups_claim' type from the given iterator.
+func ReadGroupsClaim(iterator *jsoniter.Iterator) *GroupsClaim {
+	object := &GroupsClaim{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "claim":
+			value := iterator.ReadString()
+			object.claim = value
+			object.bitmap_ |= 1
+		case "prefix":
+			value := iterator.ReadString()
+			object.prefix = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_mappings_builder.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_mappings_builder.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenClaimMappingsBuilder contains the data and logic needed to build 'token_claim_mappings' objects.
+//
+// The claim mappings defined for users and groups.
+type TokenClaimMappingsBuilder struct {
+	bitmap_  uint32
+	groups   *GroupsClaimBuilder
+	userName *UsernameClaimBuilder
+}
+
+// NewTokenClaimMappings creates a new builder of 'token_claim_mappings' objects.
+func NewTokenClaimMappings() *TokenClaimMappingsBuilder {
+	return &TokenClaimMappingsBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TokenClaimMappingsBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Groups sets the value of the 'groups' attribute to the given value.
+func (b *TokenClaimMappingsBuilder) Groups(value *GroupsClaimBuilder) *TokenClaimMappingsBuilder {
+	b.groups = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// UserName sets the value of the 'user_name' attribute to the given value.
+//
+// The username claim mapping.
+func (b *TokenClaimMappingsBuilder) UserName(value *UsernameClaimBuilder) *TokenClaimMappingsBuilder {
+	b.userName = value
+	if value != nil {
+		b.bitmap_ |= 2
+	} else {
+		b.bitmap_ &^= 2
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *TokenClaimMappingsBuilder) Copy(object *TokenClaimMappings) *TokenClaimMappingsBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.groups != nil {
+		b.groups = NewGroupsClaim().Copy(object.groups)
+	} else {
+		b.groups = nil
+	}
+	if object.userName != nil {
+		b.userName = NewUsernameClaim().Copy(object.userName)
+	} else {
+		b.userName = nil
+	}
+	return b
+}
+
+// Build creates a 'token_claim_mappings' object using the configuration stored in the builder.
+func (b *TokenClaimMappingsBuilder) Build() (object *TokenClaimMappings, err error) {
+	object = new(TokenClaimMappings)
+	object.bitmap_ = b.bitmap_
+	if b.groups != nil {
+		object.groups, err = b.groups.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.userName != nil {
+		object.userName, err = b.userName.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_mappings_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_mappings_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenClaimMappingsListBuilder contains the data and logic needed to build
+// 'token_claim_mappings' objects.
+type TokenClaimMappingsListBuilder struct {
+	items []*TokenClaimMappingsBuilder
+}
+
+// NewTokenClaimMappingsList creates a new builder of 'token_claim_mappings' objects.
+func NewTokenClaimMappingsList() *TokenClaimMappingsListBuilder {
+	return new(TokenClaimMappingsListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *TokenClaimMappingsListBuilder) Items(values ...*TokenClaimMappingsBuilder) *TokenClaimMappingsListBuilder {
+	b.items = make([]*TokenClaimMappingsBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *TokenClaimMappingsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *TokenClaimMappingsListBuilder) Copy(list *TokenClaimMappingsList) *TokenClaimMappingsListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*TokenClaimMappingsBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewTokenClaimMappings().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'token_claim_mappings' objects using the
+// configuration stored in the builder.
+func (b *TokenClaimMappingsListBuilder) Build() (list *TokenClaimMappingsList, err error) {
+	items := make([]*TokenClaimMappings, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(TokenClaimMappingsList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_mappings_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_mappings_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalTokenClaimMappingsList writes a list of values of the 'token_claim_mappings' type to
+// the given writer.
+func MarshalTokenClaimMappingsList(list []*TokenClaimMappings, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteTokenClaimMappingsList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteTokenClaimMappingsList writes a list of value of the 'token_claim_mappings' type to
+// the given stream.
+func WriteTokenClaimMappingsList(list []*TokenClaimMappings, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteTokenClaimMappings(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalTokenClaimMappingsList reads a list of values of the 'token_claim_mappings' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalTokenClaimMappingsList(source interface{}) (items []*TokenClaimMappings, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadTokenClaimMappingsList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadTokenClaimMappingsList reads list of values of the ”token_claim_mappings' type from
+// the given iterator.
+func ReadTokenClaimMappingsList(iterator *jsoniter.Iterator) []*TokenClaimMappings {
+	list := []*TokenClaimMappings{}
+	for iterator.ReadArray() {
+		item := ReadTokenClaimMappings(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_mappings_type.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_mappings_type.go
@@ -1,0 +1,189 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenClaimMappings represents the values of the 'token_claim_mappings' type.
+//
+// The claim mappings defined for users and groups.
+type TokenClaimMappings struct {
+	bitmap_  uint32
+	groups   *GroupsClaim
+	userName *UsernameClaim
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *TokenClaimMappings) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Groups returns the value of the 'groups' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Groups is a name of the claim that should be used to construct groups for the cluster identity.
+func (o *TokenClaimMappings) Groups() *GroupsClaim {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.groups
+	}
+	return nil
+}
+
+// GetGroups returns the value of the 'groups' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Groups is a name of the claim that should be used to construct groups for the cluster identity.
+func (o *TokenClaimMappings) GetGroups() (value *GroupsClaim, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.groups
+	}
+	return
+}
+
+// UserName returns the value of the 'user_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Username is a name of the claim that should be used to construct usernames for the cluster identity.
+func (o *TokenClaimMappings) UserName() *UsernameClaim {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.userName
+	}
+	return nil
+}
+
+// GetUserName returns the value of the 'user_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Username is a name of the claim that should be used to construct usernames for the cluster identity.
+func (o *TokenClaimMappings) GetUserName() (value *UsernameClaim, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.userName
+	}
+	return
+}
+
+// TokenClaimMappingsListKind is the name of the type used to represent list of objects of
+// type 'token_claim_mappings'.
+const TokenClaimMappingsListKind = "TokenClaimMappingsList"
+
+// TokenClaimMappingsListLinkKind is the name of the type used to represent links to list
+// of objects of type 'token_claim_mappings'.
+const TokenClaimMappingsListLinkKind = "TokenClaimMappingsListLink"
+
+// TokenClaimMappingsNilKind is the name of the type used to nil lists of objects of
+// type 'token_claim_mappings'.
+const TokenClaimMappingsListNilKind = "TokenClaimMappingsListNil"
+
+// TokenClaimMappingsList is a list of values of the 'token_claim_mappings' type.
+type TokenClaimMappingsList struct {
+	href  string
+	link  bool
+	items []*TokenClaimMappings
+}
+
+// Len returns the length of the list.
+func (l *TokenClaimMappingsList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *TokenClaimMappingsList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *TokenClaimMappingsList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *TokenClaimMappingsList) SetItems(items []*TokenClaimMappings) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *TokenClaimMappingsList) Items() []*TokenClaimMappings {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *TokenClaimMappingsList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *TokenClaimMappingsList) Get(i int) *TokenClaimMappings {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *TokenClaimMappingsList) Slice() []*TokenClaimMappings {
+	var slice []*TokenClaimMappings
+	if l == nil {
+		slice = make([]*TokenClaimMappings, 0)
+	} else {
+		slice = make([]*TokenClaimMappings, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *TokenClaimMappingsList) Each(f func(item *TokenClaimMappings) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *TokenClaimMappingsList) Range(f func(index int, item *TokenClaimMappings) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_mappings_type_json.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_mappings_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalTokenClaimMappings writes a value of the 'token_claim_mappings' type to the given writer.
+func MarshalTokenClaimMappings(object *TokenClaimMappings, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteTokenClaimMappings(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteTokenClaimMappings writes a value of the 'token_claim_mappings' type to the given stream.
+func WriteTokenClaimMappings(object *TokenClaimMappings, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.groups != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("groups")
+		WriteGroupsClaim(object.groups, stream)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.userName != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("username")
+		WriteUsernameClaim(object.userName, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalTokenClaimMappings reads a value of the 'token_claim_mappings' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalTokenClaimMappings(source interface{}) (object *TokenClaimMappings, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadTokenClaimMappings(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadTokenClaimMappings reads a value of the 'token_claim_mappings' type from the given iterator.
+func ReadTokenClaimMappings(iterator *jsoniter.Iterator) *TokenClaimMappings {
+	object := &TokenClaimMappings{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "groups":
+			value := ReadGroupsClaim(iterator)
+			object.groups = value
+			object.bitmap_ |= 1
+		case "username":
+			value := ReadUsernameClaim(iterator)
+			object.userName = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_validation_rule_builder.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_validation_rule_builder.go
@@ -1,0 +1,73 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenClaimValidationRuleBuilder contains the data and logic needed to build 'token_claim_validation_rule' objects.
+//
+// The rule that is applied to validate token claims to authenticate users.
+type TokenClaimValidationRuleBuilder struct {
+	bitmap_       uint32
+	claim         string
+	requiredValue string
+}
+
+// NewTokenClaimValidationRule creates a new builder of 'token_claim_validation_rule' objects.
+func NewTokenClaimValidationRule() *TokenClaimValidationRuleBuilder {
+	return &TokenClaimValidationRuleBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TokenClaimValidationRuleBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Claim sets the value of the 'claim' attribute to the given value.
+func (b *TokenClaimValidationRuleBuilder) Claim(value string) *TokenClaimValidationRuleBuilder {
+	b.claim = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// RequiredValue sets the value of the 'required_value' attribute to the given value.
+func (b *TokenClaimValidationRuleBuilder) RequiredValue(value string) *TokenClaimValidationRuleBuilder {
+	b.requiredValue = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *TokenClaimValidationRuleBuilder) Copy(object *TokenClaimValidationRule) *TokenClaimValidationRuleBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.claim = object.claim
+	b.requiredValue = object.requiredValue
+	return b
+}
+
+// Build creates a 'token_claim_validation_rule' object using the configuration stored in the builder.
+func (b *TokenClaimValidationRuleBuilder) Build() (object *TokenClaimValidationRule, err error) {
+	object = new(TokenClaimValidationRule)
+	object.bitmap_ = b.bitmap_
+	object.claim = b.claim
+	object.requiredValue = b.requiredValue
+	return
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_validation_rule_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_validation_rule_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenClaimValidationRuleListBuilder contains the data and logic needed to build
+// 'token_claim_validation_rule' objects.
+type TokenClaimValidationRuleListBuilder struct {
+	items []*TokenClaimValidationRuleBuilder
+}
+
+// NewTokenClaimValidationRuleList creates a new builder of 'token_claim_validation_rule' objects.
+func NewTokenClaimValidationRuleList() *TokenClaimValidationRuleListBuilder {
+	return new(TokenClaimValidationRuleListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *TokenClaimValidationRuleListBuilder) Items(values ...*TokenClaimValidationRuleBuilder) *TokenClaimValidationRuleListBuilder {
+	b.items = make([]*TokenClaimValidationRuleBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *TokenClaimValidationRuleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *TokenClaimValidationRuleListBuilder) Copy(list *TokenClaimValidationRuleList) *TokenClaimValidationRuleListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*TokenClaimValidationRuleBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewTokenClaimValidationRule().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'token_claim_validation_rule' objects using the
+// configuration stored in the builder.
+func (b *TokenClaimValidationRuleListBuilder) Build() (list *TokenClaimValidationRuleList, err error) {
+	items := make([]*TokenClaimValidationRule, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(TokenClaimValidationRuleList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_validation_rule_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_validation_rule_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalTokenClaimValidationRuleList writes a list of values of the 'token_claim_validation_rule' type to
+// the given writer.
+func MarshalTokenClaimValidationRuleList(list []*TokenClaimValidationRule, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteTokenClaimValidationRuleList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteTokenClaimValidationRuleList writes a list of value of the 'token_claim_validation_rule' type to
+// the given stream.
+func WriteTokenClaimValidationRuleList(list []*TokenClaimValidationRule, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteTokenClaimValidationRule(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalTokenClaimValidationRuleList reads a list of values of the 'token_claim_validation_rule' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalTokenClaimValidationRuleList(source interface{}) (items []*TokenClaimValidationRule, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadTokenClaimValidationRuleList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadTokenClaimValidationRuleList reads list of values of the ”token_claim_validation_rule' type from
+// the given iterator.
+func ReadTokenClaimValidationRuleList(iterator *jsoniter.Iterator) []*TokenClaimValidationRule {
+	list := []*TokenClaimValidationRule{}
+	for iterator.ReadArray() {
+		item := ReadTokenClaimValidationRule(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_validation_rule_type.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_validation_rule_type.go
@@ -1,0 +1,189 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenClaimValidationRule represents the values of the 'token_claim_validation_rule' type.
+//
+// The rule that is applied to validate token claims to authenticate users.
+type TokenClaimValidationRule struct {
+	bitmap_       uint32
+	claim         string
+	requiredValue string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *TokenClaimValidationRule) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Claim returns the value of the 'claim' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Claim is a name of a required claim.
+func (o *TokenClaimValidationRule) Claim() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.claim
+	}
+	return ""
+}
+
+// GetClaim returns the value of the 'claim' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Claim is a name of a required claim.
+func (o *TokenClaimValidationRule) GetClaim() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.claim
+	}
+	return
+}
+
+// RequiredValue returns the value of the 'required_value' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// RequiredValue is the required value for the claim.
+func (o *TokenClaimValidationRule) RequiredValue() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.requiredValue
+	}
+	return ""
+}
+
+// GetRequiredValue returns the value of the 'required_value' attribute and
+// a flag indicating if the attribute has a value.
+//
+// RequiredValue is the required value for the claim.
+func (o *TokenClaimValidationRule) GetRequiredValue() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.requiredValue
+	}
+	return
+}
+
+// TokenClaimValidationRuleListKind is the name of the type used to represent list of objects of
+// type 'token_claim_validation_rule'.
+const TokenClaimValidationRuleListKind = "TokenClaimValidationRuleList"
+
+// TokenClaimValidationRuleListLinkKind is the name of the type used to represent links to list
+// of objects of type 'token_claim_validation_rule'.
+const TokenClaimValidationRuleListLinkKind = "TokenClaimValidationRuleListLink"
+
+// TokenClaimValidationRuleNilKind is the name of the type used to nil lists of objects of
+// type 'token_claim_validation_rule'.
+const TokenClaimValidationRuleListNilKind = "TokenClaimValidationRuleListNil"
+
+// TokenClaimValidationRuleList is a list of values of the 'token_claim_validation_rule' type.
+type TokenClaimValidationRuleList struct {
+	href  string
+	link  bool
+	items []*TokenClaimValidationRule
+}
+
+// Len returns the length of the list.
+func (l *TokenClaimValidationRuleList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *TokenClaimValidationRuleList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *TokenClaimValidationRuleList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *TokenClaimValidationRuleList) SetItems(items []*TokenClaimValidationRule) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *TokenClaimValidationRuleList) Items() []*TokenClaimValidationRule {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *TokenClaimValidationRuleList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *TokenClaimValidationRuleList) Get(i int) *TokenClaimValidationRule {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *TokenClaimValidationRuleList) Slice() []*TokenClaimValidationRule {
+	var slice []*TokenClaimValidationRule
+	if l == nil {
+		slice = make([]*TokenClaimValidationRule, 0)
+	} else {
+		slice = make([]*TokenClaimValidationRule, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *TokenClaimValidationRuleList) Each(f func(item *TokenClaimValidationRule) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *TokenClaimValidationRuleList) Range(f func(index int, item *TokenClaimValidationRule) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/token_claim_validation_rule_type_json.go
+++ b/clientapi/arohcp/v1alpha1/token_claim_validation_rule_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalTokenClaimValidationRule writes a value of the 'token_claim_validation_rule' type to the given writer.
+func MarshalTokenClaimValidationRule(object *TokenClaimValidationRule, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteTokenClaimValidationRule(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteTokenClaimValidationRule writes a value of the 'token_claim_validation_rule' type to the given stream.
+func WriteTokenClaimValidationRule(object *TokenClaimValidationRule, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("claim")
+		stream.WriteString(object.claim)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("required_value")
+		stream.WriteString(object.requiredValue)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalTokenClaimValidationRule reads a value of the 'token_claim_validation_rule' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalTokenClaimValidationRule(source interface{}) (object *TokenClaimValidationRule, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadTokenClaimValidationRule(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadTokenClaimValidationRule reads a value of the 'token_claim_validation_rule' type from the given iterator.
+func ReadTokenClaimValidationRule(iterator *jsoniter.Iterator) *TokenClaimValidationRule {
+	object := &TokenClaimValidationRule{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "claim":
+			value := iterator.ReadString()
+			object.claim = value
+			object.bitmap_ |= 1
+		case "required_value":
+			value := iterator.ReadString()
+			object.requiredValue = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/token_issuer_builder.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_builder.go
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenIssuerBuilder contains the data and logic needed to build 'token_issuer' objects.
+//
+// Representation of a token issuer used in an external authentication.
+type TokenIssuerBuilder struct {
+	bitmap_   uint32
+	ca        string
+	url       string
+	audiences []string
+}
+
+// NewTokenIssuer creates a new builder of 'token_issuer' objects.
+func NewTokenIssuer() *TokenIssuerBuilder {
+	return &TokenIssuerBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *TokenIssuerBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// CA sets the value of the 'CA' attribute to the given value.
+func (b *TokenIssuerBuilder) CA(value string) *TokenIssuerBuilder {
+	b.ca = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// URL sets the value of the 'URL' attribute to the given value.
+func (b *TokenIssuerBuilder) URL(value string) *TokenIssuerBuilder {
+	b.url = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Audiences sets the value of the 'audiences' attribute to the given values.
+func (b *TokenIssuerBuilder) Audiences(values ...string) *TokenIssuerBuilder {
+	b.audiences = make([]string, len(values))
+	copy(b.audiences, values)
+	b.bitmap_ |= 4
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *TokenIssuerBuilder) Copy(object *TokenIssuer) *TokenIssuerBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.ca = object.ca
+	b.url = object.url
+	if object.audiences != nil {
+		b.audiences = make([]string, len(object.audiences))
+		copy(b.audiences, object.audiences)
+	} else {
+		b.audiences = nil
+	}
+	return b
+}
+
+// Build creates a 'token_issuer' object using the configuration stored in the builder.
+func (b *TokenIssuerBuilder) Build() (object *TokenIssuer, err error) {
+	object = new(TokenIssuer)
+	object.bitmap_ = b.bitmap_
+	object.ca = b.ca
+	object.url = b.url
+	if b.audiences != nil {
+		object.audiences = make([]string, len(b.audiences))
+		copy(object.audiences, b.audiences)
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/token_issuer_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenIssuerListBuilder contains the data and logic needed to build
+// 'token_issuer' objects.
+type TokenIssuerListBuilder struct {
+	items []*TokenIssuerBuilder
+}
+
+// NewTokenIssuerList creates a new builder of 'token_issuer' objects.
+func NewTokenIssuerList() *TokenIssuerListBuilder {
+	return new(TokenIssuerListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *TokenIssuerListBuilder) Items(values ...*TokenIssuerBuilder) *TokenIssuerListBuilder {
+	b.items = make([]*TokenIssuerBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *TokenIssuerListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *TokenIssuerListBuilder) Copy(list *TokenIssuerList) *TokenIssuerListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*TokenIssuerBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewTokenIssuer().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'token_issuer' objects using the
+// configuration stored in the builder.
+func (b *TokenIssuerListBuilder) Build() (list *TokenIssuerList, err error) {
+	items := make([]*TokenIssuer, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(TokenIssuerList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/token_issuer_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalTokenIssuerList writes a list of values of the 'token_issuer' type to
+// the given writer.
+func MarshalTokenIssuerList(list []*TokenIssuer, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteTokenIssuerList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteTokenIssuerList writes a list of value of the 'token_issuer' type to
+// the given stream.
+func WriteTokenIssuerList(list []*TokenIssuer, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteTokenIssuer(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalTokenIssuerList reads a list of values of the 'token_issuer' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalTokenIssuerList(source interface{}) (items []*TokenIssuer, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadTokenIssuerList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadTokenIssuerList reads list of values of the ”token_issuer' type from
+// the given iterator.
+func ReadTokenIssuerList(iterator *jsoniter.Iterator) []*TokenIssuer {
+	list := []*TokenIssuer{}
+	for iterator.ReadArray() {
+		item := ReadTokenIssuer(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/token_issuer_type.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_type.go
@@ -86,7 +86,8 @@ func (o *TokenIssuer) GetURL() (value string, ok bool) {
 // Audiences is an array of audiences that the token was issued for.
 // Valid tokens must include at least one of these values in their
 // "aud" claim.
-// Must be set to exactly one value.
+// Must have at least one audience and a maximum of ten.
+// Any clients defined for this external authentication must have their id included here.
 func (o *TokenIssuer) Audiences() []string {
 	if o != nil && o.bitmap_&4 != 0 {
 		return o.audiences
@@ -100,7 +101,8 @@ func (o *TokenIssuer) Audiences() []string {
 // Audiences is an array of audiences that the token was issued for.
 // Valid tokens must include at least one of these values in their
 // "aud" claim.
-// Must be set to exactly one value.
+// Must have at least one audience and a maximum of ten.
+// Any clients defined for this external authentication must have their id included here.
 func (o *TokenIssuer) GetAudiences() (value []string, ok bool) {
 	ok = o != nil && o.bitmap_&4 != 0
 	if ok {

--- a/clientapi/arohcp/v1alpha1/token_issuer_type.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_type.go
@@ -1,0 +1,219 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// TokenIssuer represents the values of the 'token_issuer' type.
+//
+// Representation of a token issuer used in an external authentication.
+type TokenIssuer struct {
+	bitmap_   uint32
+	ca        string
+	url       string
+	audiences []string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *TokenIssuer) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// CA returns the value of the 'CA' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Certificate bundle to use to validate server certificates for the configured URL.
+func (o *TokenIssuer) CA() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.ca
+	}
+	return ""
+}
+
+// GetCA returns the value of the 'CA' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Certificate bundle to use to validate server certificates for the configured URL.
+func (o *TokenIssuer) GetCA() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.ca
+	}
+	return
+}
+
+// URL returns the value of the 'URL' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// URL is the serving URL of the token issuer.
+func (o *TokenIssuer) URL() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.url
+	}
+	return ""
+}
+
+// GetURL returns the value of the 'URL' attribute and
+// a flag indicating if the attribute has a value.
+//
+// URL is the serving URL of the token issuer.
+func (o *TokenIssuer) GetURL() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.url
+	}
+	return
+}
+
+// Audiences returns the value of the 'audiences' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Audiences is an array of audiences that the token was issued for.
+// Valid tokens must include at least one of these values in their
+// "aud" claim.
+// Must be set to exactly one value.
+func (o *TokenIssuer) Audiences() []string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.audiences
+	}
+	return nil
+}
+
+// GetAudiences returns the value of the 'audiences' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Audiences is an array of audiences that the token was issued for.
+// Valid tokens must include at least one of these values in their
+// "aud" claim.
+// Must be set to exactly one value.
+func (o *TokenIssuer) GetAudiences() (value []string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.audiences
+	}
+	return
+}
+
+// TokenIssuerListKind is the name of the type used to represent list of objects of
+// type 'token_issuer'.
+const TokenIssuerListKind = "TokenIssuerList"
+
+// TokenIssuerListLinkKind is the name of the type used to represent links to list
+// of objects of type 'token_issuer'.
+const TokenIssuerListLinkKind = "TokenIssuerListLink"
+
+// TokenIssuerNilKind is the name of the type used to nil lists of objects of
+// type 'token_issuer'.
+const TokenIssuerListNilKind = "TokenIssuerListNil"
+
+// TokenIssuerList is a list of values of the 'token_issuer' type.
+type TokenIssuerList struct {
+	href  string
+	link  bool
+	items []*TokenIssuer
+}
+
+// Len returns the length of the list.
+func (l *TokenIssuerList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *TokenIssuerList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *TokenIssuerList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *TokenIssuerList) SetItems(items []*TokenIssuer) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *TokenIssuerList) Items() []*TokenIssuer {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *TokenIssuerList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *TokenIssuerList) Get(i int) *TokenIssuer {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *TokenIssuerList) Slice() []*TokenIssuer {
+	var slice []*TokenIssuer
+	if l == nil {
+		slice = make([]*TokenIssuer, 0)
+	} else {
+		slice = make([]*TokenIssuer, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *TokenIssuerList) Each(f func(item *TokenIssuer) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *TokenIssuerList) Range(f func(index int, item *TokenIssuer) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/token_issuer_type.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_type.go
@@ -61,6 +61,8 @@ func (o *TokenIssuer) GetCA() (value string, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // URL is the serving URL of the token issuer.
+// It must be a valid url and use the 'https' scheme.
+// This is required.
 func (o *TokenIssuer) URL() string {
 	if o != nil && o.bitmap_&2 != 0 {
 		return o.url
@@ -72,6 +74,8 @@ func (o *TokenIssuer) URL() string {
 // a flag indicating if the attribute has a value.
 //
 // URL is the serving URL of the token issuer.
+// It must be a valid url and use the 'https' scheme.
+// This is required.
 func (o *TokenIssuer) GetURL() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&2 != 0
 	if ok {

--- a/clientapi/arohcp/v1alpha1/token_issuer_type_json.go
+++ b/clientapi/arohcp/v1alpha1/token_issuer_type_json.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalTokenIssuer writes a value of the 'token_issuer' type to the given writer.
+func MarshalTokenIssuer(object *TokenIssuer, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteTokenIssuer(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteTokenIssuer writes a value of the 'token_issuer' type to the given stream.
+func WriteTokenIssuer(object *TokenIssuer, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("ca")
+		stream.WriteString(object.ca)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("url")
+		stream.WriteString(object.url)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0 && object.audiences != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("audiences")
+		WriteStringList(object.audiences, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalTokenIssuer reads a value of the 'token_issuer' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalTokenIssuer(source interface{}) (object *TokenIssuer, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadTokenIssuer(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadTokenIssuer reads a value of the 'token_issuer' type from the given iterator.
+func ReadTokenIssuer(iterator *jsoniter.Iterator) *TokenIssuer {
+	object := &TokenIssuer{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "ca":
+			value := iterator.ReadString()
+			object.ca = value
+			object.bitmap_ |= 1
+		case "url":
+			value := iterator.ReadString()
+			object.url = value
+			object.bitmap_ |= 2
+		case "audiences":
+			value := ReadStringList(iterator)
+			object.audiences = value
+			object.bitmap_ |= 4
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/username_claim_builder.go
+++ b/clientapi/arohcp/v1alpha1/username_claim_builder.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// UsernameClaimBuilder contains the data and logic needed to build 'username_claim' objects.
+//
+// The username claim mapping.
+type UsernameClaimBuilder struct {
+	bitmap_      uint32
+	claim        string
+	prefix       string
+	prefixPolicy string
+}
+
+// NewUsernameClaim creates a new builder of 'username_claim' objects.
+func NewUsernameClaim() *UsernameClaimBuilder {
+	return &UsernameClaimBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *UsernameClaimBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Claim sets the value of the 'claim' attribute to the given value.
+func (b *UsernameClaimBuilder) Claim(value string) *UsernameClaimBuilder {
+	b.claim = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Prefix sets the value of the 'prefix' attribute to the given value.
+func (b *UsernameClaimBuilder) Prefix(value string) *UsernameClaimBuilder {
+	b.prefix = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// PrefixPolicy sets the value of the 'prefix_policy' attribute to the given value.
+func (b *UsernameClaimBuilder) PrefixPolicy(value string) *UsernameClaimBuilder {
+	b.prefixPolicy = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *UsernameClaimBuilder) Copy(object *UsernameClaim) *UsernameClaimBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.claim = object.claim
+	b.prefix = object.prefix
+	b.prefixPolicy = object.prefixPolicy
+	return b
+}
+
+// Build creates a 'username_claim' object using the configuration stored in the builder.
+func (b *UsernameClaimBuilder) Build() (object *UsernameClaim, err error) {
+	object = new(UsernameClaim)
+	object.bitmap_ = b.bitmap_
+	object.claim = b.claim
+	object.prefix = b.prefix
+	object.prefixPolicy = b.prefixPolicy
+	return
+}

--- a/clientapi/arohcp/v1alpha1/username_claim_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/username_claim_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// UsernameClaimListBuilder contains the data and logic needed to build
+// 'username_claim' objects.
+type UsernameClaimListBuilder struct {
+	items []*UsernameClaimBuilder
+}
+
+// NewUsernameClaimList creates a new builder of 'username_claim' objects.
+func NewUsernameClaimList() *UsernameClaimListBuilder {
+	return new(UsernameClaimListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *UsernameClaimListBuilder) Items(values ...*UsernameClaimBuilder) *UsernameClaimListBuilder {
+	b.items = make([]*UsernameClaimBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *UsernameClaimListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *UsernameClaimListBuilder) Copy(list *UsernameClaimList) *UsernameClaimListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*UsernameClaimBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewUsernameClaim().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'username_claim' objects using the
+// configuration stored in the builder.
+func (b *UsernameClaimListBuilder) Build() (list *UsernameClaimList, err error) {
+	items := make([]*UsernameClaim, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(UsernameClaimList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/username_claim_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/username_claim_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalUsernameClaimList writes a list of values of the 'username_claim' type to
+// the given writer.
+func MarshalUsernameClaimList(list []*UsernameClaim, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteUsernameClaimList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteUsernameClaimList writes a list of value of the 'username_claim' type to
+// the given stream.
+func WriteUsernameClaimList(list []*UsernameClaim, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteUsernameClaim(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalUsernameClaimList reads a list of values of the 'username_claim' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalUsernameClaimList(source interface{}) (items []*UsernameClaim, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadUsernameClaimList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadUsernameClaimList reads list of values of the ”username_claim' type from
+// the given iterator.
+func ReadUsernameClaimList(iterator *jsoniter.Iterator) []*UsernameClaim {
+	list := []*UsernameClaim{}
+	for iterator.ReadArray() {
+		item := ReadUsernameClaim(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/username_claim_type.go
+++ b/clientapi/arohcp/v1alpha1/username_claim_type.go
@@ -89,6 +89,8 @@ func (o *UsernameClaim) GetPrefix() (value string, ok bool) {
 // prevent naming clashes with other plugins.
 //
 // Set to "NoPrefix" to disable prefixing.
+//
+// If a prefix is defined, this will be set to 'Prefix' by default.
 func (o *UsernameClaim) PrefixPolicy() string {
 	if o != nil && o.bitmap_&4 != 0 {
 		return o.prefixPolicy
@@ -105,6 +107,8 @@ func (o *UsernameClaim) PrefixPolicy() string {
 // prevent naming clashes with other plugins.
 //
 // Set to "NoPrefix" to disable prefixing.
+//
+// If a prefix is defined, this will be set to 'Prefix' by default.
 func (o *UsernameClaim) GetPrefixPolicy() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&4 != 0
 	if ok {

--- a/clientapi/arohcp/v1alpha1/username_claim_type.go
+++ b/clientapi/arohcp/v1alpha1/username_claim_type.go
@@ -1,0 +1,223 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// UsernameClaim represents the values of the 'username_claim' type.
+//
+// The username claim mapping.
+type UsernameClaim struct {
+	bitmap_      uint32
+	claim        string
+	prefix       string
+	prefixPolicy string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *UsernameClaim) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Claim returns the value of the 'claim' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The claim used in the token.
+func (o *UsernameClaim) Claim() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.claim
+	}
+	return ""
+}
+
+// GetClaim returns the value of the 'claim' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The claim used in the token.
+func (o *UsernameClaim) GetClaim() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.claim
+	}
+	return
+}
+
+// Prefix returns the value of the 'prefix' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A prefix contatenated in the claim (Optional).
+func (o *UsernameClaim) Prefix() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.prefix
+	}
+	return ""
+}
+
+// GetPrefix returns the value of the 'prefix' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A prefix contatenated in the claim (Optional).
+func (o *UsernameClaim) GetPrefix() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.prefix
+	}
+	return
+}
+
+// PrefixPolicy returns the value of the 'prefix_policy' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// PrefixPolicy specifies how a prefix should apply.
+//
+// By default, claims other than `email` will be prefixed with the issuer URL to
+// prevent naming clashes with other plugins.
+//
+// Set to "NoPrefix" to disable prefixing.
+func (o *UsernameClaim) PrefixPolicy() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.prefixPolicy
+	}
+	return ""
+}
+
+// GetPrefixPolicy returns the value of the 'prefix_policy' attribute and
+// a flag indicating if the attribute has a value.
+//
+// PrefixPolicy specifies how a prefix should apply.
+//
+// By default, claims other than `email` will be prefixed with the issuer URL to
+// prevent naming clashes with other plugins.
+//
+// Set to "NoPrefix" to disable prefixing.
+func (o *UsernameClaim) GetPrefixPolicy() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.prefixPolicy
+	}
+	return
+}
+
+// UsernameClaimListKind is the name of the type used to represent list of objects of
+// type 'username_claim'.
+const UsernameClaimListKind = "UsernameClaimList"
+
+// UsernameClaimListLinkKind is the name of the type used to represent links to list
+// of objects of type 'username_claim'.
+const UsernameClaimListLinkKind = "UsernameClaimListLink"
+
+// UsernameClaimNilKind is the name of the type used to nil lists of objects of
+// type 'username_claim'.
+const UsernameClaimListNilKind = "UsernameClaimListNil"
+
+// UsernameClaimList is a list of values of the 'username_claim' type.
+type UsernameClaimList struct {
+	href  string
+	link  bool
+	items []*UsernameClaim
+}
+
+// Len returns the length of the list.
+func (l *UsernameClaimList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *UsernameClaimList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *UsernameClaimList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *UsernameClaimList) SetItems(items []*UsernameClaim) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *UsernameClaimList) Items() []*UsernameClaim {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *UsernameClaimList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *UsernameClaimList) Get(i int) *UsernameClaim {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *UsernameClaimList) Slice() []*UsernameClaim {
+	var slice []*UsernameClaim
+	if l == nil {
+		slice = make([]*UsernameClaim, 0)
+	} else {
+		slice = make([]*UsernameClaim, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *UsernameClaimList) Each(f func(item *UsernameClaim) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *UsernameClaimList) Range(f func(index int, item *UsernameClaim) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/username_claim_type_json.go
+++ b/clientapi/arohcp/v1alpha1/username_claim_type_json.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalUsernameClaim writes a value of the 'username_claim' type to the given writer.
+func MarshalUsernameClaim(object *UsernameClaim, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteUsernameClaim(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteUsernameClaim writes a value of the 'username_claim' type to the given stream.
+func WriteUsernameClaim(object *UsernameClaim, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("claim")
+		stream.WriteString(object.claim)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("prefix")
+		stream.WriteString(object.prefix)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("prefix_policy")
+		stream.WriteString(object.prefixPolicy)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalUsernameClaim reads a value of the 'username_claim' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalUsernameClaim(source interface{}) (object *UsernameClaim, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadUsernameClaim(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadUsernameClaim reads a value of the 'username_claim' type from the given iterator.
+func ReadUsernameClaim(iterator *jsoniter.Iterator) *UsernameClaim {
+	object := &UsernameClaim{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "claim":
+			value := iterator.ReadString()
+			object.claim = value
+			object.bitmap_ |= 1
+		case "prefix":
+			value := iterator.ReadString()
+			object.prefix = value
+			object.bitmap_ |= 2
+		case "prefix_policy":
+			value := iterator.ReadString()
+			object.prefixPolicy = value
+			object.bitmap_ |= 4
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/cluster_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_builder.go
@@ -419,7 +419,7 @@ func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 
 // ExternalAuthConfig sets the value of the 'external_auth_config' attribute to the given value.
 //
-// ExternalAuthConfig configuration
+// Represents an external authentication configuration
 func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *ClusterBuilder {
 	b.externalAuthConfig = value
 	if value != nil {

--- a/clientapi/clustersmgmt/v1/cluster_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_type.go
@@ -793,7 +793,10 @@ func (o *Cluster) GetExternalID() (value string, ok bool) {
 // ExternalAuthConfig returns the value of the 'external_auth_config' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// External authentication configuration
+// External authentication configuration.
+//
+// For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
+// For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 	if o != nil && o.bitmap_&268435456 != 0 {
 		return o.externalAuthConfig
@@ -804,7 +807,10 @@ func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 // GetExternalAuthConfig returns the value of the 'external_auth_config' attribute and
 // a flag indicating if the attribute has a value.
 //
-// External authentication configuration
+// External authentication configuration.
+//
+// For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
+// For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
 	ok = o != nil && o.bitmap_&268435456 != 0
 	if ok {

--- a/clientapi/clustersmgmt/v1/external_auth_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_builder.go
@@ -29,6 +29,7 @@ type ExternalAuthBuilder struct {
 	claim   *ExternalAuthClaimBuilder
 	clients []*ExternalAuthClientConfigBuilder
 	issuer  *TokenIssuerBuilder
+	status  *ExternalAuthStatusBuilder
 }
 
 // NewExternalAuth creates a new builder of 'external_auth' objects.
@@ -95,6 +96,19 @@ func (b *ExternalAuthBuilder) Issuer(value *TokenIssuerBuilder) *ExternalAuthBui
 	return b
 }
 
+// Status sets the value of the 'status' attribute to the given value.
+//
+// Representation of the status of an external authentication provider.
+func (b *ExternalAuthBuilder) Status(value *ExternalAuthStatusBuilder) *ExternalAuthBuilder {
+	b.status = value
+	if value != nil {
+		b.bitmap_ |= 64
+	} else {
+		b.bitmap_ &^= 64
+	}
+	return b
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *ExternalAuthBuilder) Copy(object *ExternalAuth) *ExternalAuthBuilder {
 	if object == nil {
@@ -120,6 +134,11 @@ func (b *ExternalAuthBuilder) Copy(object *ExternalAuth) *ExternalAuthBuilder {
 		b.issuer = NewTokenIssuer().Copy(object.issuer)
 	} else {
 		b.issuer = nil
+	}
+	if object.status != nil {
+		b.status = NewExternalAuthStatus().Copy(object.status)
+	} else {
+		b.status = nil
 	}
 	return b
 }
@@ -147,6 +166,12 @@ func (b *ExternalAuthBuilder) Build() (object *ExternalAuth, err error) {
 	}
 	if b.issuer != nil {
 		object.issuer, err = b.issuer.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.status != nil {
+		object.status, err = b.status.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/clustersmgmt/v1/external_auth_client_config_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_config_builder.go
@@ -29,6 +29,7 @@ type ExternalAuthClientConfigBuilder struct {
 	component   *ClientComponentBuilder
 	extraScopes []string
 	secret      string
+	type_       ExternalAuthClientType
 }
 
 // NewExternalAuthClientConfig creates a new builder of 'external_auth_client_config' objects.
@@ -76,6 +77,15 @@ func (b *ExternalAuthClientConfigBuilder) Secret(value string) *ExternalAuthClie
 	return b
 }
 
+// Type sets the value of the 'type' attribute to the given value.
+//
+// Representation of the possible values of an external authentication client's type
+func (b *ExternalAuthClientConfigBuilder) Type(value ExternalAuthClientType) *ExternalAuthClientConfigBuilder {
+	b.type_ = value
+	b.bitmap_ |= 16
+	return b
+}
+
 // Copy copies the attributes of the given object into this builder, discarding any previous values.
 func (b *ExternalAuthClientConfigBuilder) Copy(object *ExternalAuthClientConfig) *ExternalAuthClientConfigBuilder {
 	if object == nil {
@@ -95,6 +105,7 @@ func (b *ExternalAuthClientConfigBuilder) Copy(object *ExternalAuthClientConfig)
 		b.extraScopes = nil
 	}
 	b.secret = object.secret
+	b.type_ = object.type_
 	return b
 }
 
@@ -114,5 +125,6 @@ func (b *ExternalAuthClientConfigBuilder) Build() (object *ExternalAuthClientCon
 		copy(object.extraScopes, b.extraScopes)
 	}
 	object.secret = b.secret
+	object.type_ = b.type_
 	return
 }

--- a/clientapi/clustersmgmt/v1/external_auth_client_config_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_config_type.go
@@ -41,6 +41,8 @@ func (o *ExternalAuthClientConfig) Empty() bool {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The identifier of the OIDC client from the OIDC provider.
+// This is required.
+// Must be at least one character length.
 func (o *ExternalAuthClientConfig) ID() string {
 	if o != nil && o.bitmap_&1 != 0 {
 		return o.id
@@ -52,6 +54,8 @@ func (o *ExternalAuthClientConfig) ID() string {
 // a flag indicating if the attribute has a value.
 //
 // The identifier of the OIDC client from the OIDC provider.
+// This is required.
+// Must be at least one character length.
 func (o *ExternalAuthClientConfig) GetID() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&1 != 0
 	if ok {
@@ -140,7 +144,7 @@ func (o *ExternalAuthClientConfig) GetSecret() (value string, ok bool) {
 //
 // Determines the OIDC provider client type.
 //
-// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+// This is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.
 //
 // For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
 // 'secret' property in the client configuration.
@@ -158,7 +162,7 @@ func (o *ExternalAuthClientConfig) Type() ExternalAuthClientType {
 //
 // Determines the OIDC provider client type.
 //
-// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+// This is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.
 //
 // For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
 // 'secret' property in the client configuration.

--- a/clientapi/clustersmgmt/v1/external_auth_client_config_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_config_type.go
@@ -29,6 +29,7 @@ type ExternalAuthClientConfig struct {
 	component   *ClientComponent
 	extraScopes []string
 	secret      string
+	type_       ExternalAuthClientType
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -109,6 +110,9 @@ func (o *ExternalAuthClientConfig) GetExtraScopes() (value []string, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The secret of the OIDC client from the OIDC provider.
+// The client is considered 'public' if no secret is specified. Otherwise, it is considered
+// as a 'confidential' client.
+// This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
 func (o *ExternalAuthClientConfig) Secret() string {
 	if o != nil && o.bitmap_&8 != 0 {
 		return o.secret
@@ -120,10 +124,50 @@ func (o *ExternalAuthClientConfig) Secret() string {
 // a flag indicating if the attribute has a value.
 //
 // The secret of the OIDC client from the OIDC provider.
+// The client is considered 'public' if no secret is specified. Otherwise, it is considered
+// as a 'confidential' client.
+// This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
 func (o *ExternalAuthClientConfig) GetSecret() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&8 != 0
 	if ok {
 		value = o.secret
+	}
+	return
+}
+
+// Type returns the value of the 'type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Determines the OIDC provider client type.
+//
+// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+//
+// For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
+// 'secret' property in the client configuration.
+//   - If the 'secret' property is set, the type of the client is 'confidential.
+//   - If the 'secret' property is not set, the type of the client is 'public.
+func (o *ExternalAuthClientConfig) Type() ExternalAuthClientType {
+	if o != nil && o.bitmap_&16 != 0 {
+		return o.type_
+	}
+	return ExternalAuthClientType("")
+}
+
+// GetType returns the value of the 'type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Determines the OIDC provider client type.
+//
+// This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+//
+// For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the
+// 'secret' property in the client configuration.
+//   - If the 'secret' property is set, the type of the client is 'confidential.
+//   - If the 'secret' property is not set, the type of the client is 'public.
+func (o *ExternalAuthClientConfig) GetType() (value ExternalAuthClientType, ok bool) {
+	ok = o != nil && o.bitmap_&16 != 0
+	if ok {
+		value = o.type_
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/external_auth_client_config_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_config_type_json.go
@@ -76,6 +76,15 @@ func WriteExternalAuthClientConfig(object *ExternalAuthClientConfig, stream *jso
 		}
 		stream.WriteObjectField("secret")
 		stream.WriteString(object.secret)
+		count++
+	}
+	present_ = object.bitmap_&16 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("type")
+		stream.WriteString(string(object.type_))
 	}
 	stream.WriteObjectEnd()
 }
@@ -117,6 +126,11 @@ func ReadExternalAuthClientConfig(iterator *jsoniter.Iterator) *ExternalAuthClie
 			value := iterator.ReadString()
 			object.secret = value
 			object.bitmap_ |= 8
+		case "type":
+			text := iterator.ReadString()
+			value := ExternalAuthClientType(text)
+			object.type_ = value
+			object.bitmap_ |= 16
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/external_auth_client_type_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_type_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthClientTypeList writes a list of values of the 'external_auth_client_type' type to
+// the given writer.
+func MarshalExternalAuthClientTypeList(list []ExternalAuthClientType, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthClientTypeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthClientTypeList writes a list of value of the 'external_auth_client_type' type to
+// the given stream.
+func WriteExternalAuthClientTypeList(list []ExternalAuthClientType, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthClientTypeList reads a list of values of the 'external_auth_client_type' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthClientTypeList(source interface{}) (items []ExternalAuthClientType, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthClientTypeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthClientTypeList reads list of values of the ”external_auth_client_type' type from
+// the given iterator.
+func ReadExternalAuthClientTypeList(iterator *jsoniter.Iterator) []ExternalAuthClientType {
+	list := []ExternalAuthClientType{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := ExternalAuthClientType(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/external_auth_client_type_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_type_type.go
@@ -1,0 +1,37 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ExternalAuthClientType represents the values of the 'external_auth_client_type' enumerated type.
+type ExternalAuthClientType string
+
+const (
+	// Indicates that the client is confidential.
+	//
+	// Confidential clients must provide a client secret.
+	// For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
+	// in the 'secret' property of the client configuration.
+	// For those belonging to an ARO HCP cluster, the secret should be provided within the cluster itself.
+	ExternalAuthClientTypeConfidential ExternalAuthClientType = "confidential"
+	// Indicates that the client is public
+	//
+	// Public clients must not provide a client secret
+	ExternalAuthClientTypePublic ExternalAuthClientType = "public"
+)

--- a/clientapi/clustersmgmt/v1/external_auth_client_type_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_client_type_type.go
@@ -28,7 +28,7 @@ const (
 	// Confidential clients must provide a client secret.
 	// For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
 	// in the 'secret' property of the client configuration.
-	// For those belonging to an ARO HCP cluster, the secret should be provided within the cluster itself.
+	// For those belonging to an ARO-HCP cluster, the secret should be provided within the cluster itself.
 	ExternalAuthClientTypeConfidential ExternalAuthClientType = "confidential"
 	// Indicates that the client is public
 	//

--- a/clientapi/clustersmgmt/v1/external_auth_config_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_config_builder.go
@@ -21,10 +21,13 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 
 // ExternalAuthConfigBuilder contains the data and logic needed to build 'external_auth_config' objects.
 //
-// ExternalAuthConfig configuration
+// Represents an external authentication configuration
 type ExternalAuthConfigBuilder struct {
 	bitmap_       uint32
+	id            string
+	href          string
 	externalAuths *ExternalAuthListBuilder
+	state         ExternalAuthConfigState
 	enabled       bool
 }
 
@@ -33,22 +36,51 @@ func NewExternalAuthConfig() *ExternalAuthConfigBuilder {
 	return &ExternalAuthConfigBuilder{}
 }
 
+// Link sets the flag that indicates if this is a link.
+func (b *ExternalAuthConfigBuilder) Link(value bool) *ExternalAuthConfigBuilder {
+	b.bitmap_ |= 1
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *ExternalAuthConfigBuilder) ID(value string) *ExternalAuthConfigBuilder {
+	b.id = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *ExternalAuthConfigBuilder) HREF(value string) *ExternalAuthConfigBuilder {
+	b.href = value
+	b.bitmap_ |= 4
+	return b
+}
+
 // Empty returns true if the builder is empty, i.e. no attribute has a value.
 func (b *ExternalAuthConfigBuilder) Empty() bool {
-	return b == nil || b.bitmap_ == 0
+	return b == nil || b.bitmap_&^1 == 0
 }
 
 // Enabled sets the value of the 'enabled' attribute to the given value.
 func (b *ExternalAuthConfigBuilder) Enabled(value bool) *ExternalAuthConfigBuilder {
 	b.enabled = value
-	b.bitmap_ |= 1
+	b.bitmap_ |= 8
 	return b
 }
 
 // ExternalAuths sets the value of the 'external_auths' attribute to the given values.
 func (b *ExternalAuthConfigBuilder) ExternalAuths(value *ExternalAuthListBuilder) *ExternalAuthConfigBuilder {
 	b.externalAuths = value
-	b.bitmap_ |= 2
+	b.bitmap_ |= 16
+	return b
+}
+
+// State sets the value of the 'state' attribute to the given value.
+//
+// Representation of the possible values for the state field of an external authentication configuration
+func (b *ExternalAuthConfigBuilder) State(value ExternalAuthConfigState) *ExternalAuthConfigBuilder {
+	b.state = value
+	b.bitmap_ |= 32
 	return b
 }
 
@@ -58,18 +90,23 @@ func (b *ExternalAuthConfigBuilder) Copy(object *ExternalAuthConfig) *ExternalAu
 		return b
 	}
 	b.bitmap_ = object.bitmap_
+	b.id = object.id
+	b.href = object.href
 	b.enabled = object.enabled
 	if object.externalAuths != nil {
 		b.externalAuths = NewExternalAuthList().Copy(object.externalAuths)
 	} else {
 		b.externalAuths = nil
 	}
+	b.state = object.state
 	return b
 }
 
 // Build creates a 'external_auth_config' object using the configuration stored in the builder.
 func (b *ExternalAuthConfigBuilder) Build() (object *ExternalAuthConfig, err error) {
 	object = new(ExternalAuthConfig)
+	object.id = b.id
+	object.href = b.href
 	object.bitmap_ = b.bitmap_
 	object.enabled = b.enabled
 	if b.externalAuths != nil {
@@ -78,5 +115,6 @@ func (b *ExternalAuthConfigBuilder) Build() (object *ExternalAuthConfig, err err
 			return
 		}
 	}
+	object.state = b.state
 	return
 }

--- a/clientapi/clustersmgmt/v1/external_auth_config_state_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_config_state_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthConfigStateList writes a list of values of the 'external_auth_config_state' type to
+// the given writer.
+func MarshalExternalAuthConfigStateList(list []ExternalAuthConfigState, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthConfigStateList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthConfigStateList writes a list of value of the 'external_auth_config_state' type to
+// the given stream.
+func WriteExternalAuthConfigStateList(list []ExternalAuthConfigState, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthConfigStateList reads a list of values of the 'external_auth_config_state' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthConfigStateList(source interface{}) (items []ExternalAuthConfigState, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthConfigStateList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthConfigStateList reads list of values of the ”external_auth_config_state' type from
+// the given iterator.
+func ReadExternalAuthConfigStateList(iterator *jsoniter.Iterator) []ExternalAuthConfigState {
+	list := []ExternalAuthConfigState{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := ExternalAuthConfigState(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/external_auth_config_state_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_config_state_type.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ExternalAuthConfigState represents the values of the 'external_auth_config_state' enumerated type.
+type ExternalAuthConfigState string
+
+const (
+	// Indicates that the cluster does not support configuration of external authentication providers
+	ExternalAuthConfigStateDisabled ExternalAuthConfigState = "disabled"
+	// Indicates that the cluster supports configuration of external authentication providers
+	ExternalAuthConfigStateEnabled ExternalAuthConfigState = "enabled"
+)

--- a/clientapi/clustersmgmt/v1/external_auth_config_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_config_type.go
@@ -19,31 +19,100 @@ limitations under the License.
 
 package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
 
+// ExternalAuthConfigKind is the name of the type used to represent objects
+// of type 'external_auth_config'.
+const ExternalAuthConfigKind = "ExternalAuthConfig"
+
+// ExternalAuthConfigLinkKind is the name of the type used to represent links
+// to objects of type 'external_auth_config'.
+const ExternalAuthConfigLinkKind = "ExternalAuthConfigLink"
+
+// ExternalAuthConfigNilKind is the name of the type used to nil references
+// to objects of type 'external_auth_config'.
+const ExternalAuthConfigNilKind = "ExternalAuthConfigNil"
+
 // ExternalAuthConfig represents the values of the 'external_auth_config' type.
 //
-// ExternalAuthConfig configuration
+// Represents an external authentication configuration
 type ExternalAuthConfig struct {
 	bitmap_       uint32
+	id            string
+	href          string
 	externalAuths *ExternalAuthList
+	state         ExternalAuthConfigState
 	enabled       bool
+}
+
+// Kind returns the name of the type of the object.
+func (o *ExternalAuthConfig) Kind() string {
+	if o == nil {
+		return ExternalAuthConfigNilKind
+	}
+	if o.bitmap_&1 != 0 {
+		return ExternalAuthConfigLinkKind
+	}
+	return ExternalAuthConfigKind
+}
+
+// Link returns true if this is a link.
+func (o *ExternalAuthConfig) Link() bool {
+	return o != nil && o.bitmap_&1 != 0
+}
+
+// ID returns the identifier of the object.
+func (o *ExternalAuthConfig) ID() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *ExternalAuthConfig) GetID() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *ExternalAuthConfig) HREF() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *ExternalAuthConfig) GetHREF() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.href
+	}
+	return
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
 func (o *ExternalAuthConfig) Empty() bool {
-	return o == nil || o.bitmap_ == 0
+	return o == nil || o.bitmap_&^1 == 0
 }
 
 // Enabled returns the value of the 'enabled' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// Boolean flag indicating if the cluster should use an external authentication configuration.
+// Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
 //
 // By default this is false.
 //
 // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
 // to have the `external-authentication` feature toggle enabled.
+//
+// For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
 func (o *ExternalAuthConfig) Enabled() bool {
-	if o != nil && o.bitmap_&1 != 0 {
+	if o != nil && o.bitmap_&8 != 0 {
 		return o.enabled
 	}
 	return false
@@ -52,14 +121,16 @@ func (o *ExternalAuthConfig) Enabled() bool {
 // GetEnabled returns the value of the 'enabled' attribute and
 // a flag indicating if the attribute has a value.
 //
-// Boolean flag indicating if the cluster should use an external authentication configuration.
+// Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
 //
 // By default this is false.
 //
 // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
 // to have the `external-authentication` feature toggle enabled.
+//
+// For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
 func (o *ExternalAuthConfig) GetEnabled() (value bool, ok bool) {
-	ok = o != nil && o.bitmap_&1 != 0
+	ok = o != nil && o.bitmap_&8 != 0
 	if ok {
 		value = o.enabled
 	}
@@ -68,8 +139,12 @@ func (o *ExternalAuthConfig) GetEnabled() (value bool, ok bool) {
 
 // ExternalAuths returns the value of the 'external_auths' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
+//
+// A list of external authentication providers configured for the cluster.
+//
+// Only one external authentication provider can be configured.
 func (o *ExternalAuthConfig) ExternalAuths() *ExternalAuthList {
-	if o != nil && o.bitmap_&2 != 0 {
+	if o != nil && o.bitmap_&16 != 0 {
 		return o.externalAuths
 	}
 	return nil
@@ -77,10 +152,45 @@ func (o *ExternalAuthConfig) ExternalAuths() *ExternalAuthList {
 
 // GetExternalAuths returns the value of the 'external_auths' attribute and
 // a flag indicating if the attribute has a value.
+//
+// A list of external authentication providers configured for the cluster.
+//
+// Only one external authentication provider can be configured.
 func (o *ExternalAuthConfig) GetExternalAuths() (value *ExternalAuthList, ok bool) {
-	ok = o != nil && o.bitmap_&2 != 0
+	ok = o != nil && o.bitmap_&16 != 0
 	if ok {
 		value = o.externalAuths
+	}
+	return
+}
+
+// State returns the value of the 'state' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+//
+// For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+//
+// FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+func (o *ExternalAuthConfig) State() ExternalAuthConfigState {
+	if o != nil && o.bitmap_&32 != 0 {
+		return o.state
+	}
+	return ExternalAuthConfigState("")
+}
+
+// GetState returns the value of the 'state' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+//
+// For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+//
+// FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+func (o *ExternalAuthConfig) GetState() (value ExternalAuthConfigState, ok bool) {
+	ok = o != nil && o.bitmap_&32 != 0
+	if ok {
+		value = o.state
 	}
 	return
 }
@@ -102,6 +212,40 @@ type ExternalAuthConfigList struct {
 	href  string
 	link  bool
 	items []*ExternalAuthConfig
+}
+
+// Kind returns the name of the type of the object.
+func (l *ExternalAuthConfigList) Kind() string {
+	if l == nil {
+		return ExternalAuthConfigListNilKind
+	}
+	if l.link {
+		return ExternalAuthConfigListLinkKind
+	}
+	return ExternalAuthConfigListKind
+}
+
+// Link returns true iif this is a link.
+func (l *ExternalAuthConfigList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *ExternalAuthConfigList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *ExternalAuthConfigList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
 }
 
 // Len returns the length of the list.

--- a/clientapi/clustersmgmt/v1/external_auth_config_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_config_type_json.go
@@ -41,8 +41,31 @@ func MarshalExternalAuthConfig(object *ExternalAuthConfig, writer io.Writer) err
 func WriteExternalAuthConfig(object *ExternalAuthConfig, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
+	stream.WriteObjectField("kind")
+	if object.bitmap_&1 != 0 {
+		stream.WriteString(ExternalAuthConfigLinkKind)
+	} else {
+		stream.WriteString(ExternalAuthConfigKind)
+	}
+	count++
+	if object.bitmap_&2 != 0 {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	if object.bitmap_&4 != 0 {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
 	var present_ bool
-	present_ = object.bitmap_&1 != 0
+	present_ = object.bitmap_&8 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -51,7 +74,7 @@ func WriteExternalAuthConfig(object *ExternalAuthConfig, stream *jsoniter.Stream
 		stream.WriteBool(object.enabled)
 		count++
 	}
-	present_ = object.bitmap_&2 != 0 && object.externalAuths != nil
+	present_ = object.bitmap_&16 != 0 && object.externalAuths != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -61,6 +84,15 @@ func WriteExternalAuthConfig(object *ExternalAuthConfig, stream *jsoniter.Stream
 		stream.WriteObjectField("items")
 		WriteExternalAuthList(object.externalAuths.Items(), stream)
 		stream.WriteObjectEnd()
+		count++
+	}
+	present_ = object.bitmap_&32 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("state")
+		stream.WriteString(string(object.state))
 	}
 	stream.WriteObjectEnd()
 }
@@ -86,10 +118,21 @@ func ReadExternalAuthConfig(iterator *jsoniter.Iterator) *ExternalAuthConfig {
 			break
 		}
 		switch field {
+		case "kind":
+			value := iterator.ReadString()
+			if value == ExternalAuthConfigLinkKind {
+				object.bitmap_ |= 1
+			}
+		case "id":
+			object.id = iterator.ReadString()
+			object.bitmap_ |= 2
+		case "href":
+			object.href = iterator.ReadString()
+			object.bitmap_ |= 4
 		case "enabled":
 			value := iterator.ReadBool()
 			object.enabled = value
-			object.bitmap_ |= 1
+			object.bitmap_ |= 8
 		case "external_auths":
 			value := &ExternalAuthList{}
 			for {
@@ -110,7 +153,12 @@ func ReadExternalAuthConfig(iterator *jsoniter.Iterator) *ExternalAuthConfig {
 				}
 			}
 			object.externalAuths = value
-			object.bitmap_ |= 2
+			object.bitmap_ |= 16
+		case "state":
+			text := iterator.ReadString()
+			value := ExternalAuthConfigState(text)
+			object.state = value
+			object.bitmap_ |= 32
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/external_auth_state_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_state_builder.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	time "time"
+)
+
+// ExternalAuthStateBuilder contains the data and logic needed to build 'external_auth_state' objects.
+//
+// Representation of the state of an external authentication provider.
+type ExternalAuthStateBuilder struct {
+	bitmap_              uint32
+	lastUpdatedTimestamp time.Time
+	value                string
+}
+
+// NewExternalAuthState creates a new builder of 'external_auth_state' objects.
+func NewExternalAuthState() *ExternalAuthStateBuilder {
+	return &ExternalAuthStateBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthStateBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// LastUpdatedTimestamp sets the value of the 'last_updated_timestamp' attribute to the given value.
+func (b *ExternalAuthStateBuilder) LastUpdatedTimestamp(value time.Time) *ExternalAuthStateBuilder {
+	b.lastUpdatedTimestamp = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Value sets the value of the 'value' attribute to the given value.
+func (b *ExternalAuthStateBuilder) Value(value string) *ExternalAuthStateBuilder {
+	b.value = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthStateBuilder) Copy(object *ExternalAuthState) *ExternalAuthStateBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.lastUpdatedTimestamp = object.lastUpdatedTimestamp
+	b.value = object.value
+	return b
+}
+
+// Build creates a 'external_auth_state' object using the configuration stored in the builder.
+func (b *ExternalAuthStateBuilder) Build() (object *ExternalAuthState, err error) {
+	object = new(ExternalAuthState)
+	object.bitmap_ = b.bitmap_
+	object.lastUpdatedTimestamp = b.lastUpdatedTimestamp
+	object.value = b.value
+	return
+}

--- a/clientapi/clustersmgmt/v1/external_auth_state_list_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_state_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ExternalAuthStateListBuilder contains the data and logic needed to build
+// 'external_auth_state' objects.
+type ExternalAuthStateListBuilder struct {
+	items []*ExternalAuthStateBuilder
+}
+
+// NewExternalAuthStateList creates a new builder of 'external_auth_state' objects.
+func NewExternalAuthStateList() *ExternalAuthStateListBuilder {
+	return new(ExternalAuthStateListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthStateListBuilder) Items(values ...*ExternalAuthStateBuilder) *ExternalAuthStateListBuilder {
+	b.items = make([]*ExternalAuthStateBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthStateListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthStateListBuilder) Copy(list *ExternalAuthStateList) *ExternalAuthStateListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthStateBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuthState().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth_state' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthStateListBuilder) Build() (list *ExternalAuthStateList, err error) {
+	items := make([]*ExternalAuthState, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthStateList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/external_auth_state_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_state_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthStateList writes a list of values of the 'external_auth_state' type to
+// the given writer.
+func MarshalExternalAuthStateList(list []*ExternalAuthState, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthStateList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthStateList writes a list of value of the 'external_auth_state' type to
+// the given stream.
+func WriteExternalAuthStateList(list []*ExternalAuthState, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuthState(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthStateList reads a list of values of the 'external_auth_state' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthStateList(source interface{}) (items []*ExternalAuthState, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthStateList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthStateList reads list of values of the ”external_auth_state' type from
+// the given iterator.
+func ReadExternalAuthStateList(iterator *jsoniter.Iterator) []*ExternalAuthState {
+	list := []*ExternalAuthState{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuthState(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/external_auth_state_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_state_type.go
@@ -1,0 +1,193 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	time "time"
+)
+
+// ExternalAuthState represents the values of the 'external_auth_state' type.
+//
+// Representation of the state of an external authentication provider.
+type ExternalAuthState struct {
+	bitmap_              uint32
+	lastUpdatedTimestamp time.Time
+	value                string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuthState) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// LastUpdatedTimestamp returns the value of the 'last_updated_timestamp' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The date and time when the external authentication provider state was last updated.
+func (o *ExternalAuthState) LastUpdatedTimestamp() time.Time {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.lastUpdatedTimestamp
+	}
+	return time.Time{}
+}
+
+// GetLastUpdatedTimestamp returns the value of the 'last_updated_timestamp' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The date and time when the external authentication provider state was last updated.
+func (o *ExternalAuthState) GetLastUpdatedTimestamp() (value time.Time, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.lastUpdatedTimestamp
+	}
+	return
+}
+
+// Value returns the value of the 'value' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A string value representing the external authentication provider's current state.
+func (o *ExternalAuthState) Value() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.value
+	}
+	return ""
+}
+
+// GetValue returns the value of the 'value' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A string value representing the external authentication provider's current state.
+func (o *ExternalAuthState) GetValue() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.value
+	}
+	return
+}
+
+// ExternalAuthStateListKind is the name of the type used to represent list of objects of
+// type 'external_auth_state'.
+const ExternalAuthStateListKind = "ExternalAuthStateList"
+
+// ExternalAuthStateListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth_state'.
+const ExternalAuthStateListLinkKind = "ExternalAuthStateListLink"
+
+// ExternalAuthStateNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth_state'.
+const ExternalAuthStateListNilKind = "ExternalAuthStateListNil"
+
+// ExternalAuthStateList is a list of values of the 'external_auth_state' type.
+type ExternalAuthStateList struct {
+	href  string
+	link  bool
+	items []*ExternalAuthState
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthStateList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStateList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStateList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStateList) SetItems(items []*ExternalAuthState) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthStateList) Items() []*ExternalAuthState {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthStateList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthStateList) Get(i int) *ExternalAuthState {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthStateList) Slice() []*ExternalAuthState {
+	var slice []*ExternalAuthState
+	if l == nil {
+		slice = make([]*ExternalAuthState, 0)
+	} else {
+		slice = make([]*ExternalAuthState, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthStateList) Each(f func(item *ExternalAuthState) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthStateList) Range(f func(index int, item *ExternalAuthState) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/external_auth_state_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_state_type_json.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthState writes a value of the 'external_auth_state' type to the given writer.
+func MarshalExternalAuthState(object *ExternalAuthState, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthState(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthState writes a value of the 'external_auth_state' type to the given stream.
+func WriteExternalAuthState(object *ExternalAuthState, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("last_updated_timestamp")
+		stream.WriteString((object.lastUpdatedTimestamp).Format(time.RFC3339))
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("value")
+		stream.WriteString(object.value)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalExternalAuthState reads a value of the 'external_auth_state' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalExternalAuthState(source interface{}) (object *ExternalAuthState, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadExternalAuthState(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthState reads a value of the 'external_auth_state' type from the given iterator.
+func ReadExternalAuthState(iterator *jsoniter.Iterator) *ExternalAuthState {
+	object := &ExternalAuthState{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "last_updated_timestamp":
+			text := iterator.ReadString()
+			value, err := time.Parse(time.RFC3339, text)
+			if err != nil {
+				iterator.ReportError("", err.Error())
+			}
+			object.lastUpdatedTimestamp = value
+			object.bitmap_ |= 1
+		case "value":
+			value := iterator.ReadString()
+			object.value = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/external_auth_status_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_status_builder.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ExternalAuthStatusBuilder contains the data and logic needed to build 'external_auth_status' objects.
+//
+// Representation of the status of an external authentication provider.
+type ExternalAuthStatusBuilder struct {
+	bitmap_ uint32
+	message string
+	state   *ExternalAuthStateBuilder
+}
+
+// NewExternalAuthStatus creates a new builder of 'external_auth_status' objects.
+func NewExternalAuthStatus() *ExternalAuthStatusBuilder {
+	return &ExternalAuthStatusBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ExternalAuthStatusBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// Message sets the value of the 'message' attribute to the given value.
+func (b *ExternalAuthStatusBuilder) Message(value string) *ExternalAuthStatusBuilder {
+	b.message = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// State sets the value of the 'state' attribute to the given value.
+//
+// Representation of the state of an external authentication provider.
+func (b *ExternalAuthStatusBuilder) State(value *ExternalAuthStateBuilder) *ExternalAuthStatusBuilder {
+	b.state = value
+	if value != nil {
+		b.bitmap_ |= 2
+	} else {
+		b.bitmap_ &^= 2
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ExternalAuthStatusBuilder) Copy(object *ExternalAuthStatus) *ExternalAuthStatusBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.message = object.message
+	if object.state != nil {
+		b.state = NewExternalAuthState().Copy(object.state)
+	} else {
+		b.state = nil
+	}
+	return b
+}
+
+// Build creates a 'external_auth_status' object using the configuration stored in the builder.
+func (b *ExternalAuthStatusBuilder) Build() (object *ExternalAuthStatus, err error) {
+	object = new(ExternalAuthStatus)
+	object.bitmap_ = b.bitmap_
+	object.message = b.message
+	if b.state != nil {
+		object.state, err = b.state.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/external_auth_status_list_builder.go
+++ b/clientapi/clustersmgmt/v1/external_auth_status_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ExternalAuthStatusListBuilder contains the data and logic needed to build
+// 'external_auth_status' objects.
+type ExternalAuthStatusListBuilder struct {
+	items []*ExternalAuthStatusBuilder
+}
+
+// NewExternalAuthStatusList creates a new builder of 'external_auth_status' objects.
+func NewExternalAuthStatusList() *ExternalAuthStatusListBuilder {
+	return new(ExternalAuthStatusListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ExternalAuthStatusListBuilder) Items(values ...*ExternalAuthStatusBuilder) *ExternalAuthStatusListBuilder {
+	b.items = make([]*ExternalAuthStatusBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ExternalAuthStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ExternalAuthStatusListBuilder) Copy(list *ExternalAuthStatusList) *ExternalAuthStatusListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ExternalAuthStatusBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewExternalAuthStatus().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'external_auth_status' objects using the
+// configuration stored in the builder.
+func (b *ExternalAuthStatusListBuilder) Build() (list *ExternalAuthStatusList, err error) {
+	items := make([]*ExternalAuthStatus, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ExternalAuthStatusList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/external_auth_status_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_status_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthStatusList writes a list of values of the 'external_auth_status' type to
+// the given writer.
+func MarshalExternalAuthStatusList(list []*ExternalAuthStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthStatusList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthStatusList writes a list of value of the 'external_auth_status' type to
+// the given stream.
+func WriteExternalAuthStatusList(list []*ExternalAuthStatus, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteExternalAuthStatus(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalExternalAuthStatusList reads a list of values of the 'external_auth_status' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalExternalAuthStatusList(source interface{}) (items []*ExternalAuthStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadExternalAuthStatusList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthStatusList reads list of values of the ”external_auth_status' type from
+// the given iterator.
+func ReadExternalAuthStatusList(iterator *jsoniter.Iterator) []*ExternalAuthStatus {
+	list := []*ExternalAuthStatus{}
+	for iterator.ReadArray() {
+		item := ReadExternalAuthStatus(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/external_auth_status_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_status_type.go
@@ -1,0 +1,191 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ExternalAuthStatus represents the values of the 'external_auth_status' type.
+//
+// Representation of the status of an external authentication provider.
+type ExternalAuthStatus struct {
+	bitmap_ uint32
+	message string
+	state   *ExternalAuthState
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ExternalAuthStatus) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// Message returns the value of the 'message' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// A descriptive message providing additional context about the current
+// state of the external authentication provider.
+func (o *ExternalAuthStatus) Message() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.message
+	}
+	return ""
+}
+
+// GetMessage returns the value of the 'message' attribute and
+// a flag indicating if the attribute has a value.
+//
+// A descriptive message providing additional context about the current
+// state of the external authentication provider.
+func (o *ExternalAuthStatus) GetMessage() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.message
+	}
+	return
+}
+
+// State returns the value of the 'state' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The current state of the external authentication provider.
+func (o *ExternalAuthStatus) State() *ExternalAuthState {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.state
+	}
+	return nil
+}
+
+// GetState returns the value of the 'state' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The current state of the external authentication provider.
+func (o *ExternalAuthStatus) GetState() (value *ExternalAuthState, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.state
+	}
+	return
+}
+
+// ExternalAuthStatusListKind is the name of the type used to represent list of objects of
+// type 'external_auth_status'.
+const ExternalAuthStatusListKind = "ExternalAuthStatusList"
+
+// ExternalAuthStatusListLinkKind is the name of the type used to represent links to list
+// of objects of type 'external_auth_status'.
+const ExternalAuthStatusListLinkKind = "ExternalAuthStatusListLink"
+
+// ExternalAuthStatusNilKind is the name of the type used to nil lists of objects of
+// type 'external_auth_status'.
+const ExternalAuthStatusListNilKind = "ExternalAuthStatusListNil"
+
+// ExternalAuthStatusList is a list of values of the 'external_auth_status' type.
+type ExternalAuthStatusList struct {
+	href  string
+	link  bool
+	items []*ExternalAuthStatus
+}
+
+// Len returns the length of the list.
+func (l *ExternalAuthStatusList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStatusList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStatusList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ExternalAuthStatusList) SetItems(items []*ExternalAuthStatus) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ExternalAuthStatusList) Items() []*ExternalAuthStatus {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ExternalAuthStatusList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ExternalAuthStatusList) Get(i int) *ExternalAuthStatus {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ExternalAuthStatusList) Slice() []*ExternalAuthStatus {
+	var slice []*ExternalAuthStatus
+	if l == nil {
+		slice = make([]*ExternalAuthStatus, 0)
+	} else {
+		slice = make([]*ExternalAuthStatus, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ExternalAuthStatusList) Each(f func(item *ExternalAuthStatus) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ExternalAuthStatusList) Range(f func(index int, item *ExternalAuthStatus) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/external_auth_status_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_status_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalExternalAuthStatus writes a value of the 'external_auth_status' type to the given writer.
+func MarshalExternalAuthStatus(object *ExternalAuthStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteExternalAuthStatus(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteExternalAuthStatus writes a value of the 'external_auth_status' type to the given stream.
+func WriteExternalAuthStatus(object *ExternalAuthStatus, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("message")
+		stream.WriteString(object.message)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.state != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("state")
+		WriteExternalAuthState(object.state, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalExternalAuthStatus reads a value of the 'external_auth_status' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalExternalAuthStatus(source interface{}) (object *ExternalAuthStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadExternalAuthStatus(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadExternalAuthStatus reads a value of the 'external_auth_status' type from the given iterator.
+func ReadExternalAuthStatus(iterator *jsoniter.Iterator) *ExternalAuthStatus {
+	object := &ExternalAuthStatus{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "message":
+			value := iterator.ReadString()
+			object.message = value
+			object.bitmap_ |= 1
+		case "state":
+			value := ReadExternalAuthState(iterator)
+			object.state = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/external_auth_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_type.go
@@ -174,6 +174,7 @@ func (o *ExternalAuth) GetIssuer() (value *TokenIssuer, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The status describes the current state of the external authentication provider.
+// This is read-only.
 func (o *ExternalAuth) Status() *ExternalAuthStatus {
 	if o != nil && o.bitmap_&64 != 0 {
 		return o.status
@@ -185,6 +186,7 @@ func (o *ExternalAuth) Status() *ExternalAuthStatus {
 // a flag indicating if the attribute has a value.
 //
 // The status describes the current state of the external authentication provider.
+// This is read-only.
 func (o *ExternalAuth) GetStatus() (value *ExternalAuthStatus, ok bool) {
 	ok = o != nil && o.bitmap_&64 != 0
 	if ok {

--- a/clientapi/clustersmgmt/v1/external_auth_type.go
+++ b/clientapi/clustersmgmt/v1/external_auth_type.go
@@ -41,6 +41,7 @@ type ExternalAuth struct {
 	claim   *ExternalAuthClaim
 	clients []*ExternalAuthClientConfig
 	issuer  *TokenIssuer
+	status  *ExternalAuthStatus
 }
 
 // Kind returns the name of the type of the object.
@@ -165,6 +166,29 @@ func (o *ExternalAuth) GetIssuer() (value *TokenIssuer, ok bool) {
 	ok = o != nil && o.bitmap_&32 != 0
 	if ok {
 		value = o.issuer
+	}
+	return
+}
+
+// Status returns the value of the 'status' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The status describes the current state of the external authentication provider.
+func (o *ExternalAuth) Status() *ExternalAuthStatus {
+	if o != nil && o.bitmap_&64 != 0 {
+		return o.status
+	}
+	return nil
+}
+
+// GetStatus returns the value of the 'status' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The status describes the current state of the external authentication provider.
+func (o *ExternalAuth) GetStatus() (value *ExternalAuthStatus, ok bool) {
+	ok = o != nil && o.bitmap_&64 != 0
+	if ok {
+		value = o.status
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/external_auth_type_json.go
+++ b/clientapi/clustersmgmt/v1/external_auth_type_json.go
@@ -90,6 +90,15 @@ func WriteExternalAuth(object *ExternalAuth, stream *jsoniter.Stream) {
 		}
 		stream.WriteObjectField("issuer")
 		WriteTokenIssuer(object.issuer, stream)
+		count++
+	}
+	present_ = object.bitmap_&64 != 0 && object.status != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("status")
+		WriteExternalAuthStatus(object.status, stream)
 	}
 	stream.WriteObjectEnd()
 }
@@ -138,6 +147,10 @@ func ReadExternalAuth(iterator *jsoniter.Iterator) *ExternalAuth {
 			value := ReadTokenIssuer(iterator)
 			object.issuer = value
 			object.bitmap_ |= 32
+		case "status":
+			value := ReadExternalAuthStatus(iterator)
+			object.status = value
+			object.bitmap_ |= 64
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/token_issuer_type.go
+++ b/clientapi/clustersmgmt/v1/token_issuer_type.go
@@ -86,7 +86,8 @@ func (o *TokenIssuer) GetURL() (value string, ok bool) {
 // Audiences is an array of audiences that the token was issued for.
 // Valid tokens must include at least one of these values in their
 // "aud" claim.
-// Must be set to exactly one value.
+// Must have at least one audience and a maximum of ten.
+// Any clients defined for this external authentication must have their id included here.
 func (o *TokenIssuer) Audiences() []string {
 	if o != nil && o.bitmap_&4 != 0 {
 		return o.audiences
@@ -100,7 +101,8 @@ func (o *TokenIssuer) Audiences() []string {
 // Audiences is an array of audiences that the token was issued for.
 // Valid tokens must include at least one of these values in their
 // "aud" claim.
-// Must be set to exactly one value.
+// Must have at least one audience and a maximum of ten.
+// Any clients defined for this external authentication must have their id included here.
 func (o *TokenIssuer) GetAudiences() (value []string, ok bool) {
 	ok = o != nil && o.bitmap_&4 != 0
 	if ok {

--- a/clientapi/clustersmgmt/v1/token_issuer_type.go
+++ b/clientapi/clustersmgmt/v1/token_issuer_type.go
@@ -61,6 +61,8 @@ func (o *TokenIssuer) GetCA() (value string, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // URL is the serving URL of the token issuer.
+// It must be a valid url and use the 'https' scheme.
+// This is required.
 func (o *TokenIssuer) URL() string {
 	if o != nil && o.bitmap_&2 != 0 {
 		return o.url
@@ -72,6 +74,8 @@ func (o *TokenIssuer) URL() string {
 // a flag indicating if the attribute has a value.
 //
 // URL is the serving URL of the token issuer.
+// It must be a valid url and use the 'https' scheme.
+// This is required.
 func (o *TokenIssuer) GetURL() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&2 != 0
 	if ok {

--- a/clientapi/clustersmgmt/v1/username_claim_type.go
+++ b/clientapi/clustersmgmt/v1/username_claim_type.go
@@ -89,6 +89,8 @@ func (o *UsernameClaim) GetPrefix() (value string, ok bool) {
 // prevent naming clashes with other plugins.
 //
 // Set to "NoPrefix" to disable prefixing.
+//
+// If a prefix is defined, this will be set to 'Prefix' by default.
 func (o *UsernameClaim) PrefixPolicy() string {
 	if o != nil && o.bitmap_&4 != 0 {
 		return o.prefixPolicy
@@ -105,6 +107,8 @@ func (o *UsernameClaim) PrefixPolicy() string {
 // prevent naming clashes with other plugins.
 //
 // Set to "NoPrefix" to disable prefixing.
+//
+// If a prefix is defined, this will be set to 'Prefix' by default.
 func (o *UsernameClaim) GetPrefixPolicy() (value string, ok bool) {
 	ok = o != nil && o.bitmap_&4 != 0
 	if ok {

--- a/model/aro_hcp/v1alpha1/cluster_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_resource.model
@@ -48,4 +48,8 @@ resource Cluster {
 	locator NodePools {
 		target NodePools
 	}
+        
+	locator ExternalAuthConfig {
+		target ExternalAuthConfig
+	}
 }

--- a/model/aro_hcp/v1alpha1/external_auth_config_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auth_config_resource.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the external authentication configuration for an ARO HCP cluster.
+resource ExternalAuthConfig {
+   method Get {
+        out Body ExternalAuthConfig
+   }
+
+    // Reference to the resource that manages the collection of ExternalAuths resources.
+    locator ExternalAuths {
+        target ExternalAuths
+    }
+}

--- a/model/aro_hcp/v1alpha1/external_auth_config_type.model
+++ b/model/aro_hcp/v1alpha1/external_auth_config_type.model
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@ref(path = "/clusters_mgmt/v1/external_auth_config")
+class ExternalAuthConfig {
+}

--- a/model/aro_hcp/v1alpha1/external_auth_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auth_resource.model
@@ -22,11 +22,13 @@ resource ExternalAuth {
     }
 
     // Updates the external authentication provider.
-    method Update {
+    @go(name="Update")
+    method AsyncUpdate {
         in out Body ExternalAuth
     }
 
     // Deletes the external authentication provider.
-    method Delete {
+    @go(name="Delete")
+    method AsyncDelete {
     }
 }

--- a/model/aro_hcp/v1alpha1/external_auth_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auth_resource.model
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific external authentication provider for an ARO HCP cluster.
+resource ExternalAuth {
+    // Retrieves the details of an external authentication provider.
+    method Get {
+        out Body ExternalAuth
+    }
+
+    // Updates the external authentication provider.
+    method Update {
+        in out Body ExternalAuth
+    }
+
+    // Deletes the external authentication provider.
+    method Delete {
+    }
+}

--- a/model/aro_hcp/v1alpha1/external_auth_type.model
+++ b/model/aro_hcp/v1alpha1/external_auth_type.model
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@ref(path = "/clusters_mgmt/v1/external_auth")
+class ExternalAuth {
+}

--- a/model/aro_hcp/v1alpha1/external_auths_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auths_resource.model
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of external authentication providers defined for an ARO HCP cluster.
+resource ExternalAuths {
+    method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Number of items contained in the returned page.
+		in out Size Integer = 100
+
+		// Total number of items of the collection.
+		out Total Integer
+
+		// Retrieved list of external authentication providers.
+		out Items []ExternalAuth
+    }
+
+	// Adds a new external authentication provider to the cluster.
+	method Add {
+		// Description of the external authentication provider.
+		in out Body ExternalAuth
+	}
+
+	// Reference to the resource that manages a specific external authentication provider.
+	locator ExternalAuth {
+		target ExternalAuth
+		variable ID
+	}
+}

--- a/model/aro_hcp/v1alpha1/external_auths_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auths_resource.model
@@ -16,29 +16,30 @@ limitations under the License.
 
 // Manages the collection of external authentication providers defined for an ARO HCP cluster.
 resource ExternalAuths {
-    method List {
-		// Index of the requested page, where one corresponds to the first page.
-		in out Page Integer = 1
+  method List {
+    // Index of the requested page, where one corresponds to the first page.
+    in out Page Integer = 1
 
-		// Number of items contained in the returned page.
-		in out Size Integer = 100
+    // Number of items contained in the returned page.
+    in out Size Integer = 100
 
-		// Total number of items of the collection.
-		out Total Integer
+    // Total number of items of the collection.
+    out Total Integer
 
-		// Retrieved list of external authentication providers.
-		out Items []ExternalAuth
-    }
+    // Retrieved list of external authentication providers.
+    out Items []ExternalAuth
+  }
 
-	// Adds a new external authentication provider to the cluster.
-	method Add {
-		// Description of the external authentication provider.
-		in out Body ExternalAuth
-	}
+  // Adds a new external authentication provider to the cluster.
+  @go(name="Add")
+  method AsyncAdd {
+    // Description of the external authentication provider.
+    in out Body ExternalAuth
+  }
 
-	// Reference to the resource that manages a specific external authentication provider.
-	locator ExternalAuth {
-		target ExternalAuth
-		variable ID
-	}
+  // Reference to the resource that manages a specific external authentication provider.
+  locator ExternalAuth {
+    target ExternalAuth
+    variable ID
+  }
 }

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -237,7 +237,10 @@ class Cluster {
 	// Details of cluster-wide KubeletConfig
 	KubeletConfig KubeletConfig
 
-	// External authentication configuration
+	// External authentication configuration.
+	// 
+	// For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
+	// For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 	ExternalAuthConfig ExternalAuthConfig
 
 	// Indicate whether the cluster is enabled for multi arch workers

--- a/model/clusters_mgmt/v1/external_auth_config_type.model
+++ b/model/clusters_mgmt/v1/external_auth_config_type.model
@@ -14,15 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// ExternalAuthConfig configuration
-struct ExternalAuthConfig {
-    // Boolean flag indicating if the cluster should use an external authentication configuration.
+// Represents an external authentication configuration
+class ExternalAuthConfig {
+    // Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
     //
     // By default this is false.
     //
     // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
     // to have the `external-authentication` feature toggle enabled.
+    //
+    // For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
     Enabled Boolean
 
+    // Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+    // 
+    // For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+    // 
+    // FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+    State ExternalAuthConfigState
+
+    // A list of external authentication providers configured for the cluster.
+    // 
+    // Only one external authentication provider can be configured.
     link ExternalAuths []ExternalAuth
+}
+
+// Representation of the possible values for the state field of an external authentication configuration
+enum ExternalAuthConfigState {
+    // Indicates that the cluster supports configuration of external authentication providers
+    @json(name="enabled")
+    Enabled
+
+    // Indicates that the cluster does not support configuration of external authentication providers
+    @json(name="disabled")
+    Disabled
 }

--- a/model/clusters_mgmt/v1/external_auth_status_type.model
+++ b/model/clusters_mgmt/v1/external_auth_status_type.model
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of the status of an external authentication provider.
+struct ExternalAuthStatus {
+    // The current state of the external authentication provider.
+    State ExternalAuthState
+
+    // A descriptive message providing additional context about the current 
+    // state of the external authentication provider.
+    Message String
+}
+
+// Representation of the state of an external authentication provider.
+struct ExternalAuthState {
+    // A string value representing the external authentication provider's current state.
+    Value String
+
+    // The date and time when the external authentication provider state was last updated.
+    LastUpdatedTimestamp Date
+}

--- a/model/clusters_mgmt/v1/external_auth_type.model
+++ b/model/clusters_mgmt/v1/external_auth_type.model
@@ -58,10 +58,23 @@ struct ExternalAuthClientConfig {
     ID String
 
     // The secret of the OIDC client from the OIDC provider.
+    // The client is considered 'public' if no secret is specified. Otherwise, it is considered
+    // as a 'confidential' client.
+    // This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
     Secret String
 
     // ExtraScopes is an optional set of scopes to request tokens with.
     ExtraScopes []String
+
+    // Determines the OIDC provider client type.
+    // 
+    // This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
+    // 
+    // For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the 
+    // 'secret' property in the client configuration. 
+    //    - If the 'secret' property is set, the type of the client is 'confidential.
+    //    - If the 'secret' property is not set, the type of the client is 'public.
+    Type ExternalAuthClientType
 }
 
 // The reference of a component that will consume the client configuration.
@@ -131,3 +144,20 @@ struct TokenClaimValidationRule {
     RequiredValue String
 }
 
+// Representation of the possible values of an external authentication client's type
+enum ExternalAuthClientType {
+    // Indicates that the client is confidential.
+    // 
+    // Confidential clients must provide a client secret.
+    // For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
+    // in the 'secret' property of the client configuration.
+    // For those belonging to an ARO HCP cluster, the secret should be provided within the cluster itself.
+    @json(name="confidential")
+    Confidential
+
+    // Indicates that the client is public
+    //
+    // Public clients must not provide a client secret
+    @json(name="public")
+    Public
+}

--- a/model/clusters_mgmt/v1/external_auth_type.model
+++ b/model/clusters_mgmt/v1/external_auth_type.model
@@ -17,23 +17,26 @@ limitations under the License.
 // Representation of an external authentication provider.
 class ExternalAuth {
 
-    // The issuer describes the attributes of the OIDC token issuer.
-    Issuer TokenIssuer
+	// The issuer describes the attributes of the OIDC token issuer.
+	Issuer TokenIssuer
 
-    // The list of the platform's clients that need to request tokens from the issuer.
-    Clients []ExternalAuthClientConfig
+	// The list of the platform's clients that need to request tokens from the issuer.
+	Clients []ExternalAuthClientConfig
 
-    // The rules on how to transform information from an ID token into a cluster identity.
-    Claim ExternalAuthClaim
+	// The rules on how to transform information from an ID token into a cluster identity.
+	Claim ExternalAuthClaim
 
-    // The status describes the current state of the external authentication provider.
-    Status ExternalAuthStatus
+	// The status describes the current state of the external authentication provider.
+	// This is read-only.
+	Status ExternalAuthStatus
 }
 
 // Representation of a token issuer used in an external authentication.
 struct TokenIssuer {
 
 	// URL is the serving URL of the token issuer.
+	// It must be a valid url and use the 'https' scheme.
+	// This is required.
 	URL String
 
 	// Audiences is an array of audiences that the token was issued for.
@@ -41,7 +44,7 @@ struct TokenIssuer {
 	// "aud" claim.
 	// Must have at least one audience and a maximum of ten.
 	// Any clients defined for this external authentication must have their id included here.
-    Audiences []String
+  Audiences []String
 
 	// Certificate bundle to use to validate server certificates for the configured URL.
 	CA String
@@ -51,113 +54,117 @@ struct TokenIssuer {
 // need to request tokens from the issuer.
 struct ExternalAuthClientConfig {
 
-    // The component that is supposed to consume this client configuration.
-    Component ClientComponent
+	// The component that is supposed to consume this client configuration.
+	Component ClientComponent
 
-    // The identifier of the OIDC client from the OIDC provider.
-    ID String
+	// The identifier of the OIDC client from the OIDC provider.
+	// This is required.
+	// Must be at least one character length.
+	ID String
 
-    // The secret of the OIDC client from the OIDC provider.
-    // The client is considered 'public' if no secret is specified. Otherwise, it is considered
-    // as a 'confidential' client.
-    // This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
-    Secret String
+	// The secret of the OIDC client from the OIDC provider.
+	// The client is considered 'public' if no secret is specified. Otherwise, it is considered
+	// as a 'confidential' client.
+	// This can only be used for an external authentication provider belonging to a ROSA HCP cluster.
+	Secret String
 
-    // ExtraScopes is an optional set of scopes to request tokens with.
-    ExtraScopes []String
+	// ExtraScopes is an optional set of scopes to request tokens with.
+	ExtraScopes []String
 
-    // Determines the OIDC provider client type.
-    // 
-    // This is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.
-    // 
-    // For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the 
-    // 'secret' property in the client configuration. 
-    //    - If the 'secret' property is set, the type of the client is 'confidential.
-    //    - If the 'secret' property is not set, the type of the client is 'public.
-    Type ExternalAuthClientType
+	// Determines the OIDC provider client type.
+	// 
+	// This is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.
+	// 
+	// For clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the 
+	// 'secret' property in the client configuration. 
+	//    - If the 'secret' property is set, the type of the client is 'confidential.
+	//    - If the 'secret' property is not set, the type of the client is 'public.
+	Type ExternalAuthClientType
 }
 
 // The reference of a component that will consume the client configuration.
 struct ClientComponent {
 
-    // The name of the component.
-    Name String
+	// The name of the component.
+	Name String
 
-    // The namespace of the component.
-    Namespace String
+	// The namespace of the component.
+	Namespace String
 }
 
 // The claims and validation rules used in the configuration of the external authentication.
 struct ExternalAuthClaim {
 
-    // Mapping describes rules on how to transform information from an ID token into a cluster identity.
-    Mappings    TokenClaimMappings
+	// Mapping describes rules on how to transform information from an ID token into a cluster identity.
+	Mappings    TokenClaimMappings
 
-    // ValidationRules are rules that are applied to validate token claims to authenticate users.
-    ValidationRules []TokenClaimValidationRule
+	// ValidationRules are rules that are applied to validate token claims to authenticate users.
+	ValidationRules []TokenClaimValidationRule
 }
 
 // The claim mappings defined for users and groups.
 struct TokenClaimMappings {
 
-    // Username is a name of the claim that should be used to construct usernames for the cluster identity.
-    @json(name = "username")
-    UserName UsernameClaim
+	// Username is a name of the claim that should be used to construct usernames for the cluster identity.
+	@json(name = "username")
+	UserName UsernameClaim
 
 	// Groups is a name of the claim that should be used to construct groups for the cluster identity.
-    Groups GroupsClaim
+  Groups GroupsClaim
 }
 
 // The username claim mapping.
 struct UsernameClaim {
 
-    // The claim used in the token.
-    Claim String
+	// The claim used in the token.
+	Claim String
 
-    // A prefix contatenated in the claim (Optional).
-    Prefix String
+	// A prefix contatenated in the claim (Optional).
+	Prefix String
 
-    // PrefixPolicy specifies how a prefix should apply.
-    //
+	// PrefixPolicy specifies how a prefix should apply.
+	//
 	// By default, claims other than `email` will be prefixed with the issuer URL to
 	// prevent naming clashes with other plugins.
 	//
 	// Set to "NoPrefix" to disable prefixing.
-    PrefixPolicy String
+	//
+	// If a prefix is defined, this will be set to 'Prefix' by default.
+	PrefixPolicy String
 }
 
 struct GroupsClaim {
-    // The claim used in the token.
-    Claim String
+	// The claim used in the token.
+	Claim String
 
-    // A prefix contatenated in the claim (Optional).
-    Prefix String
+	// A prefix contatenated in the claim (Optional).
+	Prefix String
 }
 
 // The rule that is applied to validate token claims to authenticate users.
 struct TokenClaimValidationRule {
 
-    // Claim is a name of a required claim.
-    Claim String
+	// Claim is a name of a required claim.
+	Claim String
 
-    // RequiredValue is the required value for the claim.
-    RequiredValue String
+	// RequiredValue is the required value for the claim.
+	RequiredValue String
 }
 
 // Representation of the possible values of an external authentication client's type
 enum ExternalAuthClientType {
-    // Indicates that the client is confidential.
-    // 
-    // Confidential clients must provide a client secret.
-    // For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
-    // in the 'secret' property of the client configuration.
-    // For those belonging to an ARO HCP cluster, the secret should be provided within the cluster itself.
-    @json(name="confidential")
-    Confidential
+	// Indicates that the client is confidential.
+	// 
+	// Confidential clients must provide a client secret.
+	// For external authentication provider belonging to a ROSA HCP cluster, the secret should be provided
+	// in the 'secret' property of the client configuration.
+	// For those belonging to an ARO-HCP cluster, the secret should be provided within the cluster itself.
+	@json(name="confidential")
+	Confidential
 
-    // Indicates that the client is public
-    //
-    // Public clients must not provide a client secret
-    @json(name="public")
-    Public
+	// Indicates that the client is public
+	//
+	// Public clients must not provide a client secret
+	@json(name="public")
+	Public
 }

--- a/model/clusters_mgmt/v1/external_auth_type.model
+++ b/model/clusters_mgmt/v1/external_auth_type.model
@@ -25,6 +25,9 @@ class ExternalAuth {
 
     // The rules on how to transform information from an ID token into a cluster identity.
     Claim ExternalAuthClaim
+
+    // The status describes the current state of the external authentication provider.
+    Status ExternalAuthStatus
 }
 
 // Representation of a token issuer used in an external authentication.

--- a/model/clusters_mgmt/v1/external_auth_type.model
+++ b/model/clusters_mgmt/v1/external_auth_type.model
@@ -39,7 +39,8 @@ struct TokenIssuer {
 	// Audiences is an array of audiences that the token was issued for.
 	// Valid tokens must include at least one of these values in their
 	// "aud" claim.
-	// Must be set to exactly one value.
+	// Must have at least one audience and a maximum of ten.
+	// Any clients defined for this external authentication must have their id included here.
     Audiences []String
 
 	// Certificate bundle to use to validate server certificates for the configured URL.

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -2691,10 +2691,22 @@
             }
           },
           "secret": {
-            "description": "The secret of the OIDC client from the OIDC provider.",
+            "description": "The secret of the OIDC client from the OIDC provider.\nThe client is considered 'public' if no secret is specified. Otherwise, it is considered\nas a 'confidential' client.\nThis can only be used for an external authentication provider belonging to a ROSA HCP cluster.",
             "type": "string"
+          },
+          "type": {
+            "description": "Determines the OIDC provider client type.\n\nThis is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.\n\nFor clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the \n'secret' property in the client configuration. \n   - If the 'secret' property is set, the type of the client is 'confidential.\n   - If the 'secret' property is not set, the type of the client is 'public.",
+            "$ref": "#/components/schemas/ExternalAuthClientType"
           }
         }
+      },
+      "ExternalAuthClientType": {
+        "description": "Representation of the possible values of an external authentication client's type",
+        "type": "string",
+        "enum": [
+          "confidential",
+          "public"
+        ]
       },
       "ExternalAuthConfig": {
         "description": "Represents an external authentication configuration",

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -296,6 +296,297 @@
         }
       }
     },
+    "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/external_auth_config": {
+      "get": {
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthConfig"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/external_auth_config/external_auths": {
+      "post": {
+        "description": "Adds a new external authentication provider to the cluster.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalAuth"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuth"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "page",
+            "description": "Index of the requested page, where one corresponds to the first page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "size",
+            "description": "Number of items contained in the returned page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "description": "Retrieved list of external authentication providers.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ExternalAuth"
+                      }
+                    },
+                    "page": {
+                      "description": "Index of the requested page, where one corresponds to the first page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "size": {
+                      "description": "Number of items contained in the returned page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "total": {
+                      "description": "Total number of items of the collection.",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/external_auth_config/external_auths/{external_auth_id}": {
+      "delete": {
+        "description": "Deletes the external authentication provider.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "external_auth_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Retrieves the details of an external authentication provider.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "external_auth_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuth"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Updates the external authentication provider.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "external_auth_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalAuth"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuth"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/inflight_checks": {
       "get": {
         "description": "Retrieves the list of inflight checks.",
@@ -1647,6 +1938,19 @@
           }
         }
       },
+      "ClientComponent": {
+        "description": "The reference of a component that will consume the client configuration.",
+        "properties": {
+          "name": {
+            "description": "The name of the component.",
+            "type": "string"
+          },
+          "namespace": {
+            "description": "The namespace of the component.",
+            "type": "string"
+          }
+        }
+      },
       "CloudProvider": {
         "description": "Cloud provider.",
         "properties": {
@@ -1860,7 +2164,7 @@
             "type": "string"
           },
           "external_auth_config": {
-            "description": "External authentication configuration",
+            "description": "External authentication configuration.\n\nFor ROSA HCP, if this is not specified, external authentication configuration will be disabled by default\nFor ARO HCP, if this is not specified, external authentication configuration will be enabled by default",
             "$ref": "#/components/schemas/ExternalAuthConfig"
           },
           "external_configuration": {
@@ -2316,20 +2620,117 @@
           "required"
         ]
       },
-      "ExternalAuthConfig": {
-        "description": "ExternalAuthConfig configuration",
+      "ExternalAuth": {
+        "description": "Representation of an external authentication provider.",
         "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'ExternalAuth' if this is a complete object or 'ExternalAuthLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "claim": {
+            "description": "The rules on how to transform information from an ID token into a cluster identity.",
+            "$ref": "#/components/schemas/ExternalAuthClaim"
+          },
+          "clients": {
+            "description": "The list of the platform's clients that need to request tokens from the issuer.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalAuthClientConfig"
+            }
+          },
+          "issuer": {
+            "description": "The issuer describes the attributes of the OIDC token issuer.",
+            "$ref": "#/components/schemas/TokenIssuer"
+          }
+        }
+      },
+      "ExternalAuthClaim": {
+        "description": "The claims and validation rules used in the configuration of the external authentication.",
+        "properties": {
+          "mappings": {
+            "description": "Mapping describes rules on how to transform information from an ID token into a cluster identity.",
+            "$ref": "#/components/schemas/TokenClaimMappings"
+          },
+          "validation_rules": {
+            "description": "ValidationRules are rules that are applied to validate token claims to authenticate users.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TokenClaimValidationRule"
+            }
+          }
+        }
+      },
+      "ExternalAuthClientConfig": {
+        "description": "ExternalAuthClientConfig contains configuration for the platform's clients that\nneed to request tokens from the issuer.",
+        "properties": {
+          "id": {
+            "description": "The identifier of the OIDC client from the OIDC provider.",
+            "type": "string"
+          },
+          "component": {
+            "description": "The component that is supposed to consume this client configuration.",
+            "$ref": "#/components/schemas/ClientComponent"
+          },
+          "extra_scopes": {
+            "description": "ExtraScopes is an optional set of scopes to request tokens with.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "secret": {
+            "description": "The secret of the OIDC client from the OIDC provider.",
+            "type": "string"
+          }
+        }
+      },
+      "ExternalAuthConfig": {
+        "description": "Represents an external authentication configuration",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'ExternalAuthConfig' if this is a complete object or 'ExternalAuthConfigLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
           "enabled": {
-            "description": "Boolean flag indicating if the cluster should use an external authentication configuration.\n\nBy default this is false.\n\nTo enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs\nto have the `external-authentication` feature toggle enabled.",
+            "description": "Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.\n\nBy default this is false.\n\nTo enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs\nto have the `external-authentication` feature toggle enabled.\n\nFor ARO HCP clusters, use the \"State\" property to enable/disable this feature instead.",
             "type": "boolean"
           },
           "external_auths": {
+            "description": "A list of external authentication providers configured for the cluster.\n\nOnly one external authentication provider can be configured.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExternalAuth"
             }
+          },
+          "state": {
+            "description": "Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.\n\nFor ARO HCP clusters, this will be \"enabled\" by default and cannot be set to \"disabled\".\n\nFOR ROSA HCP clusters, use the \"Enabled\" boolean flag to enable/disable this feature instead.",
+            "$ref": "#/components/schemas/ExternalAuthConfigState"
           }
         }
+      },
+      "ExternalAuthConfigState": {
+        "description": "Representation of the possible values for the state field of an external authentication configuration",
+        "type": "string",
+        "enum": [
+          "disabled",
+          "enabled"
+        ]
       },
       "ExternalConfiguration": {
         "description": "Representation of cluster external configuration.",
@@ -2389,6 +2790,18 @@
           "secure_boot": {
             "description": "Determines if Shielded VM feature \"Secure Boot\" should be set for the nodes of the cluster.",
             "type": "boolean"
+          }
+        }
+      },
+      "GroupsClaim": {
+        "properties": {
+          "claim": {
+            "description": "The claim used in the token.",
+            "type": "string"
+          },
+          "prefix": {
+            "description": "A prefix contatenated in the claim (Optional).",
+            "type": "string"
           }
         }
       },
@@ -3286,6 +3699,69 @@
           },
           "value": {
             "description": "The value for the taint.",
+            "type": "string"
+          }
+        }
+      },
+      "TokenClaimMappings": {
+        "description": "The claim mappings defined for users and groups.",
+        "properties": {
+          "groups": {
+            "description": "Groups is a name of the claim that should be used to construct groups for the cluster identity.",
+            "$ref": "#/components/schemas/GroupsClaim"
+          },
+          "username": {
+            "description": "Username is a name of the claim that should be used to construct usernames for the cluster identity.",
+            "$ref": "#/components/schemas/UsernameClaim"
+          }
+        }
+      },
+      "TokenClaimValidationRule": {
+        "description": "The rule that is applied to validate token claims to authenticate users.",
+        "properties": {
+          "claim": {
+            "description": "Claim is a name of a required claim.",
+            "type": "string"
+          },
+          "required_value": {
+            "description": "RequiredValue is the required value for the claim.",
+            "type": "string"
+          }
+        }
+      },
+      "TokenIssuer": {
+        "description": "Representation of a token issuer used in an external authentication.",
+        "properties": {
+          "ca": {
+            "description": "Certificate bundle to use to validate server certificates for the configured URL.",
+            "type": "string"
+          },
+          "url": {
+            "description": "URL is the serving URL of the token issuer.",
+            "type": "string"
+          },
+          "audiences": {
+            "description": "Audiences is an array of audiences that the token was issued for.\nValid tokens must include at least one of these values in their\n\"aud\" claim.\nMust be set to exactly one value.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UsernameClaim": {
+        "description": "The username claim mapping.",
+        "properties": {
+          "claim": {
+            "description": "The claim used in the token.",
+            "type": "string"
+          },
+          "prefix": {
+            "description": "A prefix contatenated in the claim (Optional).",
+            "type": "string"
+          },
+          "prefix_policy": {
+            "description": "PrefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to\nprevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.",
             "type": "string"
           }
         }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -3772,7 +3772,7 @@
             "type": "string"
           },
           "audiences": {
-            "description": "Audiences is an array of audiences that the token was issued for.\nValid tokens must include at least one of these values in their\n\"aud\" claim.\nMust be set to exactly one value.",
+            "description": "Audiences is an array of audiences that the token was issued for.\nValid tokens must include at least one of these values in their\n\"aud\" claim.\nMust have at least one audience and a maximum of ten.\nAny clients defined for this external authentication must have their id included here.",
             "type": "array",
             "items": {
               "type": "string"

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -2649,6 +2649,10 @@
           "issuer": {
             "description": "The issuer describes the attributes of the OIDC token issuer.",
             "$ref": "#/components/schemas/TokenIssuer"
+          },
+          "status": {
+            "description": "The status describes the current state of the external authentication provider.",
+            "$ref": "#/components/schemas/ExternalAuthStatus"
           }
         }
       },
@@ -2731,6 +2735,33 @@
           "disabled",
           "enabled"
         ]
+      },
+      "ExternalAuthState": {
+        "description": "Representation of the state of an external authentication provider.",
+        "properties": {
+          "last_updated_timestamp": {
+            "description": "The date and time when the external authentication provider state was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "description": "A string value representing the external authentication provider's current state.",
+            "type": "string"
+          }
+        }
+      },
+      "ExternalAuthStatus": {
+        "description": "Representation of the status of an external authentication provider.",
+        "properties": {
+          "message": {
+            "description": "A descriptive message providing additional context about the current \nstate of the external authentication provider.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state of the external authentication provider.",
+            "$ref": "#/components/schemas/ExternalAuthState"
+          }
+        }
       },
       "ExternalConfiguration": {
         "description": "Representation of cluster external configuration.",

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -2651,7 +2651,7 @@
             "$ref": "#/components/schemas/TokenIssuer"
           },
           "status": {
-            "description": "The status describes the current state of the external authentication provider.",
+            "description": "The status describes the current state of the external authentication provider.\nThis is read-only.",
             "$ref": "#/components/schemas/ExternalAuthStatus"
           }
         }
@@ -2676,7 +2676,7 @@
         "description": "ExternalAuthClientConfig contains configuration for the platform's clients that\nneed to request tokens from the issuer.",
         "properties": {
           "id": {
-            "description": "The identifier of the OIDC client from the OIDC provider.",
+            "description": "The identifier of the OIDC client from the OIDC provider.\nThis is required.\nMust be at least one character length.",
             "type": "string"
           },
           "component": {
@@ -2695,7 +2695,7 @@
             "type": "string"
           },
           "type": {
-            "description": "Determines the OIDC provider client type.\n\nThis is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.\n\nFor clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the \n'secret' property in the client configuration. \n   - If the 'secret' property is set, the type of the client is 'confidential.\n   - If the 'secret' property is not set, the type of the client is 'public.",
+            "description": "Determines the OIDC provider client type.\n\nThis is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.\n\nFor clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the \n'secret' property in the client configuration. \n   - If the 'secret' property is set, the type of the client is 'confidential.\n   - If the 'secret' property is not set, the type of the client is 'public.",
             "$ref": "#/components/schemas/ExternalAuthClientType"
           }
         }
@@ -3780,7 +3780,7 @@
             "type": "string"
           },
           "url": {
-            "description": "URL is the serving URL of the token issuer.",
+            "description": "URL is the serving URL of the token issuer.\nIt must be a valid url and use the 'https' scheme.\nThis is required.",
             "type": "string"
           },
           "audiences": {
@@ -3804,7 +3804,7 @@
             "type": "string"
           },
           "prefix_policy": {
-            "description": "PrefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to\nprevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.",
+            "description": "PrefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to\nprevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.\n\nIf a prefix is defined, this will be set to 'Prefix' by default.",
             "type": "string"
           }
         }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -355,7 +355,7 @@
           }
         },
         "responses": {
-          "201": {
+          "202": {
             "description": "Success.",
             "content": {
               "application/json": {
@@ -476,51 +476,8 @@
           }
         ],
         "responses": {
-          "204": {
+          "202": {
             "description": "Success."
-          },
-          "default": {
-            "description": "Error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      },
-      "get": {
-        "description": "Retrieves the details of an external authentication provider.",
-        "parameters": [
-          {
-            "name": "cluster_id",
-            "in": "path",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          },
-          {
-            "name": "external_auth_id",
-            "in": "path",
-            "schema": {
-              "type": "string"
-            },
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExternalAuth"
-                }
-              }
-            }
           },
           "default": {
             "description": "Error.",
@@ -563,6 +520,49 @@
             }
           }
         },
+        "responses": {
+          "202": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuth"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Retrieves the details of an external authentication provider.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "external_auth_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "Success.",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -18748,7 +18748,7 @@
             "type": "string"
           },
           "audiences": {
-            "description": "Audiences is an array of audiences that the token was issued for.\nValid tokens must include at least one of these values in their\n\"aud\" claim.\nMust be set to exactly one value.",
+            "description": "Audiences is an array of audiences that the token was issued for.\nValid tokens must include at least one of these values in their\n\"aud\" claim.\nMust have at least one audience and a maximum of ten.\nAny clients defined for this external authentication must have their id included here.",
             "type": "array",
             "items": {
               "type": "string"

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16431,10 +16431,22 @@
             }
           },
           "secret": {
-            "description": "The secret of the OIDC client from the OIDC provider.",
+            "description": "The secret of the OIDC client from the OIDC provider.\nThe client is considered 'public' if no secret is specified. Otherwise, it is considered\nas a 'confidential' client.\nThis can only be used for an external authentication provider belonging to a ROSA HCP cluster.",
             "type": "string"
+          },
+          "type": {
+            "description": "Determines the OIDC provider client type.\n\nThis is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.\n\nFor clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the \n'secret' property in the client configuration. \n   - If the 'secret' property is set, the type of the client is 'confidential.\n   - If the 'secret' property is not set, the type of the client is 'public.",
+            "$ref": "#/components/schemas/ExternalAuthClientType"
           }
         }
+      },
+      "ExternalAuthClientType": {
+        "description": "Representation of the possible values of an external authentication client's type",
+        "type": "string",
+        "enum": [
+          "confidential",
+          "public"
+        ]
       },
       "ExternalAuthConfig": {
         "description": "Represents an external authentication configuration",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16391,7 +16391,7 @@
             "$ref": "#/components/schemas/TokenIssuer"
           },
           "status": {
-            "description": "The status describes the current state of the external authentication provider.",
+            "description": "The status describes the current state of the external authentication provider.\nThis is read-only.",
             "$ref": "#/components/schemas/ExternalAuthStatus"
           }
         }
@@ -16416,7 +16416,7 @@
         "description": "ExternalAuthClientConfig contains configuration for the platform's clients that\nneed to request tokens from the issuer.",
         "properties": {
           "id": {
-            "description": "The identifier of the OIDC client from the OIDC provider.",
+            "description": "The identifier of the OIDC client from the OIDC provider.\nThis is required.\nMust be at least one character length.",
             "type": "string"
           },
           "component": {
@@ -16435,7 +16435,7 @@
             "type": "string"
           },
           "type": {
-            "description": "Determines the OIDC provider client type.\n\nThis is required to be defined for clients of an external authentication provider belonging to an ARO HCP cluster.\n\nFor clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the \n'secret' property in the client configuration. \n   - If the 'secret' property is set, the type of the client is 'confidential.\n   - If the 'secret' property is not set, the type of the client is 'public.",
+            "description": "Determines the OIDC provider client type.\n\nThis is required to be defined for clients of an external authentication provider belonging to an ARO-HCP cluster.\n\nFor clients belonging to a ROSA HCP cluster, this is read-only. The value of this property will be determined by the \n'secret' property in the client configuration. \n   - If the 'secret' property is set, the type of the client is 'confidential.\n   - If the 'secret' property is not set, the type of the client is 'public.",
             "$ref": "#/components/schemas/ExternalAuthClientType"
           }
         }
@@ -18756,7 +18756,7 @@
             "type": "string"
           },
           "url": {
-            "description": "URL is the serving URL of the token issuer.",
+            "description": "URL is the serving URL of the token issuer.\nIt must be a valid url and use the 'https' scheme.\nThis is required.",
             "type": "string"
           },
           "audiences": {
@@ -18937,7 +18937,7 @@
             "type": "string"
           },
           "prefix_policy": {
-            "description": "PrefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to\nprevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.",
+            "description": "PrefixPolicy specifies how a prefix should apply.\n\nBy default, claims other than `email` will be prefixed with the issuer URL to\nprevent naming clashes with other plugins.\n\nSet to \"NoPrefix\" to disable prefixing.\n\nIf a prefix is defined, this will be set to 'Prefix' by default.",
             "type": "string"
           }
         }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -15482,7 +15482,7 @@
             "type": "string"
           },
           "external_auth_config": {
-            "description": "External authentication configuration",
+            "description": "External authentication configuration.\n\nFor ROSA HCP, if this is not specified, external authentication configuration will be disabled by default\nFor ARO HCP, if this is not specified, external authentication configuration will be enabled by default",
             "$ref": "#/components/schemas/ExternalAuthConfig"
           },
           "external_configuration": {
@@ -16433,19 +16433,44 @@
         }
       },
       "ExternalAuthConfig": {
-        "description": "ExternalAuthConfig configuration",
+        "description": "Represents an external authentication configuration",
         "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'ExternalAuthConfig' if this is a complete object or 'ExternalAuthConfigLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
           "enabled": {
-            "description": "Boolean flag indicating if the cluster should use an external authentication configuration.\n\nBy default this is false.\n\nTo enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs\nto have the `external-authentication` feature toggle enabled.",
+            "description": "Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.\n\nBy default this is false.\n\nTo enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs\nto have the `external-authentication` feature toggle enabled.\n\nFor ARO HCP clusters, use the \"State\" property to enable/disable this feature instead.",
             "type": "boolean"
           },
           "external_auths": {
+            "description": "A list of external authentication providers configured for the cluster.\n\nOnly one external authentication provider can be configured.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ExternalAuth"
             }
+          },
+          "state": {
+            "description": "Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.\n\nFor ARO HCP clusters, this will be \"enabled\" by default and cannot be set to \"disabled\".\n\nFOR ROSA HCP clusters, use the \"Enabled\" boolean flag to enable/disable this feature instead.",
+            "$ref": "#/components/schemas/ExternalAuthConfigState"
           }
         }
+      },
+      "ExternalAuthConfigState": {
+        "description": "Representation of the possible values for the state field of an external authentication configuration",
+        "type": "string",
+        "enum": [
+          "disabled",
+          "enabled"
+        ]
       },
       "ExternalConfiguration": {
         "description": "Representation of cluster external configuration.",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16389,6 +16389,10 @@
           "issuer": {
             "description": "The issuer describes the attributes of the OIDC token issuer.",
             "$ref": "#/components/schemas/TokenIssuer"
+          },
+          "status": {
+            "description": "The status describes the current state of the external authentication provider.",
+            "$ref": "#/components/schemas/ExternalAuthStatus"
           }
         }
       },
@@ -16471,6 +16475,33 @@
           "disabled",
           "enabled"
         ]
+      },
+      "ExternalAuthState": {
+        "description": "Representation of the state of an external authentication provider.",
+        "properties": {
+          "last_updated_timestamp": {
+            "description": "The date and time when the external authentication provider state was last updated.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "description": "A string value representing the external authentication provider's current state.",
+            "type": "string"
+          }
+        }
+      },
+      "ExternalAuthStatus": {
+        "description": "Representation of the status of an external authentication provider.",
+        "properties": {
+          "message": {
+            "description": "A descriptive message providing additional context about the current \nstate of the external authentication provider.",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state of the external authentication provider.",
+            "$ref": "#/components/schemas/ExternalAuthState"
+          }
+        }
       },
       "ExternalConfiguration": {
         "description": "Representation of cluster external configuration.",


### PR DESCRIPTION
### What

The design document for this API can be found in [XCMSTRAT-574](https://issues.redhat.com/browse/XCMSTRAT-574).

The proposed endpoints in CS is as follows
```
GET 
/clusters/{id}/external_auth_config

GET POST 
/clusters/{id}/external_auth_config/external_auths

GET PATCH DELETE /clusters/{id}/external_auth_config/external_auths/{external_auth_id}
```

The external authentication API for both *clusters_mgmt/v1* and *aro_hcp/v1alpha1* should have similar features apart from the following differences:
* The external authentication configuration for a cluster can never be disabled for ARO HCP clusters.
* Creating, updating and deleting external authentication providers for ARO HCP clusters needs to be done asynchronously. The changes below follows closely to what has been implemented for [Node Pools state](https://github.com/openshift-online/ocm-api-model/commit/a3966e8f777561e41d92a4f7a865bf7475dfdfec#diff-1ec615fdeda70eef8a90e3f5b23aa1bc47ff606abdda448f905c86d408088321). 


Resulting API based on the changes below
<img width="1467" alt="image" src="https://github.com/user-attachments/assets/aa95d458-717d-42ef-8f60-2124d00ff9b1" />
