### PR TITLE
[DRAFT] ARO-15052: support cluster credential retrieval for aro_hcp/v1alpha1

### DIFF
--- a/model/aro_hcp/v1alpha1/break_glass_credential_resource.model
+++ b/model/aro_hcp/v1alpha1/break_glass_credential_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a specific break glass credential.
+resource BreakGlassCredential {
+	// Retrieves the details of the break glass credential.
+	method Get {
+		out Body BreakGlassCredential
+	}
+}

--- a/model/aro_hcp/v1alpha1/break_glass_credential_status_details_type.model
+++ b/model/aro_hcp/v1alpha1/break_glass_credential_status_details_type.model
@@ -1,0 +1,20 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of the status details of a break glass credential
+@ref(path = "/clusters_mgmt/v1/break_glass_credential_status_details")
+class BreakGlassCredentialStatusDetails {
+}

--- a/model/aro_hcp/v1alpha1/break_glass_credential_type.model
+++ b/model/aro_hcp/v1alpha1/break_glass_credential_type.model
@@ -1,0 +1,20 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of a break glass credential.
+@ref(path = "/clusters_mgmt/v1/break_glass_credential")
+class BreakGlassCredential {
+}

--- a/model/aro_hcp/v1alpha1/break_glass_credentials_resource.model
+++ b/model/aro_hcp/v1alpha1/break_glass_credentials_resource.model
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the break glass credentials of a cluster.
+resource BreakGlassCredentials {
+	// Retrieves the list of break glass credentials.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Number of items contained in the returned page.
+		in out Size Integer = 100
+
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the break glass credentials
+		// instead of the names of the columns of a table. For example, in order to retrieve all
+		// the credentials with a specific username and status the following is required:
+		//
+		// ```sql
+		// username='user1' AND status='expired'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// break glass credentials that the user has permission to see will be returned.
+		in Search String
+
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the break glass credentials
+		// instead of the the names of the columns of a table. For example, in order to sort the
+		// credentials descending by identifier the value should be:
+		//
+		// ```sql
+		// id desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
+
+		// Total number of items of the collection.
+		out Total Integer
+
+		// Retrieved list of break glass credentials.
+		out Items []BreakGlassCredential
+	}
+
+	// Adds a new break glass credential to the cluster.
+	@go(name="Add")
+	method AsyncAdd {
+		// Description of the break glass credential.
+		in out Body BreakGlassCredential
+	}
+
+	// Revokes all the break glass certificates signed by a specific signer.
+	@go(name="Delete")
+	method AsyncDelete {
+	}
+
+	// Reference to the service that manages a specific break glass credential.
+	locator BreakGlassCredential {
+		target BreakGlassCredential
+		variable ID
+	}
+}

--- a/model/aro_hcp/v1alpha1/cluster_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_resource.model
@@ -47,4 +47,8 @@ resource Cluster {
 	locator NodePools {
 		target NodePools
 	}
+
+	locator BreakGlassCredentials {
+		target BreakGlassCredentials
+	}
 }

--- a/model/clusters_mgmt/v1/break_glass_credential_status_details_type.model
+++ b/model/clusters_mgmt/v1/break_glass_credential_status_details_type.model
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Representation of the status details of a break glass credential
+class BreakGlassCredentialStatusDetails {
+    // The current state of the credential
+    State BreakGlassCredentialState
+    
+    // A descriptive message providing additional context about the current state of
+    // the credential
+    Message String
+}
+
+// Representation of the state of a break glass credential
+struct BreakGlassCredentialState {
+    // A string value representing the credential's current state
+    Value BreakGlassCredentialStatus
+
+    // The date and time when the credential state was last updated
+    LastUpdatedTimestamp Date
+}

--- a/model/clusters_mgmt/v1/break_glass_credential_type.model
+++ b/model/clusters_mgmt/v1/break_glass_credential_type.model
@@ -19,6 +19,9 @@ class BreakGlassCredential {
 	// Username is the user which will be used for this credential.
 	Username String
 
+	// CreationTimestamp is the date and time when the credential was created.
+	CreationTimestamp Date
+
 	// ExpirationTimestamp is the date and time when the credential will expire.
 	ExpirationTimestamp Date
 
@@ -28,6 +31,9 @@ class BreakGlassCredential {
 	// Status is the status of this credential
 	Status BreakGlassCredentialStatus
 
+	// Additional information about the current state of this credential
+	StatusDetails BreakGlassCredentialStatusDetails
+
 	// Kubeconfig is the generated kubeconfig for this credential. It is only stored in memory
 	Kubeconfig String
 }
@@ -35,9 +41,12 @@ class BreakGlassCredential {
 // Status of the break glass credential.
 enum BreakGlassCredentialStatus {
 	Created
+	Issuing
 	Issued
 	Expired
 	AwaitingRevocation
+	Revoking
 	Revoked
 	Failed
+	Denied
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -296,6 +296,218 @@
         }
       }
     },
+    "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/break_glass_credentials": {
+      "post": {
+        "description": "Adds a new break glass credential to the cluster.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BreakGlassCredential"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakGlassCredential"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Revokes all the break glass certificates signed by a specific signer.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Retrieves the list of break glass credentials.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "order",
+            "description": "Order criteria.\n\nThe syntax of this parameter is similar to the syntax of the _order by_ clause of\na SQL statement, but using the names of the attributes of the break glass credentials\ninstead of the the names of the columns of a table. For example, in order to sort the\ncredentials descending by identifier the value should be:\n\n```sql\nid desc\n```\n\nIf the parameter isn't provided, or if the value is empty, then the order of the\nresults is undefined.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "description": "Index of the requested page, where one corresponds to the first page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "search",
+            "description": "Search criteria.\n\nThe syntax of this parameter is similar to the syntax of the _where_ clause of a\nSQL statement, but using the names of the attributes of the break glass credentials\ninstead of the names of the columns of a table. For example, in order to retrieve all\nthe credentials with a specific username and status the following is required:\n\n```sql\nusername='user1' AND status='expired'\n```\n\nIf the parameter isn't provided, or if the value is empty, then all the\nbreak glass credentials that the user has permission to see will be returned.",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "size",
+            "description": "Number of items contained in the returned page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "description": "Retrieved list of break glass credentials.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BreakGlassCredential"
+                      }
+                    },
+                    "page": {
+                      "description": "Index of the requested page, where one corresponds to the first page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "size": {
+                      "description": "Number of items contained in the returned page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "total": {
+                      "description": "Total number of items of the collection.",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/break_glass_credentials/{break_glass_credential_id}": {
+      "get": {
+        "description": "Retrieves the details of the break glass credential.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "break_glass_credential_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BreakGlassCredential"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/inflight_checks": {
       "get": {
         "description": "Retrieves the list of inflight checks.",
@@ -1625,6 +1837,108 @@
           "marketplace-azure",
           "standard"
         ]
+      },
+      "BreakGlassCredential": {
+        "description": "Representation of a break glass credential.",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'BreakGlassCredential' if this is a complete object or 'BreakGlassCredentialLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "creation_timestamp": {
+            "description": "CreationTimestamp is the date and time when the credential was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiration_timestamp": {
+            "description": "ExpirationTimestamp is the date and time when the credential will expire.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "kubeconfig": {
+            "description": "Kubeconfig is the generated kubeconfig for this credential. It is only stored in memory",
+            "type": "string"
+          },
+          "revocation_timestamp": {
+            "description": "RevocationTimestamp is the date and time when the credential has been revoked.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "description": "Status is the status of this credential",
+            "$ref": "#/components/schemas/BreakGlassCredentialStatus"
+          },
+          "status_details": {
+            "description": "Additional information about the current state of this credential",
+            "$ref": "#/components/schemas/BreakGlassCredentialStatusDetails"
+          },
+          "username": {
+            "description": "Username is the user which will be used for this credential.",
+            "type": "string"
+          }
+        }
+      },
+      "BreakGlassCredentialState": {
+        "description": "Representation of the state of a break glass credential",
+        "properties": {
+          "last_updated_timestamp": {
+            "description": "The date and time when the credential state was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "description": "A string value representing the credential's current state",
+            "$ref": "#/components/schemas/BreakGlassCredentialStatus"
+          }
+        }
+      },
+      "BreakGlassCredentialStatus": {
+        "description": "Status of the break glass credential.",
+        "type": "string",
+        "enum": [
+          "awaiting_revocation",
+          "created",
+          "denied",
+          "expired",
+          "failed",
+          "issued",
+          "issuing",
+          "revoked",
+          "revoking"
+        ]
+      },
+      "BreakGlassCredentialStatusDetails": {
+        "description": "Representation of the status details of a break glass credential",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'BreakGlassCredentialStatusDetails' if this is a complete object or 'BreakGlassCredentialStatusDetailsLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A descriptive message providing additional context about the current state of\nthe credential",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state of the credential",
+            "$ref": "#/components/schemas/BreakGlassCredentialState"
+          }
+        }
       },
       "ByoOidc": {
         "description": "ByoOidc configuration.",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -15119,6 +15119,11 @@
             "description": "Self link.",
             "type": "string"
           },
+          "creation_timestamp": {
+            "description": "CreationTimestamp is the date and time when the credential was created.",
+            "type": "string",
+            "format": "date-time"
+          },
           "expiration_timestamp": {
             "description": "ExpirationTimestamp is the date and time when the credential will expire.",
             "type": "string",
@@ -15137,9 +15142,27 @@
             "description": "Status is the status of this credential",
             "$ref": "#/components/schemas/BreakGlassCredentialStatus"
           },
+          "status_details": {
+            "description": "Additional information about the current state of this credential",
+            "$ref": "#/components/schemas/BreakGlassCredentialStatusDetails"
+          },
           "username": {
             "description": "Username is the user which will be used for this credential.",
             "type": "string"
+          }
+        }
+      },
+      "BreakGlassCredentialState": {
+        "description": "Representation of the state of a break glass credential",
+        "properties": {
+          "last_updated_timestamp": {
+            "description": "The date and time when the credential state was last updated",
+            "type": "string",
+            "format": "date-time"
+          },
+          "value": {
+            "description": "A string value representing the credential's current state",
+            "$ref": "#/components/schemas/BreakGlassCredentialStatus"
           }
         }
       },
@@ -15149,11 +15172,39 @@
         "enum": [
           "awaiting_revocation",
           "created",
+          "denied",
           "expired",
           "failed",
           "issued",
-          "revoked"
+          "issuing",
+          "revoked",
+          "revoking"
         ]
+      },
+      "BreakGlassCredentialStatusDetails": {
+        "description": "Representation of the status details of a break glass credential",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'BreakGlassCredentialStatusDetails' if this is a complete object or 'BreakGlassCredentialStatusDetailsLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "message": {
+            "description": "A descriptive message providing additional context about the current state of\nthe credential",
+            "type": "string"
+          },
+          "state": {
+            "description": "The current state of the credential",
+            "$ref": "#/components/schemas/BreakGlassCredentialState"
+          }
+        }
       },
       "ByoOidc": {
         "description": "ByoOidc configuration.",


### PR DESCRIPTION
h4. What

The design document for this API can be found in  [XCMSTRAT-1135](https://issues.redhat.com/browse/XCMSTRAT-1135).

The proposed endpoints in ARO HCP v1alpha1 is as follows:

```
GET POST DELETE
/clusters/{cluster_id}/break_glass_credentials

GET 
/clusters/{cluster_id}/break_glass_credentials/{break_glass_credential_id}
```

The break glass credentials API for both _clusters_mgmt/v1_ and _aro_hcp/v1alpha1_ should have similar features apart from the following differences:
- Creating and deleting break glass credentials for ARO HCP clusters needs to be done asynchronously. The POST and DELETE endpoints must return a 202 Accepted status code.
- Additional states were added: `issuing`, `revoking` and `denied`

A few additional properties has been added to _clusters_mgmt/v1_ `BreakGlassCredentials` type:
- *CreationTimestamp*: added in order to determine when to clean up 'denied' and 'failed' credentials. It may also be useful for auditing/tracing. 
   
  For existing credentials, these will be set to a default of zero time. These will be omitted in the API output. Moving forward, all break glass credentials under both _clusters_mgmt/v1_ and _aro_hcp/v1alpha1_ will have this property set.
- *StatusDetails*: added to contain additional properties about the break glass credential's state such as 'message'. As there is already an existing `Status` property, we can't align its name with the rest of the other endpoints like Node Pools to capture this information. A few alternative options on naming were considered such as 'State' or 'StatusContext'.

Additional endpoints that we may consider adding:
```
GET
/clusters/{cluster_id}/break_glass_credentials/{break_glass_credential_id}/status
```
- A similar proposal was made for external authentication provider, based on the discussion there, we may want to consider adding this endpoint for break glass credentials as well: https://github.com/openshift-online/ocm-api-model/pull/1047#discussion_r2140398429

Only the openapi files have been generated for now to make it easier to review the changes here.

Resulting changes in the ARO HCP API
<img width="1463" alt="image" src="https://github.com/user-attachments/assets/80f63993-97a7-4501-8025-628201edd2ff" />
