### PR TITLE
ARO-19064: Make OCM API changes for Azure Etcd data level encryption with customer managed keys.

### DIFF
--- a/clientapi/arohcp/v1alpha1/azure_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_builder.go
@@ -24,6 +24,7 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 // Microsoft Azure settings of a cluster.
 type AzureBuilder struct {
 	bitmap_                        uint32
+	etcdEncryption                 *AzureEtcdEncryptionBuilder
 	managedResourceGroupName       string
 	networkSecurityGroupResourceID string
 	nodesOutboundConnectivity      *AzureNodesOutboundConnectivityBuilder
@@ -45,17 +46,30 @@ func (b *AzureBuilder) Empty() bool {
 	return b == nil || b.bitmap_ == 0
 }
 
+// EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+func (b *AzureBuilder) EtcdEncryption(value *AzureEtcdEncryptionBuilder) *AzureBuilder {
+	b.etcdEncryption = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
 // ManagedResourceGroupName sets the value of the 'managed_resource_group_name' attribute to the given value.
 func (b *AzureBuilder) ManagedResourceGroupName(value string) *AzureBuilder {
 	b.managedResourceGroupName = value
-	b.bitmap_ |= 1
+	b.bitmap_ |= 2
 	return b
 }
 
 // NetworkSecurityGroupResourceID sets the value of the 'network_security_group_resource_ID' attribute to the given value.
 func (b *AzureBuilder) NetworkSecurityGroupResourceID(value string) *AzureBuilder {
 	b.networkSecurityGroupResourceID = value
-	b.bitmap_ |= 2
+	b.bitmap_ |= 4
 	return b
 }
 
@@ -65,9 +79,9 @@ func (b *AzureBuilder) NetworkSecurityGroupResourceID(value string) *AzureBuilde
 func (b *AzureBuilder) NodesOutboundConnectivity(value *AzureNodesOutboundConnectivityBuilder) *AzureBuilder {
 	b.nodesOutboundConnectivity = value
 	if value != nil {
-		b.bitmap_ |= 4
+		b.bitmap_ |= 8
 	} else {
-		b.bitmap_ &^= 4
+		b.bitmap_ &^= 8
 	}
 	return b
 }
@@ -79,9 +93,9 @@ func (b *AzureBuilder) NodesOutboundConnectivity(value *AzureNodesOutboundConnec
 func (b *AzureBuilder) OperatorsAuthentication(value *AzureOperatorsAuthenticationBuilder) *AzureBuilder {
 	b.operatorsAuthentication = value
 	if value != nil {
-		b.bitmap_ |= 8
+		b.bitmap_ |= 16
 	} else {
-		b.bitmap_ &^= 8
+		b.bitmap_ &^= 16
 	}
 	return b
 }
@@ -89,35 +103,35 @@ func (b *AzureBuilder) OperatorsAuthentication(value *AzureOperatorsAuthenticati
 // ResourceGroupName sets the value of the 'resource_group_name' attribute to the given value.
 func (b *AzureBuilder) ResourceGroupName(value string) *AzureBuilder {
 	b.resourceGroupName = value
-	b.bitmap_ |= 16
+	b.bitmap_ |= 32
 	return b
 }
 
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureBuilder) ResourceName(value string) *AzureBuilder {
 	b.resourceName = value
-	b.bitmap_ |= 32
+	b.bitmap_ |= 64
 	return b
 }
 
 // SubnetResourceID sets the value of the 'subnet_resource_ID' attribute to the given value.
 func (b *AzureBuilder) SubnetResourceID(value string) *AzureBuilder {
 	b.subnetResourceID = value
-	b.bitmap_ |= 64
+	b.bitmap_ |= 128
 	return b
 }
 
 // SubscriptionID sets the value of the 'subscription_ID' attribute to the given value.
 func (b *AzureBuilder) SubscriptionID(value string) *AzureBuilder {
 	b.subscriptionID = value
-	b.bitmap_ |= 128
+	b.bitmap_ |= 256
 	return b
 }
 
 // TenantID sets the value of the 'tenant_ID' attribute to the given value.
 func (b *AzureBuilder) TenantID(value string) *AzureBuilder {
 	b.tenantID = value
-	b.bitmap_ |= 256
+	b.bitmap_ |= 512
 	return b
 }
 
@@ -127,6 +141,11 @@ func (b *AzureBuilder) Copy(object *Azure) *AzureBuilder {
 		return b
 	}
 	b.bitmap_ = object.bitmap_
+	if object.etcdEncryption != nil {
+		b.etcdEncryption = NewAzureEtcdEncryption().Copy(object.etcdEncryption)
+	} else {
+		b.etcdEncryption = nil
+	}
 	b.managedResourceGroupName = object.managedResourceGroupName
 	b.networkSecurityGroupResourceID = object.networkSecurityGroupResourceID
 	if object.nodesOutboundConnectivity != nil {
@@ -151,6 +170,12 @@ func (b *AzureBuilder) Copy(object *Azure) *AzureBuilder {
 func (b *AzureBuilder) Build() (object *Azure, err error) {
 	object = new(Azure)
 	object.bitmap_ = b.bitmap_
+	if b.etcdEncryption != nil {
+		object.etcdEncryption, err = b.etcdEncryption.Build()
+		if err != nil {
+			return
+		}
+	}
 	object.managedResourceGroupName = b.managedResourceGroupName
 	object.networkSecurityGroupResourceID = b.networkSecurityGroupResourceID
 	if b.nodesOutboundConnectivity != nil {

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_builder.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdDataEncryptionBuilder contains the data and logic needed to build 'azure_etcd_data_encryption' objects.
+//
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+type AzureEtcdDataEncryptionBuilder struct {
+	bitmap_           uint32
+	customerManaged   *AzureEtcdDataEncryptionCustomerManagedBuilder
+	keyManagementMode string
+}
+
+// NewAzureEtcdDataEncryption creates a new builder of 'azure_etcd_data_encryption' objects.
+func NewAzureEtcdDataEncryption() *AzureEtcdDataEncryptionBuilder {
+	return &AzureEtcdDataEncryptionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureEtcdDataEncryptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// CustomerManaged sets the value of the 'customer_managed' attribute to the given value.
+//
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+func (b *AzureEtcdDataEncryptionBuilder) CustomerManaged(value *AzureEtcdDataEncryptionCustomerManagedBuilder) *AzureEtcdDataEncryptionBuilder {
+	b.customerManaged = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// KeyManagementMode sets the value of the 'key_management_mode' attribute to the given value.
+func (b *AzureEtcdDataEncryptionBuilder) KeyManagementMode(value string) *AzureEtcdDataEncryptionBuilder {
+	b.keyManagementMode = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureEtcdDataEncryptionBuilder) Copy(object *AzureEtcdDataEncryption) *AzureEtcdDataEncryptionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.customerManaged != nil {
+		b.customerManaged = NewAzureEtcdDataEncryptionCustomerManaged().Copy(object.customerManaged)
+	} else {
+		b.customerManaged = nil
+	}
+	b.keyManagementMode = object.keyManagementMode
+	return b
+}
+
+// Build creates a 'azure_etcd_data_encryption' object using the configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionBuilder) Build() (object *AzureEtcdDataEncryption, err error) {
+	object = new(AzureEtcdDataEncryption)
+	object.bitmap_ = b.bitmap_
+	if b.customerManaged != nil {
+		object.customerManaged, err = b.customerManaged.Build()
+		if err != nil {
+			return
+		}
+	}
+	object.keyManagementMode = b.keyManagementMode
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_builder.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdDataEncryptionCustomerManagedBuilder contains the data and logic needed to build 'azure_etcd_data_encryption_customer_managed' objects.
+//
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+type AzureEtcdDataEncryptionCustomerManagedBuilder struct {
+	bitmap_        uint32
+	encryptionType string
+	kms            *AzureKmsEncryptionBuilder
+}
+
+// NewAzureEtcdDataEncryptionCustomerManaged creates a new builder of 'azure_etcd_data_encryption_customer_managed' objects.
+func NewAzureEtcdDataEncryptionCustomerManaged() *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	return &AzureEtcdDataEncryptionCustomerManagedBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// EncryptionType sets the value of the 'encryption_type' attribute to the given value.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) EncryptionType(value string) *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	b.encryptionType = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Kms sets the value of the 'kms' attribute to the given value.
+//
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Kms(value *AzureKmsEncryptionBuilder) *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	b.kms = value
+	if value != nil {
+		b.bitmap_ |= 2
+	} else {
+		b.bitmap_ &^= 2
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Copy(object *AzureEtcdDataEncryptionCustomerManaged) *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.encryptionType = object.encryptionType
+	if object.kms != nil {
+		b.kms = NewAzureKmsEncryption().Copy(object.kms)
+	} else {
+		b.kms = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_etcd_data_encryption_customer_managed' object using the configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Build() (object *AzureEtcdDataEncryptionCustomerManaged, err error) {
+	object = new(AzureEtcdDataEncryptionCustomerManaged)
+	object.bitmap_ = b.bitmap_
+	object.encryptionType = b.encryptionType
+	if b.kms != nil {
+		object.kms, err = b.kms.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdDataEncryptionCustomerManagedListBuilder contains the data and logic needed to build
+// 'azure_etcd_data_encryption_customer_managed' objects.
+type AzureEtcdDataEncryptionCustomerManagedListBuilder struct {
+	items []*AzureEtcdDataEncryptionCustomerManagedBuilder
+}
+
+// NewAzureEtcdDataEncryptionCustomerManagedList creates a new builder of 'azure_etcd_data_encryption_customer_managed' objects.
+func NewAzureEtcdDataEncryptionCustomerManagedList() *AzureEtcdDataEncryptionCustomerManagedListBuilder {
+	return new(AzureEtcdDataEncryptionCustomerManagedListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Items(values ...*AzureEtcdDataEncryptionCustomerManagedBuilder) *AzureEtcdDataEncryptionCustomerManagedListBuilder {
+	b.items = make([]*AzureEtcdDataEncryptionCustomerManagedBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Copy(list *AzureEtcdDataEncryptionCustomerManagedList) *AzureEtcdDataEncryptionCustomerManagedListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureEtcdDataEncryptionCustomerManagedBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureEtcdDataEncryptionCustomerManaged().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_etcd_data_encryption_customer_managed' objects using the
+// configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Build() (list *AzureEtcdDataEncryptionCustomerManagedList, err error) {
+	items := make([]*AzureEtcdDataEncryptionCustomerManaged, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureEtcdDataEncryptionCustomerManagedList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryptionCustomerManagedList writes a list of values of the 'azure_etcd_data_encryption_customer_managed' type to
+// the given writer.
+func MarshalAzureEtcdDataEncryptionCustomerManagedList(list []*AzureEtcdDataEncryptionCustomerManaged, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryptionCustomerManagedList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryptionCustomerManagedList writes a list of value of the 'azure_etcd_data_encryption_customer_managed' type to
+// the given stream.
+func WriteAzureEtcdDataEncryptionCustomerManagedList(list []*AzureEtcdDataEncryptionCustomerManaged, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureEtcdDataEncryptionCustomerManaged(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryptionCustomerManagedList reads a list of values of the 'azure_etcd_data_encryption_customer_managed' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryptionCustomerManagedList(source interface{}) (items []*AzureEtcdDataEncryptionCustomerManaged, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureEtcdDataEncryptionCustomerManagedList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryptionCustomerManagedList reads list of values of the ”azure_etcd_data_encryption_customer_managed' type from
+// the given iterator.
+func ReadAzureEtcdDataEncryptionCustomerManagedList(iterator *jsoniter.Iterator) []*AzureEtcdDataEncryptionCustomerManaged {
+	list := []*AzureEtcdDataEncryptionCustomerManaged{}
+	for iterator.ReadArray() {
+		item := ReadAzureEtcdDataEncryptionCustomerManaged(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_type.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdDataEncryptionCustomerManaged represents the values of the 'azure_etcd_data_encryption_customer_managed' type.
+//
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+type AzureEtcdDataEncryptionCustomerManaged struct {
+	bitmap_        uint32
+	encryptionType string
+	kms            *AzureKmsEncryption
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureEtcdDataEncryptionCustomerManaged) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// EncryptionType returns the value of the 'encryption_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The encryption type used.
+// Accepted values are: "kms".
+// By default, "kms" is used.
+func (o *AzureEtcdDataEncryptionCustomerManaged) EncryptionType() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.encryptionType
+	}
+	return ""
+}
+
+// GetEncryptionType returns the value of the 'encryption_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The encryption type used.
+// Accepted values are: "kms".
+// By default, "kms" is used.
+func (o *AzureEtcdDataEncryptionCustomerManaged) GetEncryptionType() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.encryptionType
+	}
+	return
+}
+
+// Kms returns the value of the 'kms' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The KMS encryption configuration.
+// Required when encryption_type is "kms".
+func (o *AzureEtcdDataEncryptionCustomerManaged) Kms() *AzureKmsEncryption {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.kms
+	}
+	return nil
+}
+
+// GetKms returns the value of the 'kms' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The KMS encryption configuration.
+// Required when encryption_type is "kms".
+func (o *AzureEtcdDataEncryptionCustomerManaged) GetKms() (value *AzureKmsEncryption, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.kms
+	}
+	return
+}
+
+// AzureEtcdDataEncryptionCustomerManagedListKind is the name of the type used to represent list of objects of
+// type 'azure_etcd_data_encryption_customer_managed'.
+const AzureEtcdDataEncryptionCustomerManagedListKind = "AzureEtcdDataEncryptionCustomerManagedList"
+
+// AzureEtcdDataEncryptionCustomerManagedListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_etcd_data_encryption_customer_managed'.
+const AzureEtcdDataEncryptionCustomerManagedListLinkKind = "AzureEtcdDataEncryptionCustomerManagedListLink"
+
+// AzureEtcdDataEncryptionCustomerManagedNilKind is the name of the type used to nil lists of objects of
+// type 'azure_etcd_data_encryption_customer_managed'.
+const AzureEtcdDataEncryptionCustomerManagedListNilKind = "AzureEtcdDataEncryptionCustomerManagedListNil"
+
+// AzureEtcdDataEncryptionCustomerManagedList is a list of values of the 'azure_etcd_data_encryption_customer_managed' type.
+type AzureEtcdDataEncryptionCustomerManagedList struct {
+	href  string
+	link  bool
+	items []*AzureEtcdDataEncryptionCustomerManaged
+}
+
+// Len returns the length of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) SetItems(items []*AzureEtcdDataEncryptionCustomerManaged) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Items() []*AzureEtcdDataEncryptionCustomerManaged {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Get(i int) *AzureEtcdDataEncryptionCustomerManaged {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Slice() []*AzureEtcdDataEncryptionCustomerManaged {
+	var slice []*AzureEtcdDataEncryptionCustomerManaged
+	if l == nil {
+		slice = make([]*AzureEtcdDataEncryptionCustomerManaged, 0)
+	} else {
+		slice = make([]*AzureEtcdDataEncryptionCustomerManaged, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Each(f func(item *AzureEtcdDataEncryptionCustomerManaged) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Range(f func(index int, item *AzureEtcdDataEncryptionCustomerManaged) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_customer_managed_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryptionCustomerManaged writes a value of the 'azure_etcd_data_encryption_customer_managed' type to the given writer.
+func MarshalAzureEtcdDataEncryptionCustomerManaged(object *AzureEtcdDataEncryptionCustomerManaged, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryptionCustomerManaged(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryptionCustomerManaged writes a value of the 'azure_etcd_data_encryption_customer_managed' type to the given stream.
+func WriteAzureEtcdDataEncryptionCustomerManaged(object *AzureEtcdDataEncryptionCustomerManaged, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("encryption_type")
+		stream.WriteString(object.encryptionType)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.kms != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("kms")
+		WriteAzureKmsEncryption(object.kms, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryptionCustomerManaged reads a value of the 'azure_etcd_data_encryption_customer_managed' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryptionCustomerManaged(source interface{}) (object *AzureEtcdDataEncryptionCustomerManaged, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureEtcdDataEncryptionCustomerManaged(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryptionCustomerManaged reads a value of the 'azure_etcd_data_encryption_customer_managed' type from the given iterator.
+func ReadAzureEtcdDataEncryptionCustomerManaged(iterator *jsoniter.Iterator) *AzureEtcdDataEncryptionCustomerManaged {
+	object := &AzureEtcdDataEncryptionCustomerManaged{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "encryption_type":
+			value := iterator.ReadString()
+			object.encryptionType = value
+			object.bitmap_ |= 1
+		case "kms":
+			value := ReadAzureKmsEncryption(iterator)
+			object.kms = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdDataEncryptionListBuilder contains the data and logic needed to build
+// 'azure_etcd_data_encryption' objects.
+type AzureEtcdDataEncryptionListBuilder struct {
+	items []*AzureEtcdDataEncryptionBuilder
+}
+
+// NewAzureEtcdDataEncryptionList creates a new builder of 'azure_etcd_data_encryption' objects.
+func NewAzureEtcdDataEncryptionList() *AzureEtcdDataEncryptionListBuilder {
+	return new(AzureEtcdDataEncryptionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureEtcdDataEncryptionListBuilder) Items(values ...*AzureEtcdDataEncryptionBuilder) *AzureEtcdDataEncryptionListBuilder {
+	b.items = make([]*AzureEtcdDataEncryptionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureEtcdDataEncryptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureEtcdDataEncryptionListBuilder) Copy(list *AzureEtcdDataEncryptionList) *AzureEtcdDataEncryptionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureEtcdDataEncryptionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureEtcdDataEncryption().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_etcd_data_encryption' objects using the
+// configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionListBuilder) Build() (list *AzureEtcdDataEncryptionList, err error) {
+	items := make([]*AzureEtcdDataEncryption, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureEtcdDataEncryptionList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryptionList writes a list of values of the 'azure_etcd_data_encryption' type to
+// the given writer.
+func MarshalAzureEtcdDataEncryptionList(list []*AzureEtcdDataEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryptionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryptionList writes a list of value of the 'azure_etcd_data_encryption' type to
+// the given stream.
+func WriteAzureEtcdDataEncryptionList(list []*AzureEtcdDataEncryption, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureEtcdDataEncryption(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryptionList reads a list of values of the 'azure_etcd_data_encryption' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryptionList(source interface{}) (items []*AzureEtcdDataEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureEtcdDataEncryptionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryptionList reads list of values of the ”azure_etcd_data_encryption' type from
+// the given iterator.
+func ReadAzureEtcdDataEncryptionList(iterator *jsoniter.Iterator) []*AzureEtcdDataEncryption {
+	list := []*AzureEtcdDataEncryption{}
+	for iterator.ReadArray() {
+		item := ReadAzureEtcdDataEncryption(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_type.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdDataEncryption represents the values of the 'azure_etcd_data_encryption' type.
+//
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+type AzureEtcdDataEncryption struct {
+	bitmap_           uint32
+	customerManaged   *AzureEtcdDataEncryptionCustomerManaged
+	keyManagementMode string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureEtcdDataEncryption) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// CustomerManaged returns the value of the 'customer_managed' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Customer Managed encryption keys configuration.
+// Required when key_management_mode is "customer_managed".
+func (o *AzureEtcdDataEncryption) CustomerManaged() *AzureEtcdDataEncryptionCustomerManaged {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.customerManaged
+	}
+	return nil
+}
+
+// GetCustomerManaged returns the value of the 'customer_managed' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Customer Managed encryption keys configuration.
+// Required when key_management_mode is "customer_managed".
+func (o *AzureEtcdDataEncryption) GetCustomerManaged() (value *AzureEtcdDataEncryptionCustomerManaged, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.customerManaged
+	}
+	return
+}
+
+// KeyManagementMode returns the value of the 'key_management_mode' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The key management strategy used for the encryption key that encrypts the etcd data.
+// Accepted values are: "customer_managed", "platform_managed".
+// By default, "platform_managed" is used.
+// Currently only "customer_managed" mode is supported.
+func (o *AzureEtcdDataEncryption) KeyManagementMode() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.keyManagementMode
+	}
+	return ""
+}
+
+// GetKeyManagementMode returns the value of the 'key_management_mode' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The key management strategy used for the encryption key that encrypts the etcd data.
+// Accepted values are: "customer_managed", "platform_managed".
+// By default, "platform_managed" is used.
+// Currently only "customer_managed" mode is supported.
+func (o *AzureEtcdDataEncryption) GetKeyManagementMode() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.keyManagementMode
+	}
+	return
+}
+
+// AzureEtcdDataEncryptionListKind is the name of the type used to represent list of objects of
+// type 'azure_etcd_data_encryption'.
+const AzureEtcdDataEncryptionListKind = "AzureEtcdDataEncryptionList"
+
+// AzureEtcdDataEncryptionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_etcd_data_encryption'.
+const AzureEtcdDataEncryptionListLinkKind = "AzureEtcdDataEncryptionListLink"
+
+// AzureEtcdDataEncryptionNilKind is the name of the type used to nil lists of objects of
+// type 'azure_etcd_data_encryption'.
+const AzureEtcdDataEncryptionListNilKind = "AzureEtcdDataEncryptionListNil"
+
+// AzureEtcdDataEncryptionList is a list of values of the 'azure_etcd_data_encryption' type.
+type AzureEtcdDataEncryptionList struct {
+	href  string
+	link  bool
+	items []*AzureEtcdDataEncryption
+}
+
+// Len returns the length of the list.
+func (l *AzureEtcdDataEncryptionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionList) SetItems(items []*AzureEtcdDataEncryption) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureEtcdDataEncryptionList) Items() []*AzureEtcdDataEncryption {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureEtcdDataEncryptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureEtcdDataEncryptionList) Get(i int) *AzureEtcdDataEncryption {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureEtcdDataEncryptionList) Slice() []*AzureEtcdDataEncryption {
+	var slice []*AzureEtcdDataEncryption
+	if l == nil {
+		slice = make([]*AzureEtcdDataEncryption, 0)
+	} else {
+		slice = make([]*AzureEtcdDataEncryption, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureEtcdDataEncryptionList) Each(f func(item *AzureEtcdDataEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureEtcdDataEncryptionList) Range(f func(index int, item *AzureEtcdDataEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_data_encryption_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryption writes a value of the 'azure_etcd_data_encryption' type to the given writer.
+func MarshalAzureEtcdDataEncryption(object *AzureEtcdDataEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryption(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryption writes a value of the 'azure_etcd_data_encryption' type to the given stream.
+func WriteAzureEtcdDataEncryption(object *AzureEtcdDataEncryption, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.customerManaged != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("customer_managed")
+		WriteAzureEtcdDataEncryptionCustomerManaged(object.customerManaged, stream)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_management_mode")
+		stream.WriteString(object.keyManagementMode)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryption reads a value of the 'azure_etcd_data_encryption' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryption(source interface{}) (object *AzureEtcdDataEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureEtcdDataEncryption(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryption reads a value of the 'azure_etcd_data_encryption' type from the given iterator.
+func ReadAzureEtcdDataEncryption(iterator *jsoniter.Iterator) *AzureEtcdDataEncryption {
+	object := &AzureEtcdDataEncryption{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "customer_managed":
+			value := ReadAzureEtcdDataEncryptionCustomerManaged(iterator)
+			object.customerManaged = value
+			object.bitmap_ |= 1
+		case "key_management_mode":
+			value := iterator.ReadString()
+			object.keyManagementMode = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_encryption_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_encryption_builder.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdEncryptionBuilder contains the data and logic needed to build 'azure_etcd_encryption' objects.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+type AzureEtcdEncryptionBuilder struct {
+	bitmap_        uint32
+	dataEncryption *AzureEtcdDataEncryptionBuilder
+}
+
+// NewAzureEtcdEncryption creates a new builder of 'azure_etcd_encryption' objects.
+func NewAzureEtcdEncryption() *AzureEtcdEncryptionBuilder {
+	return &AzureEtcdEncryptionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureEtcdEncryptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// DataEncryption sets the value of the 'data_encryption' attribute to the given value.
+//
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+func (b *AzureEtcdEncryptionBuilder) DataEncryption(value *AzureEtcdDataEncryptionBuilder) *AzureEtcdEncryptionBuilder {
+	b.dataEncryption = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureEtcdEncryptionBuilder) Copy(object *AzureEtcdEncryption) *AzureEtcdEncryptionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.dataEncryption != nil {
+		b.dataEncryption = NewAzureEtcdDataEncryption().Copy(object.dataEncryption)
+	} else {
+		b.dataEncryption = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_etcd_encryption' object using the configuration stored in the builder.
+func (b *AzureEtcdEncryptionBuilder) Build() (object *AzureEtcdEncryption, err error) {
+	object = new(AzureEtcdEncryption)
+	object.bitmap_ = b.bitmap_
+	if b.dataEncryption != nil {
+		object.dataEncryption, err = b.dataEncryption.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_encryption_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_encryption_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdEncryptionListBuilder contains the data and logic needed to build
+// 'azure_etcd_encryption' objects.
+type AzureEtcdEncryptionListBuilder struct {
+	items []*AzureEtcdEncryptionBuilder
+}
+
+// NewAzureEtcdEncryptionList creates a new builder of 'azure_etcd_encryption' objects.
+func NewAzureEtcdEncryptionList() *AzureEtcdEncryptionListBuilder {
+	return new(AzureEtcdEncryptionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureEtcdEncryptionListBuilder) Items(values ...*AzureEtcdEncryptionBuilder) *AzureEtcdEncryptionListBuilder {
+	b.items = make([]*AzureEtcdEncryptionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureEtcdEncryptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureEtcdEncryptionListBuilder) Copy(list *AzureEtcdEncryptionList) *AzureEtcdEncryptionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureEtcdEncryptionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureEtcdEncryption().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_etcd_encryption' objects using the
+// configuration stored in the builder.
+func (b *AzureEtcdEncryptionListBuilder) Build() (list *AzureEtcdEncryptionList, err error) {
+	items := make([]*AzureEtcdEncryption, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureEtcdEncryptionList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_encryption_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_encryption_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdEncryptionList writes a list of values of the 'azure_etcd_encryption' type to
+// the given writer.
+func MarshalAzureEtcdEncryptionList(list []*AzureEtcdEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdEncryptionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdEncryptionList writes a list of value of the 'azure_etcd_encryption' type to
+// the given stream.
+func WriteAzureEtcdEncryptionList(list []*AzureEtcdEncryption, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureEtcdEncryption(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureEtcdEncryptionList reads a list of values of the 'azure_etcd_encryption' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdEncryptionList(source interface{}) (items []*AzureEtcdEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureEtcdEncryptionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdEncryptionList reads list of values of the ”azure_etcd_encryption' type from
+// the given iterator.
+func ReadAzureEtcdEncryptionList(iterator *jsoniter.Iterator) []*AzureEtcdEncryption {
+	list := []*AzureEtcdEncryption{}
+	for iterator.ReadArray() {
+		item := ReadAzureEtcdEncryption(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_encryption_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_encryption_type.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureEtcdEncryption represents the values of the 'azure_etcd_encryption' type.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+type AzureEtcdEncryption struct {
+	bitmap_        uint32
+	dataEncryption *AzureEtcdDataEncryption
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureEtcdEncryption) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// DataEncryption returns the value of the 'data_encryption' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// etcd data encryption settings.
+// If not specified, etcd data is encrypted with platform managed keys.
+func (o *AzureEtcdEncryption) DataEncryption() *AzureEtcdDataEncryption {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.dataEncryption
+	}
+	return nil
+}
+
+// GetDataEncryption returns the value of the 'data_encryption' attribute and
+// a flag indicating if the attribute has a value.
+//
+// etcd data encryption settings.
+// If not specified, etcd data is encrypted with platform managed keys.
+func (o *AzureEtcdEncryption) GetDataEncryption() (value *AzureEtcdDataEncryption, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.dataEncryption
+	}
+	return
+}
+
+// AzureEtcdEncryptionListKind is the name of the type used to represent list of objects of
+// type 'azure_etcd_encryption'.
+const AzureEtcdEncryptionListKind = "AzureEtcdEncryptionList"
+
+// AzureEtcdEncryptionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_etcd_encryption'.
+const AzureEtcdEncryptionListLinkKind = "AzureEtcdEncryptionListLink"
+
+// AzureEtcdEncryptionNilKind is the name of the type used to nil lists of objects of
+// type 'azure_etcd_encryption'.
+const AzureEtcdEncryptionListNilKind = "AzureEtcdEncryptionListNil"
+
+// AzureEtcdEncryptionList is a list of values of the 'azure_etcd_encryption' type.
+type AzureEtcdEncryptionList struct {
+	href  string
+	link  bool
+	items []*AzureEtcdEncryption
+}
+
+// Len returns the length of the list.
+func (l *AzureEtcdEncryptionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdEncryptionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdEncryptionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdEncryptionList) SetItems(items []*AzureEtcdEncryption) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureEtcdEncryptionList) Items() []*AzureEtcdEncryption {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureEtcdEncryptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureEtcdEncryptionList) Get(i int) *AzureEtcdEncryption {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureEtcdEncryptionList) Slice() []*AzureEtcdEncryption {
+	var slice []*AzureEtcdEncryption
+	if l == nil {
+		slice = make([]*AzureEtcdEncryption, 0)
+	} else {
+		slice = make([]*AzureEtcdEncryption, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureEtcdEncryptionList) Each(f func(item *AzureEtcdEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureEtcdEncryptionList) Range(f func(index int, item *AzureEtcdEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_etcd_encryption_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_etcd_encryption_type_json.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdEncryption writes a value of the 'azure_etcd_encryption' type to the given writer.
+func MarshalAzureEtcdEncryption(object *AzureEtcdEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdEncryption(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdEncryption writes a value of the 'azure_etcd_encryption' type to the given stream.
+func WriteAzureEtcdEncryption(object *AzureEtcdEncryption, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.dataEncryption != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("data_encryption")
+		WriteAzureEtcdDataEncryption(object.dataEncryption, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureEtcdEncryption reads a value of the 'azure_etcd_encryption' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdEncryption(source interface{}) (object *AzureEtcdEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureEtcdEncryption(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdEncryption reads a value of the 'azure_etcd_encryption' type from the given iterator.
+func ReadAzureEtcdEncryption(iterator *jsoniter.Iterator) *AzureEtcdEncryption {
+	object := &AzureEtcdEncryption{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "data_encryption":
+			value := ReadAzureEtcdDataEncryption(iterator)
+			object.dataEncryption = value
+			object.bitmap_ |= 1
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_encryption_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_encryption_builder.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureKmsEncryptionBuilder contains the data and logic needed to build 'azure_kms_encryption' objects.
+//
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+type AzureKmsEncryptionBuilder struct {
+	bitmap_   uint32
+	activeKey *AzureKmsKeyBuilder
+}
+
+// NewAzureKmsEncryption creates a new builder of 'azure_kms_encryption' objects.
+func NewAzureKmsEncryption() *AzureKmsEncryptionBuilder {
+	return &AzureKmsEncryptionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureKmsEncryptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// ActiveKey sets the value of the 'active_key' attribute to the given value.
+//
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+func (b *AzureKmsEncryptionBuilder) ActiveKey(value *AzureKmsKeyBuilder) *AzureKmsEncryptionBuilder {
+	b.activeKey = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureKmsEncryptionBuilder) Copy(object *AzureKmsEncryption) *AzureKmsEncryptionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.activeKey != nil {
+		b.activeKey = NewAzureKmsKey().Copy(object.activeKey)
+	} else {
+		b.activeKey = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_kms_encryption' object using the configuration stored in the builder.
+func (b *AzureKmsEncryptionBuilder) Build() (object *AzureKmsEncryption, err error) {
+	object = new(AzureKmsEncryption)
+	object.bitmap_ = b.bitmap_
+	if b.activeKey != nil {
+		object.activeKey, err = b.activeKey.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_encryption_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_encryption_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureKmsEncryptionListBuilder contains the data and logic needed to build
+// 'azure_kms_encryption' objects.
+type AzureKmsEncryptionListBuilder struct {
+	items []*AzureKmsEncryptionBuilder
+}
+
+// NewAzureKmsEncryptionList creates a new builder of 'azure_kms_encryption' objects.
+func NewAzureKmsEncryptionList() *AzureKmsEncryptionListBuilder {
+	return new(AzureKmsEncryptionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureKmsEncryptionListBuilder) Items(values ...*AzureKmsEncryptionBuilder) *AzureKmsEncryptionListBuilder {
+	b.items = make([]*AzureKmsEncryptionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureKmsEncryptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureKmsEncryptionListBuilder) Copy(list *AzureKmsEncryptionList) *AzureKmsEncryptionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureKmsEncryptionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureKmsEncryption().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_kms_encryption' objects using the
+// configuration stored in the builder.
+func (b *AzureKmsEncryptionListBuilder) Build() (list *AzureKmsEncryptionList, err error) {
+	items := make([]*AzureKmsEncryption, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureKmsEncryptionList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_encryption_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_encryption_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsEncryptionList writes a list of values of the 'azure_kms_encryption' type to
+// the given writer.
+func MarshalAzureKmsEncryptionList(list []*AzureKmsEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsEncryptionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsEncryptionList writes a list of value of the 'azure_kms_encryption' type to
+// the given stream.
+func WriteAzureKmsEncryptionList(list []*AzureKmsEncryption, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureKmsEncryption(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureKmsEncryptionList reads a list of values of the 'azure_kms_encryption' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureKmsEncryptionList(source interface{}) (items []*AzureKmsEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureKmsEncryptionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsEncryptionList reads list of values of the ”azure_kms_encryption' type from
+// the given iterator.
+func ReadAzureKmsEncryptionList(iterator *jsoniter.Iterator) []*AzureKmsEncryption {
+	list := []*AzureKmsEncryption{}
+	for iterator.ReadArray() {
+		item := ReadAzureKmsEncryption(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_encryption_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_encryption_type.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureKmsEncryption represents the values of the 'azure_kms_encryption' type.
+//
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+type AzureKmsEncryption struct {
+	bitmap_   uint32
+	activeKey *AzureKmsKey
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureKmsEncryption) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// ActiveKey returns the value of the 'active_key' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The details of the active key
+// Required during creation.
+func (o *AzureKmsEncryption) ActiveKey() *AzureKmsKey {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.activeKey
+	}
+	return nil
+}
+
+// GetActiveKey returns the value of the 'active_key' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The details of the active key
+// Required during creation.
+func (o *AzureKmsEncryption) GetActiveKey() (value *AzureKmsKey, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.activeKey
+	}
+	return
+}
+
+// AzureKmsEncryptionListKind is the name of the type used to represent list of objects of
+// type 'azure_kms_encryption'.
+const AzureKmsEncryptionListKind = "AzureKmsEncryptionList"
+
+// AzureKmsEncryptionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_kms_encryption'.
+const AzureKmsEncryptionListLinkKind = "AzureKmsEncryptionListLink"
+
+// AzureKmsEncryptionNilKind is the name of the type used to nil lists of objects of
+// type 'azure_kms_encryption'.
+const AzureKmsEncryptionListNilKind = "AzureKmsEncryptionListNil"
+
+// AzureKmsEncryptionList is a list of values of the 'azure_kms_encryption' type.
+type AzureKmsEncryptionList struct {
+	href  string
+	link  bool
+	items []*AzureKmsEncryption
+}
+
+// Len returns the length of the list.
+func (l *AzureKmsEncryptionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsEncryptionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsEncryptionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsEncryptionList) SetItems(items []*AzureKmsEncryption) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureKmsEncryptionList) Items() []*AzureKmsEncryption {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureKmsEncryptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureKmsEncryptionList) Get(i int) *AzureKmsEncryption {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureKmsEncryptionList) Slice() []*AzureKmsEncryption {
+	var slice []*AzureKmsEncryption
+	if l == nil {
+		slice = make([]*AzureKmsEncryption, 0)
+	} else {
+		slice = make([]*AzureKmsEncryption, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureKmsEncryptionList) Each(f func(item *AzureKmsEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureKmsEncryptionList) Range(f func(index int, item *AzureKmsEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_encryption_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_encryption_type_json.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsEncryption writes a value of the 'azure_kms_encryption' type to the given writer.
+func MarshalAzureKmsEncryption(object *AzureKmsEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsEncryption(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsEncryption writes a value of the 'azure_kms_encryption' type to the given stream.
+func WriteAzureKmsEncryption(object *AzureKmsEncryption, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.activeKey != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("active_key")
+		WriteAzureKmsKey(object.activeKey, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureKmsEncryption reads a value of the 'azure_kms_encryption' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureKmsEncryption(source interface{}) (object *AzureKmsEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureKmsEncryption(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsEncryption reads a value of the 'azure_kms_encryption' type from the given iterator.
+func ReadAzureKmsEncryption(iterator *jsoniter.Iterator) *AzureKmsEncryption {
+	object := &AzureKmsEncryption{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "active_key":
+			value := ReadAzureKmsKey(iterator)
+			object.activeKey = value
+			object.bitmap_ |= 1
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_key_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_key_builder.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureKmsKeyBuilder contains the data and logic needed to build 'azure_kms_key' objects.
+//
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+type AzureKmsKeyBuilder struct {
+	bitmap_      uint32
+	keyName      string
+	keyVaultName string
+	keyVersion   string
+}
+
+// NewAzureKmsKey creates a new builder of 'azure_kms_key' objects.
+func NewAzureKmsKey() *AzureKmsKeyBuilder {
+	return &AzureKmsKeyBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureKmsKeyBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// KeyName sets the value of the 'key_name' attribute to the given value.
+func (b *AzureKmsKeyBuilder) KeyName(value string) *AzureKmsKeyBuilder {
+	b.keyName = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// KeyVaultName sets the value of the 'key_vault_name' attribute to the given value.
+func (b *AzureKmsKeyBuilder) KeyVaultName(value string) *AzureKmsKeyBuilder {
+	b.keyVaultName = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// KeyVersion sets the value of the 'key_version' attribute to the given value.
+func (b *AzureKmsKeyBuilder) KeyVersion(value string) *AzureKmsKeyBuilder {
+	b.keyVersion = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureKmsKeyBuilder) Copy(object *AzureKmsKey) *AzureKmsKeyBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.keyName = object.keyName
+	b.keyVaultName = object.keyVaultName
+	b.keyVersion = object.keyVersion
+	return b
+}
+
+// Build creates a 'azure_kms_key' object using the configuration stored in the builder.
+func (b *AzureKmsKeyBuilder) Build() (object *AzureKmsKey, err error) {
+	object = new(AzureKmsKey)
+	object.bitmap_ = b.bitmap_
+	object.keyName = b.keyName
+	object.keyVaultName = b.keyVaultName
+	object.keyVersion = b.keyVersion
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_key_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_key_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureKmsKeyListBuilder contains the data and logic needed to build
+// 'azure_kms_key' objects.
+type AzureKmsKeyListBuilder struct {
+	items []*AzureKmsKeyBuilder
+}
+
+// NewAzureKmsKeyList creates a new builder of 'azure_kms_key' objects.
+func NewAzureKmsKeyList() *AzureKmsKeyListBuilder {
+	return new(AzureKmsKeyListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureKmsKeyListBuilder) Items(values ...*AzureKmsKeyBuilder) *AzureKmsKeyListBuilder {
+	b.items = make([]*AzureKmsKeyBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureKmsKeyListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureKmsKeyListBuilder) Copy(list *AzureKmsKeyList) *AzureKmsKeyListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureKmsKeyBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureKmsKey().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_kms_key' objects using the
+// configuration stored in the builder.
+func (b *AzureKmsKeyListBuilder) Build() (list *AzureKmsKeyList, err error) {
+	items := make([]*AzureKmsKey, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureKmsKeyList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_key_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_key_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsKeyList writes a list of values of the 'azure_kms_key' type to
+// the given writer.
+func MarshalAzureKmsKeyList(list []*AzureKmsKey, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsKeyList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsKeyList writes a list of value of the 'azure_kms_key' type to
+// the given stream.
+func WriteAzureKmsKeyList(list []*AzureKmsKey, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureKmsKey(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureKmsKeyList reads a list of values of the 'azure_kms_key' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureKmsKeyList(source interface{}) (items []*AzureKmsKey, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureKmsKeyList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsKeyList reads list of values of the ”azure_kms_key' type from
+// the given iterator.
+func ReadAzureKmsKeyList(iterator *jsoniter.Iterator) []*AzureKmsKey {
+	list := []*AzureKmsKey{}
+	for iterator.ReadArray() {
+		item := ReadAzureKmsKey(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_key_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_key_type.go
@@ -1,0 +1,219 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureKmsKey represents the values of the 'azure_kms_key' type.
+//
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+type AzureKmsKey struct {
+	bitmap_      uint32
+	keyName      string
+	keyVaultName string
+	keyVersion   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureKmsKey) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// KeyName returns the value of the 'key_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// key_name is the name of the Azure Key Vault Key
+// Required during creation.
+func (o *AzureKmsKey) KeyName() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.keyName
+	}
+	return ""
+}
+
+// GetKeyName returns the value of the 'key_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// key_name is the name of the Azure Key Vault Key
+// Required during creation.
+func (o *AzureKmsKey) GetKeyName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.keyName
+	}
+	return
+}
+
+// KeyVaultName returns the value of the 'key_vault_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// key_vault_name is the name of the Azure Key Vault that contains the encryption key
+// Required during creation.
+func (o *AzureKmsKey) KeyVaultName() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.keyVaultName
+	}
+	return ""
+}
+
+// GetKeyVaultName returns the value of the 'key_vault_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// key_vault_name is the name of the Azure Key Vault that contains the encryption key
+// Required during creation.
+func (o *AzureKmsKey) GetKeyVaultName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.keyVaultName
+	}
+	return
+}
+
+// KeyVersion returns the value of the 'key_version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// key_version is the version of the Azure Key Vault key
+// Required during creation.
+func (o *AzureKmsKey) KeyVersion() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.keyVersion
+	}
+	return ""
+}
+
+// GetKeyVersion returns the value of the 'key_version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// key_version is the version of the Azure Key Vault key
+// Required during creation.
+func (o *AzureKmsKey) GetKeyVersion() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.keyVersion
+	}
+	return
+}
+
+// AzureKmsKeyListKind is the name of the type used to represent list of objects of
+// type 'azure_kms_key'.
+const AzureKmsKeyListKind = "AzureKmsKeyList"
+
+// AzureKmsKeyListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_kms_key'.
+const AzureKmsKeyListLinkKind = "AzureKmsKeyListLink"
+
+// AzureKmsKeyNilKind is the name of the type used to nil lists of objects of
+// type 'azure_kms_key'.
+const AzureKmsKeyListNilKind = "AzureKmsKeyListNil"
+
+// AzureKmsKeyList is a list of values of the 'azure_kms_key' type.
+type AzureKmsKeyList struct {
+	href  string
+	link  bool
+	items []*AzureKmsKey
+}
+
+// Len returns the length of the list.
+func (l *AzureKmsKeyList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsKeyList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsKeyList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsKeyList) SetItems(items []*AzureKmsKey) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureKmsKeyList) Items() []*AzureKmsKey {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureKmsKeyList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureKmsKeyList) Get(i int) *AzureKmsKey {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureKmsKeyList) Slice() []*AzureKmsKey {
+	var slice []*AzureKmsKey
+	if l == nil {
+		slice = make([]*AzureKmsKey, 0)
+	} else {
+		slice = make([]*AzureKmsKey, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureKmsKeyList) Each(f func(item *AzureKmsKey) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureKmsKeyList) Range(f func(index int, item *AzureKmsKey) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_kms_key_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_kms_key_type_json.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsKey writes a value of the 'azure_kms_key' type to the given writer.
+func MarshalAzureKmsKey(object *AzureKmsKey, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsKey(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsKey writes a value of the 'azure_kms_key' type to the given stream.
+func WriteAzureKmsKey(object *AzureKmsKey, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_name")
+		stream.WriteString(object.keyName)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_vault_name")
+		stream.WriteString(object.keyVaultName)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_version")
+		stream.WriteString(object.keyVersion)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureKmsKey reads a value of the 'azure_kms_key' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureKmsKey(source interface{}) (object *AzureKmsKey, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureKmsKey(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsKey reads a value of the 'azure_kms_key' type from the given iterator.
+func ReadAzureKmsKey(iterator *jsoniter.Iterator) *AzureKmsKey {
+	object := &AzureKmsKey{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "key_name":
+			value := iterator.ReadString()
+			object.keyName = value
+			object.bitmap_ |= 1
+		case "key_vault_name":
+			value := iterator.ReadString()
+			object.keyVaultName = value
+			object.bitmap_ |= 2
+		case "key_version":
+			value := iterator.ReadString()
+			object.keyVersion = value
+			object.bitmap_ |= 4
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_type.go
@@ -24,6 +24,7 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 // Microsoft Azure settings of a cluster.
 type Azure struct {
 	bitmap_                        uint32
+	etcdEncryption                 *AzureEtcdEncryption
 	managedResourceGroupName       string
 	networkSecurityGroupResourceID string
 	nodesOutboundConnectivity      *AzureNodesOutboundConnectivity
@@ -38,6 +39,35 @@ type Azure struct {
 // Empty returns true if the object is empty, i.e. no attribute has a value.
 func (o *Azure) Empty() bool {
 	return o == nil || o.bitmap_ == 0
+}
+
+// EtcdEncryption returns the value of the 'etcd_encryption' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Etcd encryption configuration.
+// If not specified, etcd data is encrypted with platform managed keys.
+// Currently etcd data encryption is only supported with customer managed keys.
+// Creating a cluster with platform managed keys will result in a failure creating the cluster.
+func (o *Azure) EtcdEncryption() *AzureEtcdEncryption {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.etcdEncryption
+	}
+	return nil
+}
+
+// GetEtcdEncryption returns the value of the 'etcd_encryption' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Etcd encryption configuration.
+// If not specified, etcd data is encrypted with platform managed keys.
+// Currently etcd data encryption is only supported with customer managed keys.
+// Creating a cluster with platform managed keys will result in a failure creating the cluster.
+func (o *Azure) GetEtcdEncryption() (value *AzureEtcdEncryption, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.etcdEncryption
+	}
+	return
 }
 
 // ManagedResourceGroupName returns the value of the 'managed_resource_group_name' attribute, or
@@ -55,7 +85,7 @@ func (o *Azure) Empty() bool {
 // Required during creation.
 // Immutable.
 func (o *Azure) ManagedResourceGroupName() string {
-	if o != nil && o.bitmap_&1 != 0 {
+	if o != nil && o.bitmap_&2 != 0 {
 		return o.managedResourceGroupName
 	}
 	return ""
@@ -76,7 +106,7 @@ func (o *Azure) ManagedResourceGroupName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetManagedResourceGroupName() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&1 != 0
+	ok = o != nil && o.bitmap_&2 != 0
 	if ok {
 		value = o.managedResourceGroupName
 	}
@@ -108,7 +138,7 @@ func (o *Azure) GetManagedResourceGroupName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) NetworkSecurityGroupResourceID() string {
-	if o != nil && o.bitmap_&2 != 0 {
+	if o != nil && o.bitmap_&4 != 0 {
 		return o.networkSecurityGroupResourceID
 	}
 	return ""
@@ -139,7 +169,7 @@ func (o *Azure) NetworkSecurityGroupResourceID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetNetworkSecurityGroupResourceID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&2 != 0
+	ok = o != nil && o.bitmap_&4 != 0
 	if ok {
 		value = o.networkSecurityGroupResourceID
 	}
@@ -153,7 +183,7 @@ func (o *Azure) GetNetworkSecurityGroupResourceID() (value string, ok bool) {
 // configuration of the Cluster's Node Pool's Nodes is performed.
 // By default this is configured as Azure Load Balancer. This value is immutable.
 func (o *Azure) NodesOutboundConnectivity() *AzureNodesOutboundConnectivity {
-	if o != nil && o.bitmap_&4 != 0 {
+	if o != nil && o.bitmap_&8 != 0 {
 		return o.nodesOutboundConnectivity
 	}
 	return nil
@@ -166,7 +196,7 @@ func (o *Azure) NodesOutboundConnectivity() *AzureNodesOutboundConnectivity {
 // configuration of the Cluster's Node Pool's Nodes is performed.
 // By default this is configured as Azure Load Balancer. This value is immutable.
 func (o *Azure) GetNodesOutboundConnectivity() (value *AzureNodesOutboundConnectivity, ok bool) {
-	ok = o != nil && o.bitmap_&4 != 0
+	ok = o != nil && o.bitmap_&8 != 0
 	if ok {
 		value = o.nodesOutboundConnectivity
 	}
@@ -180,7 +210,7 @@ func (o *Azure) GetNodesOutboundConnectivity() (value *AzureNodesOutboundConnect
 // Required during creation.
 // Immutable.
 func (o *Azure) OperatorsAuthentication() *AzureOperatorsAuthentication {
-	if o != nil && o.bitmap_&8 != 0 {
+	if o != nil && o.bitmap_&16 != 0 {
 		return o.operatorsAuthentication
 	}
 	return nil
@@ -193,7 +223,7 @@ func (o *Azure) OperatorsAuthentication() *AzureOperatorsAuthentication {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetOperatorsAuthentication() (value *AzureOperatorsAuthentication, ok bool) {
-	ok = o != nil && o.bitmap_&8 != 0
+	ok = o != nil && o.bitmap_&16 != 0
 	if ok {
 		value = o.operatorsAuthentication
 	}
@@ -211,7 +241,7 @@ func (o *Azure) GetOperatorsAuthentication() (value *AzureOperatorsAuthenticatio
 // Required during creation.
 // Immutable.
 func (o *Azure) ResourceGroupName() string {
-	if o != nil && o.bitmap_&16 != 0 {
+	if o != nil && o.bitmap_&32 != 0 {
 		return o.resourceGroupName
 	}
 	return ""
@@ -228,7 +258,7 @@ func (o *Azure) ResourceGroupName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetResourceGroupName() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&16 != 0
+	ok = o != nil && o.bitmap_&32 != 0
 	if ok {
 		value = o.resourceGroupName
 	}
@@ -244,7 +274,7 @@ func (o *Azure) GetResourceGroupName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) ResourceName() string {
-	if o != nil && o.bitmap_&32 != 0 {
+	if o != nil && o.bitmap_&64 != 0 {
 		return o.resourceName
 	}
 	return ""
@@ -259,7 +289,7 @@ func (o *Azure) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetResourceName() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&32 != 0
+	ok = o != nil && o.bitmap_&64 != 0
 	if ok {
 		value = o.resourceName
 	}
@@ -286,7 +316,7 @@ func (o *Azure) GetResourceName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) SubnetResourceID() string {
-	if o != nil && o.bitmap_&64 != 0 {
+	if o != nil && o.bitmap_&128 != 0 {
 		return o.subnetResourceID
 	}
 	return ""
@@ -312,7 +342,7 @@ func (o *Azure) SubnetResourceID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetSubnetResourceID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&64 != 0
+	ok = o != nil && o.bitmap_&128 != 0
 	if ok {
 		value = o.subnetResourceID
 	}
@@ -327,7 +357,7 @@ func (o *Azure) GetSubnetResourceID() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) SubscriptionID() string {
-	if o != nil && o.bitmap_&128 != 0 {
+	if o != nil && o.bitmap_&256 != 0 {
 		return o.subscriptionID
 	}
 	return ""
@@ -341,7 +371,7 @@ func (o *Azure) SubscriptionID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetSubscriptionID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&128 != 0
+	ok = o != nil && o.bitmap_&256 != 0
 	if ok {
 		value = o.subscriptionID
 	}
@@ -355,7 +385,7 @@ func (o *Azure) GetSubscriptionID() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) TenantID() string {
-	if o != nil && o.bitmap_&256 != 0 {
+	if o != nil && o.bitmap_&512 != 0 {
 		return o.tenantID
 	}
 	return ""
@@ -368,7 +398,7 @@ func (o *Azure) TenantID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetTenantID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&256 != 0
+	ok = o != nil && o.bitmap_&512 != 0
 	if ok {
 		value = o.tenantID
 	}

--- a/clientapi/arohcp/v1alpha1/azure_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_type_json.go
@@ -42,7 +42,16 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
 	var present_ bool
-	present_ = object.bitmap_&1 != 0
+	present_ = object.bitmap_&1 != 0 && object.etcdEncryption != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("etcd_encryption")
+		WriteAzureEtcdEncryption(object.etcdEncryption, stream)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -51,7 +60,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.managedResourceGroupName)
 		count++
 	}
-	present_ = object.bitmap_&2 != 0
+	present_ = object.bitmap_&4 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -60,7 +69,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.networkSecurityGroupResourceID)
 		count++
 	}
-	present_ = object.bitmap_&4 != 0 && object.nodesOutboundConnectivity != nil
+	present_ = object.bitmap_&8 != 0 && object.nodesOutboundConnectivity != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -69,7 +78,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureNodesOutboundConnectivity(object.nodesOutboundConnectivity, stream)
 		count++
 	}
-	present_ = object.bitmap_&8 != 0 && object.operatorsAuthentication != nil
+	present_ = object.bitmap_&16 != 0 && object.operatorsAuthentication != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -78,7 +87,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureOperatorsAuthentication(object.operatorsAuthentication, stream)
 		count++
 	}
-	present_ = object.bitmap_&16 != 0
+	present_ = object.bitmap_&32 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -87,7 +96,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.resourceGroupName)
 		count++
 	}
-	present_ = object.bitmap_&32 != 0
+	present_ = object.bitmap_&64 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -96,7 +105,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.resourceName)
 		count++
 	}
-	present_ = object.bitmap_&64 != 0
+	present_ = object.bitmap_&128 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -105,7 +114,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.subnetResourceID)
 		count++
 	}
-	present_ = object.bitmap_&128 != 0
+	present_ = object.bitmap_&256 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -114,7 +123,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.subscriptionID)
 		count++
 	}
-	present_ = object.bitmap_&256 != 0
+	present_ = object.bitmap_&512 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -146,42 +155,46 @@ func ReadAzure(iterator *jsoniter.Iterator) *Azure {
 			break
 		}
 		switch field {
+		case "etcd_encryption":
+			value := ReadAzureEtcdEncryption(iterator)
+			object.etcdEncryption = value
+			object.bitmap_ |= 1
 		case "managed_resource_group_name":
 			value := iterator.ReadString()
 			object.managedResourceGroupName = value
-			object.bitmap_ |= 1
+			object.bitmap_ |= 2
 		case "network_security_group_resource_id":
 			value := iterator.ReadString()
 			object.networkSecurityGroupResourceID = value
-			object.bitmap_ |= 2
+			object.bitmap_ |= 4
 		case "nodes_outbound_connectivity":
 			value := ReadAzureNodesOutboundConnectivity(iterator)
 			object.nodesOutboundConnectivity = value
-			object.bitmap_ |= 4
+			object.bitmap_ |= 8
 		case "operators_authentication":
 			value := ReadAzureOperatorsAuthentication(iterator)
 			object.operatorsAuthentication = value
-			object.bitmap_ |= 8
+			object.bitmap_ |= 16
 		case "resource_group_name":
 			value := iterator.ReadString()
 			object.resourceGroupName = value
-			object.bitmap_ |= 16
+			object.bitmap_ |= 32
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.bitmap_ |= 32
+			object.bitmap_ |= 64
 		case "subnet_resource_id":
 			value := iterator.ReadString()
 			object.subnetResourceID = value
-			object.bitmap_ |= 64
+			object.bitmap_ |= 128
 		case "subscription_id":
 			value := iterator.ReadString()
 			object.subscriptionID = value
-			object.bitmap_ |= 128
+			object.bitmap_ |= 256
 		case "tenant_id":
 			value := iterator.ReadString()
 			object.tenantID = value
-			object.bitmap_ |= 256
+			object.bitmap_ |= 512
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/azure_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_builder.go
@@ -24,6 +24,7 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 // Microsoft Azure settings of a cluster.
 type AzureBuilder struct {
 	bitmap_                        uint32
+	etcdEncryption                 *AzureEtcdEncryptionBuilder
 	managedResourceGroupName       string
 	networkSecurityGroupResourceID string
 	nodesOutboundConnectivity      *AzureNodesOutboundConnectivityBuilder
@@ -45,17 +46,30 @@ func (b *AzureBuilder) Empty() bool {
 	return b == nil || b.bitmap_ == 0
 }
 
+// EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+func (b *AzureBuilder) EtcdEncryption(value *AzureEtcdEncryptionBuilder) *AzureBuilder {
+	b.etcdEncryption = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
 // ManagedResourceGroupName sets the value of the 'managed_resource_group_name' attribute to the given value.
 func (b *AzureBuilder) ManagedResourceGroupName(value string) *AzureBuilder {
 	b.managedResourceGroupName = value
-	b.bitmap_ |= 1
+	b.bitmap_ |= 2
 	return b
 }
 
 // NetworkSecurityGroupResourceID sets the value of the 'network_security_group_resource_ID' attribute to the given value.
 func (b *AzureBuilder) NetworkSecurityGroupResourceID(value string) *AzureBuilder {
 	b.networkSecurityGroupResourceID = value
-	b.bitmap_ |= 2
+	b.bitmap_ |= 4
 	return b
 }
 
@@ -65,9 +79,9 @@ func (b *AzureBuilder) NetworkSecurityGroupResourceID(value string) *AzureBuilde
 func (b *AzureBuilder) NodesOutboundConnectivity(value *AzureNodesOutboundConnectivityBuilder) *AzureBuilder {
 	b.nodesOutboundConnectivity = value
 	if value != nil {
-		b.bitmap_ |= 4
+		b.bitmap_ |= 8
 	} else {
-		b.bitmap_ &^= 4
+		b.bitmap_ &^= 8
 	}
 	return b
 }
@@ -79,9 +93,9 @@ func (b *AzureBuilder) NodesOutboundConnectivity(value *AzureNodesOutboundConnec
 func (b *AzureBuilder) OperatorsAuthentication(value *AzureOperatorsAuthenticationBuilder) *AzureBuilder {
 	b.operatorsAuthentication = value
 	if value != nil {
-		b.bitmap_ |= 8
+		b.bitmap_ |= 16
 	} else {
-		b.bitmap_ &^= 8
+		b.bitmap_ &^= 16
 	}
 	return b
 }
@@ -89,35 +103,35 @@ func (b *AzureBuilder) OperatorsAuthentication(value *AzureOperatorsAuthenticati
 // ResourceGroupName sets the value of the 'resource_group_name' attribute to the given value.
 func (b *AzureBuilder) ResourceGroupName(value string) *AzureBuilder {
 	b.resourceGroupName = value
-	b.bitmap_ |= 16
+	b.bitmap_ |= 32
 	return b
 }
 
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureBuilder) ResourceName(value string) *AzureBuilder {
 	b.resourceName = value
-	b.bitmap_ |= 32
+	b.bitmap_ |= 64
 	return b
 }
 
 // SubnetResourceID sets the value of the 'subnet_resource_ID' attribute to the given value.
 func (b *AzureBuilder) SubnetResourceID(value string) *AzureBuilder {
 	b.subnetResourceID = value
-	b.bitmap_ |= 64
+	b.bitmap_ |= 128
 	return b
 }
 
 // SubscriptionID sets the value of the 'subscription_ID' attribute to the given value.
 func (b *AzureBuilder) SubscriptionID(value string) *AzureBuilder {
 	b.subscriptionID = value
-	b.bitmap_ |= 128
+	b.bitmap_ |= 256
 	return b
 }
 
 // TenantID sets the value of the 'tenant_ID' attribute to the given value.
 func (b *AzureBuilder) TenantID(value string) *AzureBuilder {
 	b.tenantID = value
-	b.bitmap_ |= 256
+	b.bitmap_ |= 512
 	return b
 }
 
@@ -127,6 +141,11 @@ func (b *AzureBuilder) Copy(object *Azure) *AzureBuilder {
 		return b
 	}
 	b.bitmap_ = object.bitmap_
+	if object.etcdEncryption != nil {
+		b.etcdEncryption = NewAzureEtcdEncryption().Copy(object.etcdEncryption)
+	} else {
+		b.etcdEncryption = nil
+	}
 	b.managedResourceGroupName = object.managedResourceGroupName
 	b.networkSecurityGroupResourceID = object.networkSecurityGroupResourceID
 	if object.nodesOutboundConnectivity != nil {
@@ -151,6 +170,12 @@ func (b *AzureBuilder) Copy(object *Azure) *AzureBuilder {
 func (b *AzureBuilder) Build() (object *Azure, err error) {
 	object = new(Azure)
 	object.bitmap_ = b.bitmap_
+	if b.etcdEncryption != nil {
+		object.etcdEncryption, err = b.etcdEncryption.Build()
+		if err != nil {
+			return
+		}
+	}
 	object.managedResourceGroupName = b.managedResourceGroupName
 	object.networkSecurityGroupResourceID = b.networkSecurityGroupResourceID
 	if b.nodesOutboundConnectivity != nil {

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_builder.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdDataEncryptionBuilder contains the data and logic needed to build 'azure_etcd_data_encryption' objects.
+//
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+type AzureEtcdDataEncryptionBuilder struct {
+	bitmap_           uint32
+	customerManaged   *AzureEtcdDataEncryptionCustomerManagedBuilder
+	keyManagementMode string
+}
+
+// NewAzureEtcdDataEncryption creates a new builder of 'azure_etcd_data_encryption' objects.
+func NewAzureEtcdDataEncryption() *AzureEtcdDataEncryptionBuilder {
+	return &AzureEtcdDataEncryptionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureEtcdDataEncryptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// CustomerManaged sets the value of the 'customer_managed' attribute to the given value.
+//
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+func (b *AzureEtcdDataEncryptionBuilder) CustomerManaged(value *AzureEtcdDataEncryptionCustomerManagedBuilder) *AzureEtcdDataEncryptionBuilder {
+	b.customerManaged = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// KeyManagementMode sets the value of the 'key_management_mode' attribute to the given value.
+func (b *AzureEtcdDataEncryptionBuilder) KeyManagementMode(value string) *AzureEtcdDataEncryptionBuilder {
+	b.keyManagementMode = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureEtcdDataEncryptionBuilder) Copy(object *AzureEtcdDataEncryption) *AzureEtcdDataEncryptionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.customerManaged != nil {
+		b.customerManaged = NewAzureEtcdDataEncryptionCustomerManaged().Copy(object.customerManaged)
+	} else {
+		b.customerManaged = nil
+	}
+	b.keyManagementMode = object.keyManagementMode
+	return b
+}
+
+// Build creates a 'azure_etcd_data_encryption' object using the configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionBuilder) Build() (object *AzureEtcdDataEncryption, err error) {
+	object = new(AzureEtcdDataEncryption)
+	object.bitmap_ = b.bitmap_
+	if b.customerManaged != nil {
+		object.customerManaged, err = b.customerManaged.Build()
+		if err != nil {
+			return
+		}
+	}
+	object.keyManagementMode = b.keyManagementMode
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_builder.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdDataEncryptionCustomerManagedBuilder contains the data and logic needed to build 'azure_etcd_data_encryption_customer_managed' objects.
+//
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+type AzureEtcdDataEncryptionCustomerManagedBuilder struct {
+	bitmap_        uint32
+	encryptionType string
+	kms            *AzureKmsEncryptionBuilder
+}
+
+// NewAzureEtcdDataEncryptionCustomerManaged creates a new builder of 'azure_etcd_data_encryption_customer_managed' objects.
+func NewAzureEtcdDataEncryptionCustomerManaged() *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	return &AzureEtcdDataEncryptionCustomerManagedBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// EncryptionType sets the value of the 'encryption_type' attribute to the given value.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) EncryptionType(value string) *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	b.encryptionType = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// Kms sets the value of the 'kms' attribute to the given value.
+//
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Kms(value *AzureKmsEncryptionBuilder) *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	b.kms = value
+	if value != nil {
+		b.bitmap_ |= 2
+	} else {
+		b.bitmap_ &^= 2
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Copy(object *AzureEtcdDataEncryptionCustomerManaged) *AzureEtcdDataEncryptionCustomerManagedBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.encryptionType = object.encryptionType
+	if object.kms != nil {
+		b.kms = NewAzureKmsEncryption().Copy(object.kms)
+	} else {
+		b.kms = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_etcd_data_encryption_customer_managed' object using the configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionCustomerManagedBuilder) Build() (object *AzureEtcdDataEncryptionCustomerManaged, err error) {
+	object = new(AzureEtcdDataEncryptionCustomerManaged)
+	object.bitmap_ = b.bitmap_
+	object.encryptionType = b.encryptionType
+	if b.kms != nil {
+		object.kms, err = b.kms.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_list_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdDataEncryptionCustomerManagedListBuilder contains the data and logic needed to build
+// 'azure_etcd_data_encryption_customer_managed' objects.
+type AzureEtcdDataEncryptionCustomerManagedListBuilder struct {
+	items []*AzureEtcdDataEncryptionCustomerManagedBuilder
+}
+
+// NewAzureEtcdDataEncryptionCustomerManagedList creates a new builder of 'azure_etcd_data_encryption_customer_managed' objects.
+func NewAzureEtcdDataEncryptionCustomerManagedList() *AzureEtcdDataEncryptionCustomerManagedListBuilder {
+	return new(AzureEtcdDataEncryptionCustomerManagedListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Items(values ...*AzureEtcdDataEncryptionCustomerManagedBuilder) *AzureEtcdDataEncryptionCustomerManagedListBuilder {
+	b.items = make([]*AzureEtcdDataEncryptionCustomerManagedBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Copy(list *AzureEtcdDataEncryptionCustomerManagedList) *AzureEtcdDataEncryptionCustomerManagedListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureEtcdDataEncryptionCustomerManagedBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureEtcdDataEncryptionCustomerManaged().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_etcd_data_encryption_customer_managed' objects using the
+// configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionCustomerManagedListBuilder) Build() (list *AzureEtcdDataEncryptionCustomerManagedList, err error) {
+	items := make([]*AzureEtcdDataEncryptionCustomerManaged, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureEtcdDataEncryptionCustomerManagedList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryptionCustomerManagedList writes a list of values of the 'azure_etcd_data_encryption_customer_managed' type to
+// the given writer.
+func MarshalAzureEtcdDataEncryptionCustomerManagedList(list []*AzureEtcdDataEncryptionCustomerManaged, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryptionCustomerManagedList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryptionCustomerManagedList writes a list of value of the 'azure_etcd_data_encryption_customer_managed' type to
+// the given stream.
+func WriteAzureEtcdDataEncryptionCustomerManagedList(list []*AzureEtcdDataEncryptionCustomerManaged, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureEtcdDataEncryptionCustomerManaged(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryptionCustomerManagedList reads a list of values of the 'azure_etcd_data_encryption_customer_managed' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryptionCustomerManagedList(source interface{}) (items []*AzureEtcdDataEncryptionCustomerManaged, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureEtcdDataEncryptionCustomerManagedList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryptionCustomerManagedList reads list of values of the ”azure_etcd_data_encryption_customer_managed' type from
+// the given iterator.
+func ReadAzureEtcdDataEncryptionCustomerManagedList(iterator *jsoniter.Iterator) []*AzureEtcdDataEncryptionCustomerManaged {
+	list := []*AzureEtcdDataEncryptionCustomerManaged{}
+	for iterator.ReadArray() {
+		item := ReadAzureEtcdDataEncryptionCustomerManaged(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_type.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_type.go
@@ -1,0 +1,196 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdDataEncryptionCustomerManaged represents the values of the 'azure_etcd_data_encryption_customer_managed' type.
+//
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+type AzureEtcdDataEncryptionCustomerManaged struct {
+	bitmap_        uint32
+	encryptionType string
+	kms            *AzureKmsEncryption
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureEtcdDataEncryptionCustomerManaged) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// EncryptionType returns the value of the 'encryption_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The encryption type used.
+// Accepted values are: "kms".
+// By default, "kms" is used.
+func (o *AzureEtcdDataEncryptionCustomerManaged) EncryptionType() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.encryptionType
+	}
+	return ""
+}
+
+// GetEncryptionType returns the value of the 'encryption_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The encryption type used.
+// Accepted values are: "kms".
+// By default, "kms" is used.
+func (o *AzureEtcdDataEncryptionCustomerManaged) GetEncryptionType() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.encryptionType
+	}
+	return
+}
+
+// Kms returns the value of the 'kms' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The KMS encryption configuration.
+// Required when encryption_type is "kms".
+func (o *AzureEtcdDataEncryptionCustomerManaged) Kms() *AzureKmsEncryption {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.kms
+	}
+	return nil
+}
+
+// GetKms returns the value of the 'kms' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The KMS encryption configuration.
+// Required when encryption_type is "kms".
+func (o *AzureEtcdDataEncryptionCustomerManaged) GetKms() (value *AzureKmsEncryption, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.kms
+	}
+	return
+}
+
+// AzureEtcdDataEncryptionCustomerManagedListKind is the name of the type used to represent list of objects of
+// type 'azure_etcd_data_encryption_customer_managed'.
+const AzureEtcdDataEncryptionCustomerManagedListKind = "AzureEtcdDataEncryptionCustomerManagedList"
+
+// AzureEtcdDataEncryptionCustomerManagedListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_etcd_data_encryption_customer_managed'.
+const AzureEtcdDataEncryptionCustomerManagedListLinkKind = "AzureEtcdDataEncryptionCustomerManagedListLink"
+
+// AzureEtcdDataEncryptionCustomerManagedNilKind is the name of the type used to nil lists of objects of
+// type 'azure_etcd_data_encryption_customer_managed'.
+const AzureEtcdDataEncryptionCustomerManagedListNilKind = "AzureEtcdDataEncryptionCustomerManagedListNil"
+
+// AzureEtcdDataEncryptionCustomerManagedList is a list of values of the 'azure_etcd_data_encryption_customer_managed' type.
+type AzureEtcdDataEncryptionCustomerManagedList struct {
+	href  string
+	link  bool
+	items []*AzureEtcdDataEncryptionCustomerManaged
+}
+
+// Len returns the length of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) SetItems(items []*AzureEtcdDataEncryptionCustomerManaged) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Items() []*AzureEtcdDataEncryptionCustomerManaged {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Get(i int) *AzureEtcdDataEncryptionCustomerManaged {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Slice() []*AzureEtcdDataEncryptionCustomerManaged {
+	var slice []*AzureEtcdDataEncryptionCustomerManaged
+	if l == nil {
+		slice = make([]*AzureEtcdDataEncryptionCustomerManaged, 0)
+	} else {
+		slice = make([]*AzureEtcdDataEncryptionCustomerManaged, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Each(f func(item *AzureEtcdDataEncryptionCustomerManaged) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureEtcdDataEncryptionCustomerManagedList) Range(f func(index int, item *AzureEtcdDataEncryptionCustomerManaged) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_customer_managed_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryptionCustomerManaged writes a value of the 'azure_etcd_data_encryption_customer_managed' type to the given writer.
+func MarshalAzureEtcdDataEncryptionCustomerManaged(object *AzureEtcdDataEncryptionCustomerManaged, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryptionCustomerManaged(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryptionCustomerManaged writes a value of the 'azure_etcd_data_encryption_customer_managed' type to the given stream.
+func WriteAzureEtcdDataEncryptionCustomerManaged(object *AzureEtcdDataEncryptionCustomerManaged, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("encryption_type")
+		stream.WriteString(object.encryptionType)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0 && object.kms != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("kms")
+		WriteAzureKmsEncryption(object.kms, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryptionCustomerManaged reads a value of the 'azure_etcd_data_encryption_customer_managed' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryptionCustomerManaged(source interface{}) (object *AzureEtcdDataEncryptionCustomerManaged, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureEtcdDataEncryptionCustomerManaged(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryptionCustomerManaged reads a value of the 'azure_etcd_data_encryption_customer_managed' type from the given iterator.
+func ReadAzureEtcdDataEncryptionCustomerManaged(iterator *jsoniter.Iterator) *AzureEtcdDataEncryptionCustomerManaged {
+	object := &AzureEtcdDataEncryptionCustomerManaged{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "encryption_type":
+			value := iterator.ReadString()
+			object.encryptionType = value
+			object.bitmap_ |= 1
+		case "kms":
+			value := ReadAzureKmsEncryption(iterator)
+			object.kms = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_list_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdDataEncryptionListBuilder contains the data and logic needed to build
+// 'azure_etcd_data_encryption' objects.
+type AzureEtcdDataEncryptionListBuilder struct {
+	items []*AzureEtcdDataEncryptionBuilder
+}
+
+// NewAzureEtcdDataEncryptionList creates a new builder of 'azure_etcd_data_encryption' objects.
+func NewAzureEtcdDataEncryptionList() *AzureEtcdDataEncryptionListBuilder {
+	return new(AzureEtcdDataEncryptionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureEtcdDataEncryptionListBuilder) Items(values ...*AzureEtcdDataEncryptionBuilder) *AzureEtcdDataEncryptionListBuilder {
+	b.items = make([]*AzureEtcdDataEncryptionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureEtcdDataEncryptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureEtcdDataEncryptionListBuilder) Copy(list *AzureEtcdDataEncryptionList) *AzureEtcdDataEncryptionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureEtcdDataEncryptionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureEtcdDataEncryption().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_etcd_data_encryption' objects using the
+// configuration stored in the builder.
+func (b *AzureEtcdDataEncryptionListBuilder) Build() (list *AzureEtcdDataEncryptionList, err error) {
+	items := make([]*AzureEtcdDataEncryption, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureEtcdDataEncryptionList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryptionList writes a list of values of the 'azure_etcd_data_encryption' type to
+// the given writer.
+func MarshalAzureEtcdDataEncryptionList(list []*AzureEtcdDataEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryptionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryptionList writes a list of value of the 'azure_etcd_data_encryption' type to
+// the given stream.
+func WriteAzureEtcdDataEncryptionList(list []*AzureEtcdDataEncryption, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureEtcdDataEncryption(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryptionList reads a list of values of the 'azure_etcd_data_encryption' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryptionList(source interface{}) (items []*AzureEtcdDataEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureEtcdDataEncryptionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryptionList reads list of values of the ”azure_etcd_data_encryption' type from
+// the given iterator.
+func ReadAzureEtcdDataEncryptionList(iterator *jsoniter.Iterator) []*AzureEtcdDataEncryption {
+	list := []*AzureEtcdDataEncryption{}
+	for iterator.ReadArray() {
+		item := ReadAzureEtcdDataEncryption(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_type.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_type.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdDataEncryption represents the values of the 'azure_etcd_data_encryption' type.
+//
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+type AzureEtcdDataEncryption struct {
+	bitmap_           uint32
+	customerManaged   *AzureEtcdDataEncryptionCustomerManaged
+	keyManagementMode string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureEtcdDataEncryption) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// CustomerManaged returns the value of the 'customer_managed' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Customer Managed encryption keys configuration.
+// Required when key_management_mode is "customer_managed".
+func (o *AzureEtcdDataEncryption) CustomerManaged() *AzureEtcdDataEncryptionCustomerManaged {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.customerManaged
+	}
+	return nil
+}
+
+// GetCustomerManaged returns the value of the 'customer_managed' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Customer Managed encryption keys configuration.
+// Required when key_management_mode is "customer_managed".
+func (o *AzureEtcdDataEncryption) GetCustomerManaged() (value *AzureEtcdDataEncryptionCustomerManaged, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.customerManaged
+	}
+	return
+}
+
+// KeyManagementMode returns the value of the 'key_management_mode' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The key management strategy used for the encryption key that encrypts the etcd data.
+// Accepted values are: "customer_managed", "platform_managed".
+// By default, "platform_managed" is used.
+// Currently only "customer_managed" mode is supported.
+func (o *AzureEtcdDataEncryption) KeyManagementMode() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.keyManagementMode
+	}
+	return ""
+}
+
+// GetKeyManagementMode returns the value of the 'key_management_mode' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The key management strategy used for the encryption key that encrypts the etcd data.
+// Accepted values are: "customer_managed", "platform_managed".
+// By default, "platform_managed" is used.
+// Currently only "customer_managed" mode is supported.
+func (o *AzureEtcdDataEncryption) GetKeyManagementMode() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.keyManagementMode
+	}
+	return
+}
+
+// AzureEtcdDataEncryptionListKind is the name of the type used to represent list of objects of
+// type 'azure_etcd_data_encryption'.
+const AzureEtcdDataEncryptionListKind = "AzureEtcdDataEncryptionList"
+
+// AzureEtcdDataEncryptionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_etcd_data_encryption'.
+const AzureEtcdDataEncryptionListLinkKind = "AzureEtcdDataEncryptionListLink"
+
+// AzureEtcdDataEncryptionNilKind is the name of the type used to nil lists of objects of
+// type 'azure_etcd_data_encryption'.
+const AzureEtcdDataEncryptionListNilKind = "AzureEtcdDataEncryptionListNil"
+
+// AzureEtcdDataEncryptionList is a list of values of the 'azure_etcd_data_encryption' type.
+type AzureEtcdDataEncryptionList struct {
+	href  string
+	link  bool
+	items []*AzureEtcdDataEncryption
+}
+
+// Len returns the length of the list.
+func (l *AzureEtcdDataEncryptionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdDataEncryptionList) SetItems(items []*AzureEtcdDataEncryption) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureEtcdDataEncryptionList) Items() []*AzureEtcdDataEncryption {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureEtcdDataEncryptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureEtcdDataEncryptionList) Get(i int) *AzureEtcdDataEncryption {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureEtcdDataEncryptionList) Slice() []*AzureEtcdDataEncryption {
+	var slice []*AzureEtcdDataEncryption
+	if l == nil {
+		slice = make([]*AzureEtcdDataEncryption, 0)
+	} else {
+		slice = make([]*AzureEtcdDataEncryption, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureEtcdDataEncryptionList) Each(f func(item *AzureEtcdDataEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureEtcdDataEncryptionList) Range(f func(index int, item *AzureEtcdDataEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_data_encryption_type_json.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdDataEncryption writes a value of the 'azure_etcd_data_encryption' type to the given writer.
+func MarshalAzureEtcdDataEncryption(object *AzureEtcdDataEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdDataEncryption(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdDataEncryption writes a value of the 'azure_etcd_data_encryption' type to the given stream.
+func WriteAzureEtcdDataEncryption(object *AzureEtcdDataEncryption, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.customerManaged != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("customer_managed")
+		WriteAzureEtcdDataEncryptionCustomerManaged(object.customerManaged, stream)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_management_mode")
+		stream.WriteString(object.keyManagementMode)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureEtcdDataEncryption reads a value of the 'azure_etcd_data_encryption' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdDataEncryption(source interface{}) (object *AzureEtcdDataEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureEtcdDataEncryption(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdDataEncryption reads a value of the 'azure_etcd_data_encryption' type from the given iterator.
+func ReadAzureEtcdDataEncryption(iterator *jsoniter.Iterator) *AzureEtcdDataEncryption {
+	object := &AzureEtcdDataEncryption{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "customer_managed":
+			value := ReadAzureEtcdDataEncryptionCustomerManaged(iterator)
+			object.customerManaged = value
+			object.bitmap_ |= 1
+		case "key_management_mode":
+			value := iterator.ReadString()
+			object.keyManagementMode = value
+			object.bitmap_ |= 2
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_encryption_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_encryption_builder.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdEncryptionBuilder contains the data and logic needed to build 'azure_etcd_encryption' objects.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+type AzureEtcdEncryptionBuilder struct {
+	bitmap_        uint32
+	dataEncryption *AzureEtcdDataEncryptionBuilder
+}
+
+// NewAzureEtcdEncryption creates a new builder of 'azure_etcd_encryption' objects.
+func NewAzureEtcdEncryption() *AzureEtcdEncryptionBuilder {
+	return &AzureEtcdEncryptionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureEtcdEncryptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// DataEncryption sets the value of the 'data_encryption' attribute to the given value.
+//
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+func (b *AzureEtcdEncryptionBuilder) DataEncryption(value *AzureEtcdDataEncryptionBuilder) *AzureEtcdEncryptionBuilder {
+	b.dataEncryption = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureEtcdEncryptionBuilder) Copy(object *AzureEtcdEncryption) *AzureEtcdEncryptionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.dataEncryption != nil {
+		b.dataEncryption = NewAzureEtcdDataEncryption().Copy(object.dataEncryption)
+	} else {
+		b.dataEncryption = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_etcd_encryption' object using the configuration stored in the builder.
+func (b *AzureEtcdEncryptionBuilder) Build() (object *AzureEtcdEncryption, err error) {
+	object = new(AzureEtcdEncryption)
+	object.bitmap_ = b.bitmap_
+	if b.dataEncryption != nil {
+		object.dataEncryption, err = b.dataEncryption.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_encryption_list_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_encryption_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdEncryptionListBuilder contains the data and logic needed to build
+// 'azure_etcd_encryption' objects.
+type AzureEtcdEncryptionListBuilder struct {
+	items []*AzureEtcdEncryptionBuilder
+}
+
+// NewAzureEtcdEncryptionList creates a new builder of 'azure_etcd_encryption' objects.
+func NewAzureEtcdEncryptionList() *AzureEtcdEncryptionListBuilder {
+	return new(AzureEtcdEncryptionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureEtcdEncryptionListBuilder) Items(values ...*AzureEtcdEncryptionBuilder) *AzureEtcdEncryptionListBuilder {
+	b.items = make([]*AzureEtcdEncryptionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureEtcdEncryptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureEtcdEncryptionListBuilder) Copy(list *AzureEtcdEncryptionList) *AzureEtcdEncryptionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureEtcdEncryptionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureEtcdEncryption().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_etcd_encryption' objects using the
+// configuration stored in the builder.
+func (b *AzureEtcdEncryptionListBuilder) Build() (list *AzureEtcdEncryptionList, err error) {
+	items := make([]*AzureEtcdEncryption, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureEtcdEncryptionList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_encryption_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_encryption_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdEncryptionList writes a list of values of the 'azure_etcd_encryption' type to
+// the given writer.
+func MarshalAzureEtcdEncryptionList(list []*AzureEtcdEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdEncryptionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdEncryptionList writes a list of value of the 'azure_etcd_encryption' type to
+// the given stream.
+func WriteAzureEtcdEncryptionList(list []*AzureEtcdEncryption, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureEtcdEncryption(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureEtcdEncryptionList reads a list of values of the 'azure_etcd_encryption' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdEncryptionList(source interface{}) (items []*AzureEtcdEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureEtcdEncryptionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdEncryptionList reads list of values of the ”azure_etcd_encryption' type from
+// the given iterator.
+func ReadAzureEtcdEncryptionList(iterator *jsoniter.Iterator) []*AzureEtcdEncryption {
+	list := []*AzureEtcdEncryption{}
+	for iterator.ReadArray() {
+		item := ReadAzureEtcdEncryption(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_encryption_type.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_encryption_type.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureEtcdEncryption represents the values of the 'azure_etcd_encryption' type.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+type AzureEtcdEncryption struct {
+	bitmap_        uint32
+	dataEncryption *AzureEtcdDataEncryption
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureEtcdEncryption) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// DataEncryption returns the value of the 'data_encryption' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// etcd data encryption settings.
+// If not specified, etcd data is encrypted with platform managed keys.
+func (o *AzureEtcdEncryption) DataEncryption() *AzureEtcdDataEncryption {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.dataEncryption
+	}
+	return nil
+}
+
+// GetDataEncryption returns the value of the 'data_encryption' attribute and
+// a flag indicating if the attribute has a value.
+//
+// etcd data encryption settings.
+// If not specified, etcd data is encrypted with platform managed keys.
+func (o *AzureEtcdEncryption) GetDataEncryption() (value *AzureEtcdDataEncryption, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.dataEncryption
+	}
+	return
+}
+
+// AzureEtcdEncryptionListKind is the name of the type used to represent list of objects of
+// type 'azure_etcd_encryption'.
+const AzureEtcdEncryptionListKind = "AzureEtcdEncryptionList"
+
+// AzureEtcdEncryptionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_etcd_encryption'.
+const AzureEtcdEncryptionListLinkKind = "AzureEtcdEncryptionListLink"
+
+// AzureEtcdEncryptionNilKind is the name of the type used to nil lists of objects of
+// type 'azure_etcd_encryption'.
+const AzureEtcdEncryptionListNilKind = "AzureEtcdEncryptionListNil"
+
+// AzureEtcdEncryptionList is a list of values of the 'azure_etcd_encryption' type.
+type AzureEtcdEncryptionList struct {
+	href  string
+	link  bool
+	items []*AzureEtcdEncryption
+}
+
+// Len returns the length of the list.
+func (l *AzureEtcdEncryptionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdEncryptionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdEncryptionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureEtcdEncryptionList) SetItems(items []*AzureEtcdEncryption) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureEtcdEncryptionList) Items() []*AzureEtcdEncryption {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureEtcdEncryptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureEtcdEncryptionList) Get(i int) *AzureEtcdEncryption {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureEtcdEncryptionList) Slice() []*AzureEtcdEncryption {
+	var slice []*AzureEtcdEncryption
+	if l == nil {
+		slice = make([]*AzureEtcdEncryption, 0)
+	} else {
+		slice = make([]*AzureEtcdEncryption, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureEtcdEncryptionList) Each(f func(item *AzureEtcdEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureEtcdEncryptionList) Range(f func(index int, item *AzureEtcdEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/azure_etcd_encryption_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_etcd_encryption_type_json.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureEtcdEncryption writes a value of the 'azure_etcd_encryption' type to the given writer.
+func MarshalAzureEtcdEncryption(object *AzureEtcdEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureEtcdEncryption(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureEtcdEncryption writes a value of the 'azure_etcd_encryption' type to the given stream.
+func WriteAzureEtcdEncryption(object *AzureEtcdEncryption, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.dataEncryption != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("data_encryption")
+		WriteAzureEtcdDataEncryption(object.dataEncryption, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureEtcdEncryption reads a value of the 'azure_etcd_encryption' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureEtcdEncryption(source interface{}) (object *AzureEtcdEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureEtcdEncryption(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureEtcdEncryption reads a value of the 'azure_etcd_encryption' type from the given iterator.
+func ReadAzureEtcdEncryption(iterator *jsoniter.Iterator) *AzureEtcdEncryption {
+	object := &AzureEtcdEncryption{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "data_encryption":
+			value := ReadAzureEtcdDataEncryption(iterator)
+			object.dataEncryption = value
+			object.bitmap_ |= 1
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_encryption_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_encryption_builder.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureKmsEncryptionBuilder contains the data and logic needed to build 'azure_kms_encryption' objects.
+//
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+type AzureKmsEncryptionBuilder struct {
+	bitmap_   uint32
+	activeKey *AzureKmsKeyBuilder
+}
+
+// NewAzureKmsEncryption creates a new builder of 'azure_kms_encryption' objects.
+func NewAzureKmsEncryption() *AzureKmsEncryptionBuilder {
+	return &AzureKmsEncryptionBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureKmsEncryptionBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// ActiveKey sets the value of the 'active_key' attribute to the given value.
+//
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+func (b *AzureKmsEncryptionBuilder) ActiveKey(value *AzureKmsKeyBuilder) *AzureKmsEncryptionBuilder {
+	b.activeKey = value
+	if value != nil {
+		b.bitmap_ |= 1
+	} else {
+		b.bitmap_ &^= 1
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureKmsEncryptionBuilder) Copy(object *AzureKmsEncryption) *AzureKmsEncryptionBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	if object.activeKey != nil {
+		b.activeKey = NewAzureKmsKey().Copy(object.activeKey)
+	} else {
+		b.activeKey = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_kms_encryption' object using the configuration stored in the builder.
+func (b *AzureKmsEncryptionBuilder) Build() (object *AzureKmsEncryption, err error) {
+	object = new(AzureKmsEncryption)
+	object.bitmap_ = b.bitmap_
+	if b.activeKey != nil {
+		object.activeKey, err = b.activeKey.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_encryption_list_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_encryption_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureKmsEncryptionListBuilder contains the data and logic needed to build
+// 'azure_kms_encryption' objects.
+type AzureKmsEncryptionListBuilder struct {
+	items []*AzureKmsEncryptionBuilder
+}
+
+// NewAzureKmsEncryptionList creates a new builder of 'azure_kms_encryption' objects.
+func NewAzureKmsEncryptionList() *AzureKmsEncryptionListBuilder {
+	return new(AzureKmsEncryptionListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureKmsEncryptionListBuilder) Items(values ...*AzureKmsEncryptionBuilder) *AzureKmsEncryptionListBuilder {
+	b.items = make([]*AzureKmsEncryptionBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureKmsEncryptionListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureKmsEncryptionListBuilder) Copy(list *AzureKmsEncryptionList) *AzureKmsEncryptionListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureKmsEncryptionBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureKmsEncryption().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_kms_encryption' objects using the
+// configuration stored in the builder.
+func (b *AzureKmsEncryptionListBuilder) Build() (list *AzureKmsEncryptionList, err error) {
+	items := make([]*AzureKmsEncryption, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureKmsEncryptionList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_encryption_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_encryption_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsEncryptionList writes a list of values of the 'azure_kms_encryption' type to
+// the given writer.
+func MarshalAzureKmsEncryptionList(list []*AzureKmsEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsEncryptionList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsEncryptionList writes a list of value of the 'azure_kms_encryption' type to
+// the given stream.
+func WriteAzureKmsEncryptionList(list []*AzureKmsEncryption, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureKmsEncryption(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureKmsEncryptionList reads a list of values of the 'azure_kms_encryption' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureKmsEncryptionList(source interface{}) (items []*AzureKmsEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureKmsEncryptionList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsEncryptionList reads list of values of the ”azure_kms_encryption' type from
+// the given iterator.
+func ReadAzureKmsEncryptionList(iterator *jsoniter.Iterator) []*AzureKmsEncryption {
+	list := []*AzureKmsEncryption{}
+	for iterator.ReadArray() {
+		item := ReadAzureKmsEncryption(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_encryption_type.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_encryption_type.go
@@ -1,0 +1,167 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureKmsEncryption represents the values of the 'azure_kms_encryption' type.
+//
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+type AzureKmsEncryption struct {
+	bitmap_   uint32
+	activeKey *AzureKmsKey
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureKmsEncryption) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// ActiveKey returns the value of the 'active_key' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The details of the active key
+// Required during creation.
+func (o *AzureKmsEncryption) ActiveKey() *AzureKmsKey {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.activeKey
+	}
+	return nil
+}
+
+// GetActiveKey returns the value of the 'active_key' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The details of the active key
+// Required during creation.
+func (o *AzureKmsEncryption) GetActiveKey() (value *AzureKmsKey, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.activeKey
+	}
+	return
+}
+
+// AzureKmsEncryptionListKind is the name of the type used to represent list of objects of
+// type 'azure_kms_encryption'.
+const AzureKmsEncryptionListKind = "AzureKmsEncryptionList"
+
+// AzureKmsEncryptionListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_kms_encryption'.
+const AzureKmsEncryptionListLinkKind = "AzureKmsEncryptionListLink"
+
+// AzureKmsEncryptionNilKind is the name of the type used to nil lists of objects of
+// type 'azure_kms_encryption'.
+const AzureKmsEncryptionListNilKind = "AzureKmsEncryptionListNil"
+
+// AzureKmsEncryptionList is a list of values of the 'azure_kms_encryption' type.
+type AzureKmsEncryptionList struct {
+	href  string
+	link  bool
+	items []*AzureKmsEncryption
+}
+
+// Len returns the length of the list.
+func (l *AzureKmsEncryptionList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsEncryptionList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsEncryptionList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsEncryptionList) SetItems(items []*AzureKmsEncryption) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureKmsEncryptionList) Items() []*AzureKmsEncryption {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureKmsEncryptionList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureKmsEncryptionList) Get(i int) *AzureKmsEncryption {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureKmsEncryptionList) Slice() []*AzureKmsEncryption {
+	var slice []*AzureKmsEncryption
+	if l == nil {
+		slice = make([]*AzureKmsEncryption, 0)
+	} else {
+		slice = make([]*AzureKmsEncryption, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureKmsEncryptionList) Each(f func(item *AzureKmsEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureKmsEncryptionList) Range(f func(index int, item *AzureKmsEncryption) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_encryption_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_encryption_type_json.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsEncryption writes a value of the 'azure_kms_encryption' type to the given writer.
+func MarshalAzureKmsEncryption(object *AzureKmsEncryption, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsEncryption(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsEncryption writes a value of the 'azure_kms_encryption' type to the given stream.
+func WriteAzureKmsEncryption(object *AzureKmsEncryption, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0 && object.activeKey != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("active_key")
+		WriteAzureKmsKey(object.activeKey, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureKmsEncryption reads a value of the 'azure_kms_encryption' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureKmsEncryption(source interface{}) (object *AzureKmsEncryption, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureKmsEncryption(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsEncryption reads a value of the 'azure_kms_encryption' type from the given iterator.
+func ReadAzureKmsEncryption(iterator *jsoniter.Iterator) *AzureKmsEncryption {
+	object := &AzureKmsEncryption{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "active_key":
+			value := ReadAzureKmsKey(iterator)
+			object.activeKey = value
+			object.bitmap_ |= 1
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_key_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_key_builder.go
@@ -1,0 +1,83 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureKmsKeyBuilder contains the data and logic needed to build 'azure_kms_key' objects.
+//
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+type AzureKmsKeyBuilder struct {
+	bitmap_      uint32
+	keyName      string
+	keyVaultName string
+	keyVersion   string
+}
+
+// NewAzureKmsKey creates a new builder of 'azure_kms_key' objects.
+func NewAzureKmsKey() *AzureKmsKeyBuilder {
+	return &AzureKmsKeyBuilder{}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureKmsKeyBuilder) Empty() bool {
+	return b == nil || b.bitmap_ == 0
+}
+
+// KeyName sets the value of the 'key_name' attribute to the given value.
+func (b *AzureKmsKeyBuilder) KeyName(value string) *AzureKmsKeyBuilder {
+	b.keyName = value
+	b.bitmap_ |= 1
+	return b
+}
+
+// KeyVaultName sets the value of the 'key_vault_name' attribute to the given value.
+func (b *AzureKmsKeyBuilder) KeyVaultName(value string) *AzureKmsKeyBuilder {
+	b.keyVaultName = value
+	b.bitmap_ |= 2
+	return b
+}
+
+// KeyVersion sets the value of the 'key_version' attribute to the given value.
+func (b *AzureKmsKeyBuilder) KeyVersion(value string) *AzureKmsKeyBuilder {
+	b.keyVersion = value
+	b.bitmap_ |= 4
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureKmsKeyBuilder) Copy(object *AzureKmsKey) *AzureKmsKeyBuilder {
+	if object == nil {
+		return b
+	}
+	b.bitmap_ = object.bitmap_
+	b.keyName = object.keyName
+	b.keyVaultName = object.keyVaultName
+	b.keyVersion = object.keyVersion
+	return b
+}
+
+// Build creates a 'azure_kms_key' object using the configuration stored in the builder.
+func (b *AzureKmsKeyBuilder) Build() (object *AzureKmsKey, err error) {
+	object = new(AzureKmsKey)
+	object.bitmap_ = b.bitmap_
+	object.keyName = b.keyName
+	object.keyVaultName = b.keyVaultName
+	object.keyVersion = b.keyVersion
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_key_list_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_key_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureKmsKeyListBuilder contains the data and logic needed to build
+// 'azure_kms_key' objects.
+type AzureKmsKeyListBuilder struct {
+	items []*AzureKmsKeyBuilder
+}
+
+// NewAzureKmsKeyList creates a new builder of 'azure_kms_key' objects.
+func NewAzureKmsKeyList() *AzureKmsKeyListBuilder {
+	return new(AzureKmsKeyListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureKmsKeyListBuilder) Items(values ...*AzureKmsKeyBuilder) *AzureKmsKeyListBuilder {
+	b.items = make([]*AzureKmsKeyBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureKmsKeyListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureKmsKeyListBuilder) Copy(list *AzureKmsKeyList) *AzureKmsKeyListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureKmsKeyBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureKmsKey().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_kms_key' objects using the
+// configuration stored in the builder.
+func (b *AzureKmsKeyListBuilder) Build() (list *AzureKmsKeyList, err error) {
+	items := make([]*AzureKmsKey, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureKmsKeyList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_key_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_key_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsKeyList writes a list of values of the 'azure_kms_key' type to
+// the given writer.
+func MarshalAzureKmsKeyList(list []*AzureKmsKey, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsKeyList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsKeyList writes a list of value of the 'azure_kms_key' type to
+// the given stream.
+func WriteAzureKmsKeyList(list []*AzureKmsKey, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureKmsKey(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureKmsKeyList reads a list of values of the 'azure_kms_key' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureKmsKeyList(source interface{}) (items []*AzureKmsKey, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureKmsKeyList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsKeyList reads list of values of the ”azure_kms_key' type from
+// the given iterator.
+func ReadAzureKmsKeyList(iterator *jsoniter.Iterator) []*AzureKmsKey {
+	list := []*AzureKmsKey{}
+	for iterator.ReadArray() {
+		item := ReadAzureKmsKey(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_key_type.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_key_type.go
@@ -1,0 +1,219 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureKmsKey represents the values of the 'azure_kms_key' type.
+//
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+type AzureKmsKey struct {
+	bitmap_      uint32
+	keyName      string
+	keyVaultName string
+	keyVersion   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureKmsKey) Empty() bool {
+	return o == nil || o.bitmap_ == 0
+}
+
+// KeyName returns the value of the 'key_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// key_name is the name of the Azure Key Vault Key
+// Required during creation.
+func (o *AzureKmsKey) KeyName() string {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.keyName
+	}
+	return ""
+}
+
+// GetKeyName returns the value of the 'key_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// key_name is the name of the Azure Key Vault Key
+// Required during creation.
+func (o *AzureKmsKey) GetKeyName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.keyName
+	}
+	return
+}
+
+// KeyVaultName returns the value of the 'key_vault_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// key_vault_name is the name of the Azure Key Vault that contains the encryption key
+// Required during creation.
+func (o *AzureKmsKey) KeyVaultName() string {
+	if o != nil && o.bitmap_&2 != 0 {
+		return o.keyVaultName
+	}
+	return ""
+}
+
+// GetKeyVaultName returns the value of the 'key_vault_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// key_vault_name is the name of the Azure Key Vault that contains the encryption key
+// Required during creation.
+func (o *AzureKmsKey) GetKeyVaultName() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&2 != 0
+	if ok {
+		value = o.keyVaultName
+	}
+	return
+}
+
+// KeyVersion returns the value of the 'key_version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// key_version is the version of the Azure Key Vault key
+// Required during creation.
+func (o *AzureKmsKey) KeyVersion() string {
+	if o != nil && o.bitmap_&4 != 0 {
+		return o.keyVersion
+	}
+	return ""
+}
+
+// GetKeyVersion returns the value of the 'key_version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// key_version is the version of the Azure Key Vault key
+// Required during creation.
+func (o *AzureKmsKey) GetKeyVersion() (value string, ok bool) {
+	ok = o != nil && o.bitmap_&4 != 0
+	if ok {
+		value = o.keyVersion
+	}
+	return
+}
+
+// AzureKmsKeyListKind is the name of the type used to represent list of objects of
+// type 'azure_kms_key'.
+const AzureKmsKeyListKind = "AzureKmsKeyList"
+
+// AzureKmsKeyListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_kms_key'.
+const AzureKmsKeyListLinkKind = "AzureKmsKeyListLink"
+
+// AzureKmsKeyNilKind is the name of the type used to nil lists of objects of
+// type 'azure_kms_key'.
+const AzureKmsKeyListNilKind = "AzureKmsKeyListNil"
+
+// AzureKmsKeyList is a list of values of the 'azure_kms_key' type.
+type AzureKmsKeyList struct {
+	href  string
+	link  bool
+	items []*AzureKmsKey
+}
+
+// Len returns the length of the list.
+func (l *AzureKmsKeyList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsKeyList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsKeyList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureKmsKeyList) SetItems(items []*AzureKmsKey) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureKmsKeyList) Items() []*AzureKmsKey {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureKmsKeyList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureKmsKeyList) Get(i int) *AzureKmsKey {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureKmsKeyList) Slice() []*AzureKmsKey {
+	var slice []*AzureKmsKey
+	if l == nil {
+		slice = make([]*AzureKmsKey, 0)
+	} else {
+		slice = make([]*AzureKmsKey, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureKmsKeyList) Each(f func(item *AzureKmsKey) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureKmsKeyList) Range(f func(index int, item *AzureKmsKey) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/azure_kms_key_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_kms_key_type_json.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureKmsKey writes a value of the 'azure_kms_key' type to the given writer.
+func MarshalAzureKmsKey(object *AzureKmsKey, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureKmsKey(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureKmsKey writes a value of the 'azure_kms_key' type to the given stream.
+func WriteAzureKmsKey(object *AzureKmsKey, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = object.bitmap_&1 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_name")
+		stream.WriteString(object.keyName)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_vault_name")
+		stream.WriteString(object.keyVaultName)
+		count++
+	}
+	present_ = object.bitmap_&4 != 0
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("key_version")
+		stream.WriteString(object.keyVersion)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureKmsKey reads a value of the 'azure_kms_key' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureKmsKey(source interface{}) (object *AzureKmsKey, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureKmsKey(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureKmsKey reads a value of the 'azure_kms_key' type from the given iterator.
+func ReadAzureKmsKey(iterator *jsoniter.Iterator) *AzureKmsKey {
+	object := &AzureKmsKey{}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "key_name":
+			value := iterator.ReadString()
+			object.keyName = value
+			object.bitmap_ |= 1
+		case "key_vault_name":
+			value := iterator.ReadString()
+			object.keyVaultName = value
+			object.bitmap_ |= 2
+		case "key_version":
+			value := iterator.ReadString()
+			object.keyVersion = value
+			object.bitmap_ |= 4
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/azure_type.go
+++ b/clientapi/clustersmgmt/v1/azure_type.go
@@ -24,6 +24,7 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 // Microsoft Azure settings of a cluster.
 type Azure struct {
 	bitmap_                        uint32
+	etcdEncryption                 *AzureEtcdEncryption
 	managedResourceGroupName       string
 	networkSecurityGroupResourceID string
 	nodesOutboundConnectivity      *AzureNodesOutboundConnectivity
@@ -38,6 +39,35 @@ type Azure struct {
 // Empty returns true if the object is empty, i.e. no attribute has a value.
 func (o *Azure) Empty() bool {
 	return o == nil || o.bitmap_ == 0
+}
+
+// EtcdEncryption returns the value of the 'etcd_encryption' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Etcd encryption configuration.
+// If not specified, etcd data is encrypted with platform managed keys.
+// Currently etcd data encryption is only supported with customer managed keys.
+// Creating a cluster with platform managed keys will result in a failure creating the cluster.
+func (o *Azure) EtcdEncryption() *AzureEtcdEncryption {
+	if o != nil && o.bitmap_&1 != 0 {
+		return o.etcdEncryption
+	}
+	return nil
+}
+
+// GetEtcdEncryption returns the value of the 'etcd_encryption' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Etcd encryption configuration.
+// If not specified, etcd data is encrypted with platform managed keys.
+// Currently etcd data encryption is only supported with customer managed keys.
+// Creating a cluster with platform managed keys will result in a failure creating the cluster.
+func (o *Azure) GetEtcdEncryption() (value *AzureEtcdEncryption, ok bool) {
+	ok = o != nil && o.bitmap_&1 != 0
+	if ok {
+		value = o.etcdEncryption
+	}
+	return
 }
 
 // ManagedResourceGroupName returns the value of the 'managed_resource_group_name' attribute, or
@@ -55,7 +85,7 @@ func (o *Azure) Empty() bool {
 // Required during creation.
 // Immutable.
 func (o *Azure) ManagedResourceGroupName() string {
-	if o != nil && o.bitmap_&1 != 0 {
+	if o != nil && o.bitmap_&2 != 0 {
 		return o.managedResourceGroupName
 	}
 	return ""
@@ -76,7 +106,7 @@ func (o *Azure) ManagedResourceGroupName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetManagedResourceGroupName() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&1 != 0
+	ok = o != nil && o.bitmap_&2 != 0
 	if ok {
 		value = o.managedResourceGroupName
 	}
@@ -108,7 +138,7 @@ func (o *Azure) GetManagedResourceGroupName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) NetworkSecurityGroupResourceID() string {
-	if o != nil && o.bitmap_&2 != 0 {
+	if o != nil && o.bitmap_&4 != 0 {
 		return o.networkSecurityGroupResourceID
 	}
 	return ""
@@ -139,7 +169,7 @@ func (o *Azure) NetworkSecurityGroupResourceID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetNetworkSecurityGroupResourceID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&2 != 0
+	ok = o != nil && o.bitmap_&4 != 0
 	if ok {
 		value = o.networkSecurityGroupResourceID
 	}
@@ -153,7 +183,7 @@ func (o *Azure) GetNetworkSecurityGroupResourceID() (value string, ok bool) {
 // configuration of the Cluster's Node Pool's Nodes is performed.
 // By default this is configured as Azure Load Balancer. This value is immutable.
 func (o *Azure) NodesOutboundConnectivity() *AzureNodesOutboundConnectivity {
-	if o != nil && o.bitmap_&4 != 0 {
+	if o != nil && o.bitmap_&8 != 0 {
 		return o.nodesOutboundConnectivity
 	}
 	return nil
@@ -166,7 +196,7 @@ func (o *Azure) NodesOutboundConnectivity() *AzureNodesOutboundConnectivity {
 // configuration of the Cluster's Node Pool's Nodes is performed.
 // By default this is configured as Azure Load Balancer. This value is immutable.
 func (o *Azure) GetNodesOutboundConnectivity() (value *AzureNodesOutboundConnectivity, ok bool) {
-	ok = o != nil && o.bitmap_&4 != 0
+	ok = o != nil && o.bitmap_&8 != 0
 	if ok {
 		value = o.nodesOutboundConnectivity
 	}
@@ -180,7 +210,7 @@ func (o *Azure) GetNodesOutboundConnectivity() (value *AzureNodesOutboundConnect
 // Required during creation.
 // Immutable.
 func (o *Azure) OperatorsAuthentication() *AzureOperatorsAuthentication {
-	if o != nil && o.bitmap_&8 != 0 {
+	if o != nil && o.bitmap_&16 != 0 {
 		return o.operatorsAuthentication
 	}
 	return nil
@@ -193,7 +223,7 @@ func (o *Azure) OperatorsAuthentication() *AzureOperatorsAuthentication {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetOperatorsAuthentication() (value *AzureOperatorsAuthentication, ok bool) {
-	ok = o != nil && o.bitmap_&8 != 0
+	ok = o != nil && o.bitmap_&16 != 0
 	if ok {
 		value = o.operatorsAuthentication
 	}
@@ -211,7 +241,7 @@ func (o *Azure) GetOperatorsAuthentication() (value *AzureOperatorsAuthenticatio
 // Required during creation.
 // Immutable.
 func (o *Azure) ResourceGroupName() string {
-	if o != nil && o.bitmap_&16 != 0 {
+	if o != nil && o.bitmap_&32 != 0 {
 		return o.resourceGroupName
 	}
 	return ""
@@ -228,7 +258,7 @@ func (o *Azure) ResourceGroupName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetResourceGroupName() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&16 != 0
+	ok = o != nil && o.bitmap_&32 != 0
 	if ok {
 		value = o.resourceGroupName
 	}
@@ -244,7 +274,7 @@ func (o *Azure) GetResourceGroupName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) ResourceName() string {
-	if o != nil && o.bitmap_&32 != 0 {
+	if o != nil && o.bitmap_&64 != 0 {
 		return o.resourceName
 	}
 	return ""
@@ -259,7 +289,7 @@ func (o *Azure) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetResourceName() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&32 != 0
+	ok = o != nil && o.bitmap_&64 != 0
 	if ok {
 		value = o.resourceName
 	}
@@ -286,7 +316,7 @@ func (o *Azure) GetResourceName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) SubnetResourceID() string {
-	if o != nil && o.bitmap_&64 != 0 {
+	if o != nil && o.bitmap_&128 != 0 {
 		return o.subnetResourceID
 	}
 	return ""
@@ -312,7 +342,7 @@ func (o *Azure) SubnetResourceID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetSubnetResourceID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&64 != 0
+	ok = o != nil && o.bitmap_&128 != 0
 	if ok {
 		value = o.subnetResourceID
 	}
@@ -327,7 +357,7 @@ func (o *Azure) GetSubnetResourceID() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) SubscriptionID() string {
-	if o != nil && o.bitmap_&128 != 0 {
+	if o != nil && o.bitmap_&256 != 0 {
 		return o.subscriptionID
 	}
 	return ""
@@ -341,7 +371,7 @@ func (o *Azure) SubscriptionID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetSubscriptionID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&128 != 0
+	ok = o != nil && o.bitmap_&256 != 0
 	if ok {
 		value = o.subscriptionID
 	}
@@ -355,7 +385,7 @@ func (o *Azure) GetSubscriptionID() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) TenantID() string {
-	if o != nil && o.bitmap_&256 != 0 {
+	if o != nil && o.bitmap_&512 != 0 {
 		return o.tenantID
 	}
 	return ""
@@ -368,7 +398,7 @@ func (o *Azure) TenantID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetTenantID() (value string, ok bool) {
-	ok = o != nil && o.bitmap_&256 != 0
+	ok = o != nil && o.bitmap_&512 != 0
 	if ok {
 		value = o.tenantID
 	}

--- a/clientapi/clustersmgmt/v1/azure_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_type_json.go
@@ -42,7 +42,16 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
 	var present_ bool
-	present_ = object.bitmap_&1 != 0
+	present_ = object.bitmap_&1 != 0 && object.etcdEncryption != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("etcd_encryption")
+		WriteAzureEtcdEncryption(object.etcdEncryption, stream)
+		count++
+	}
+	present_ = object.bitmap_&2 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -51,7 +60,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.managedResourceGroupName)
 		count++
 	}
-	present_ = object.bitmap_&2 != 0
+	present_ = object.bitmap_&4 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -60,7 +69,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.networkSecurityGroupResourceID)
 		count++
 	}
-	present_ = object.bitmap_&4 != 0 && object.nodesOutboundConnectivity != nil
+	present_ = object.bitmap_&8 != 0 && object.nodesOutboundConnectivity != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -69,7 +78,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureNodesOutboundConnectivity(object.nodesOutboundConnectivity, stream)
 		count++
 	}
-	present_ = object.bitmap_&8 != 0 && object.operatorsAuthentication != nil
+	present_ = object.bitmap_&16 != 0 && object.operatorsAuthentication != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -78,7 +87,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureOperatorsAuthentication(object.operatorsAuthentication, stream)
 		count++
 	}
-	present_ = object.bitmap_&16 != 0
+	present_ = object.bitmap_&32 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -87,7 +96,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.resourceGroupName)
 		count++
 	}
-	present_ = object.bitmap_&32 != 0
+	present_ = object.bitmap_&64 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -96,7 +105,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.resourceName)
 		count++
 	}
-	present_ = object.bitmap_&64 != 0
+	present_ = object.bitmap_&128 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -105,7 +114,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.subnetResourceID)
 		count++
 	}
-	present_ = object.bitmap_&128 != 0
+	present_ = object.bitmap_&256 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -114,7 +123,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.subscriptionID)
 		count++
 	}
-	present_ = object.bitmap_&256 != 0
+	present_ = object.bitmap_&512 != 0
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -146,42 +155,46 @@ func ReadAzure(iterator *jsoniter.Iterator) *Azure {
 			break
 		}
 		switch field {
+		case "etcd_encryption":
+			value := ReadAzureEtcdEncryption(iterator)
+			object.etcdEncryption = value
+			object.bitmap_ |= 1
 		case "managed_resource_group_name":
 			value := iterator.ReadString()
 			object.managedResourceGroupName = value
-			object.bitmap_ |= 1
+			object.bitmap_ |= 2
 		case "network_security_group_resource_id":
 			value := iterator.ReadString()
 			object.networkSecurityGroupResourceID = value
-			object.bitmap_ |= 2
+			object.bitmap_ |= 4
 		case "nodes_outbound_connectivity":
 			value := ReadAzureNodesOutboundConnectivity(iterator)
 			object.nodesOutboundConnectivity = value
-			object.bitmap_ |= 4
+			object.bitmap_ |= 8
 		case "operators_authentication":
 			value := ReadAzureOperatorsAuthentication(iterator)
 			object.operatorsAuthentication = value
-			object.bitmap_ |= 8
+			object.bitmap_ |= 16
 		case "resource_group_name":
 			value := iterator.ReadString()
 			object.resourceGroupName = value
-			object.bitmap_ |= 16
+			object.bitmap_ |= 32
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.bitmap_ |= 32
+			object.bitmap_ |= 64
 		case "subnet_resource_id":
 			value := iterator.ReadString()
 			object.subnetResourceID = value
-			object.bitmap_ |= 64
+			object.bitmap_ |= 128
 		case "subscription_id":
 			value := iterator.ReadString()
 			object.subscriptionID = value
-			object.bitmap_ |= 128
+			object.bitmap_ |= 256
 		case "tenant_id":
 			value := iterator.ReadString()
 			object.tenantID = value
-			object.bitmap_ |= 256
+			object.bitmap_ |= 512
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/azure_etcd_data_encryption_customer_managed_type.model
+++ b/model/clusters_mgmt/v1/azure_etcd_data_encryption_customer_managed_type.model
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support etcd data encryption with customer managed keys
+// for Azure based clusters.
+struct AzureEtcdDataEncryptionCustomerManaged {
+	// The encryption type used.
+	// Accepted values are: "kms".
+	// By default, "kms" is used.
+	EncryptionType string
+
+	// The KMS encryption configuration.
+	// Required when encryption_type is "kms".
+	Kms  AzureKmsEncryption
+}

--- a/model/clusters_mgmt/v1/azure_etcd_data_encryption_type.model
+++ b/model/clusters_mgmt/v1/azure_etcd_data_encryption_type.model
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support data encryption for Azure based clusters.
+struct AzureEtcdDataEncryption {
+	// The key management strategy used for the encryption key that encrypts the etcd data.
+	// Accepted values are: "customer_managed", "platform_managed".
+	// By default, "platform_managed" is used.
+	// Currently only "customer_managed" mode is supported.
+	KeyManagementMode string
+
+	// Customer Managed encryption keys configuration.
+	// Required when key_management_mode is "customer_managed".
+	CustomerManaged  AzureEtcdDataEncryptionCustomerManaged
+}

--- a/model/clusters_mgmt/v1/azure_etcd_encryption_type.model
+++ b/model/clusters_mgmt/v1/azure_etcd_encryption_type.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+struct AzureEtcdEncryption {
+	// etcd data encryption settings.
+	// If not specified, etcd data is encrypted with platform managed keys.
+	DataEncryption AzureEtcdDataEncryption
+}

--- a/model/clusters_mgmt/v1/azure_kms_encryption_type.model
+++ b/model/clusters_mgmt/v1/azure_kms_encryption_type.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support KMS encryption for Azure based clusters.
+struct AzureKmsEncryption {
+	// The details of the active key
+	// Required during creation.
+	ActiveKey  AzureKmsKey
+}

--- a/model/clusters_mgmt/v1/azure_kms_key_type.model
+++ b/model/clusters_mgmt/v1/azure_kms_key_type.model
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains the necessary attributes to support KMS encryption key for Azure based clusters
+struct AzureKmsKey {
+	// key_vault_name is the name of the Azure Key Vault that contains the encryption key
+	// Required during creation.
+	KeyVaultName  string
+
+	// key_name is the name of the Azure Key Vault Key
+	// Required during creation.
+	KeyName  string
+
+	// key_version is the version of the Azure Key Vault key
+	// Required during creation.
+	KeyVersion  string
+}

--- a/model/clusters_mgmt/v1/azure_type.model
+++ b/model/clusters_mgmt/v1/azure_type.model
@@ -106,4 +106,10 @@ struct Azure {
 	// configuration of the Cluster's Node Pool's Nodes is performed.
 	// By default this is configured as Azure Load Balancer. This value is immutable.
 	NodesOutboundConnectivity AzureNodesOutboundConnectivity
+
+	// Etcd encryption configuration.
+	// If not specified, etcd data is encrypted with platform managed keys.
+	// Currently etcd data encryption is only supported with customer managed keys.
+	// Creating a cluster with platform managed keys will result in a failure creating the cluster.
+	EtcdEncryption AzureEtcdEncryption
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -1489,6 +1489,10 @@
       "Azure": {
         "description": "Microsoft Azure settings of a cluster.",
         "properties": {
+          "etcd_encryption": {
+            "description": "Etcd encryption configuration.\nIf not specified, etcd data is encrypted with platform managed keys.\nCurrently etcd data encryption is only supported with customer managed keys.\nCreating a cluster with platform managed keys will result in a failure creating the cluster.",
+            "$ref": "#/components/schemas/AzureEtcdEncryption"
+          },
           "managed_resource_group_name": {
             "description": "The desired name of the Azure Resource Group where the Azure Resources related\nto the cluster are created. It must not previously exist. The Azure Resource\nGroup is created with the given value, within the Azure Subscription\n`subscription_id` of the cluster.\n`managed_resource_group_name` cannot be equal to the value of `managed_resource_group`.\n`managed_resource_group_name` is located in the same Azure location as the\ncluster's region.\nNot to be confused with `resource_group_name`, which is the Azure Resource Group Name\nwhere the own Azure Resource associated to the cluster resides.\nRequired during creation.\nImmutable.",
             "type": "string"
@@ -1549,6 +1553,67 @@
         "properties": {
           "resource_id": {
             "description": "The Azure Resource ID of the Azure User-Assigned Managed\nIdentity. The managed identity represented must exist before\ncreating the cluster.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust belong to the Azure Subscription specified in `.azure.subscription_id`,\nand in the same Azure location as the cluster's region.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust be a different Resource Group Name than the one specified in\n`.azure.managed_resource_group_name`.\nThe Azure Resource Group Name specified as part of the Resource ID\ncan be the same, or a different one than the one specified in\n`.azure.resource_group_name`.\nRequired during creation.\nImmutable.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureEtcdDataEncryption": {
+        "description": "Contains the necessary attributes to support data encryption for Azure based clusters.",
+        "properties": {
+          "customer_managed": {
+            "description": "Customer Managed encryption keys configuration.\nRequired when key_management_mode is \"customer_managed\".",
+            "$ref": "#/components/schemas/AzureEtcdDataEncryptionCustomerManaged"
+          },
+          "key_management_mode": {
+            "description": "The key management strategy used for the encryption key that encrypts the etcd data.\nAccepted values are: \"customer_managed\", \"platform_managed\".\nBy default, \"platform_managed\" is used.\nCurrently only \"customer_managed\" mode is supported.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureEtcdDataEncryptionCustomerManaged": {
+        "description": "Contains the necessary attributes to support etcd data encryption with customer managed keys\nfor Azure based clusters.",
+        "properties": {
+          "encryption_type": {
+            "description": "The encryption type used.\nAccepted values are: \"kms\".\nBy default, \"kms\" is used.",
+            "type": "string"
+          },
+          "kms": {
+            "description": "The KMS encryption configuration.\nRequired when encryption_type is \"kms\".",
+            "$ref": "#/components/schemas/AzureKmsEncryption"
+          }
+        }
+      },
+      "AzureEtcdEncryption": {
+        "description": "Contains the necessary attributes to support etcd encryption for Azure based clusters.",
+        "properties": {
+          "data_encryption": {
+            "description": "etcd data encryption settings.\nIf not specified, etcd data is encrypted with platform managed keys.",
+            "$ref": "#/components/schemas/AzureEtcdDataEncryption"
+          }
+        }
+      },
+      "AzureKmsEncryption": {
+        "description": "Contains the necessary attributes to support KMS encryption for Azure based clusters.",
+        "properties": {
+          "active_key": {
+            "description": "The details of the active key\nRequired during creation.",
+            "$ref": "#/components/schemas/AzureKmsKey"
+          }
+        }
+      },
+      "AzureKmsKey": {
+        "description": "Contains the necessary attributes to support KMS encryption key for Azure based clusters",
+        "properties": {
+          "key_name": {
+            "description": "key_name is the name of the Azure Key Vault Key\nRequired during creation.",
+            "type": "string"
+          },
+          "key_vault_name": {
+            "description": "key_vault_name is the name of the Azure Key Vault that contains the encryption key\nRequired during creation.",
+            "type": "string"
+          },
+          "key_version": {
+            "description": "key_version is the version of the Azure Key Vault key\nRequired during creation.",
             "type": "string"
           }
         }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -14922,6 +14922,10 @@
       "Azure": {
         "description": "Microsoft Azure settings of a cluster.",
         "properties": {
+          "etcd_encryption": {
+            "description": "Etcd encryption configuration.\nIf not specified, etcd data is encrypted with platform managed keys.\nCurrently etcd data encryption is only supported with customer managed keys.\nCreating a cluster with platform managed keys will result in a failure creating the cluster.",
+            "$ref": "#/components/schemas/AzureEtcdEncryption"
+          },
           "managed_resource_group_name": {
             "description": "The desired name of the Azure Resource Group where the Azure Resources related\nto the cluster are created. It must not previously exist. The Azure Resource\nGroup is created with the given value, within the Azure Subscription\n`subscription_id` of the cluster.\n`managed_resource_group_name` cannot be equal to the value of `managed_resource_group`.\n`managed_resource_group_name` is located in the same Azure location as the\ncluster's region.\nNot to be confused with `resource_group_name`, which is the Azure Resource Group Name\nwhere the own Azure Resource associated to the cluster resides.\nRequired during creation.\nImmutable.",
             "type": "string"
@@ -14982,6 +14986,67 @@
         "properties": {
           "resource_id": {
             "description": "The Azure Resource ID of the Azure User-Assigned Managed\nIdentity. The managed identity represented must exist before\ncreating the cluster.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust belong to the Azure Subscription specified in `.azure.subscription_id`,\nand in the same Azure location as the cluster's region.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust be a different Resource Group Name than the one specified in\n`.azure.managed_resource_group_name`.\nThe Azure Resource Group Name specified as part of the Resource ID\ncan be the same, or a different one than the one specified in\n`.azure.resource_group_name`.\nRequired during creation.\nImmutable.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureEtcdDataEncryption": {
+        "description": "Contains the necessary attributes to support data encryption for Azure based clusters.",
+        "properties": {
+          "customer_managed": {
+            "description": "Customer Managed encryption keys configuration.\nRequired when key_management_mode is \"customer_managed\".",
+            "$ref": "#/components/schemas/AzureEtcdDataEncryptionCustomerManaged"
+          },
+          "key_management_mode": {
+            "description": "The key management strategy used for the encryption key that encrypts the etcd data.\nAccepted values are: \"customer_managed\", \"platform_managed\".\nBy default, \"platform_managed\" is used.\nCurrently only \"customer_managed\" mode is supported.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureEtcdDataEncryptionCustomerManaged": {
+        "description": "Contains the necessary attributes to support etcd data encryption with customer managed keys\nfor Azure based clusters.",
+        "properties": {
+          "encryption_type": {
+            "description": "The encryption type used.\nAccepted values are: \"kms\".\nBy default, \"kms\" is used.",
+            "type": "string"
+          },
+          "kms": {
+            "description": "The KMS encryption configuration.\nRequired when encryption_type is \"kms\".",
+            "$ref": "#/components/schemas/AzureKmsEncryption"
+          }
+        }
+      },
+      "AzureEtcdEncryption": {
+        "description": "Contains the necessary attributes to support etcd encryption for Azure based clusters.",
+        "properties": {
+          "data_encryption": {
+            "description": "etcd data encryption settings.\nIf not specified, etcd data is encrypted with platform managed keys.",
+            "$ref": "#/components/schemas/AzureEtcdDataEncryption"
+          }
+        }
+      },
+      "AzureKmsEncryption": {
+        "description": "Contains the necessary attributes to support KMS encryption for Azure based clusters.",
+        "properties": {
+          "active_key": {
+            "description": "The details of the active key\nRequired during creation.",
+            "$ref": "#/components/schemas/AzureKmsKey"
+          }
+        }
+      },
+      "AzureKmsKey": {
+        "description": "Contains the necessary attributes to support KMS encryption key for Azure based clusters",
+        "properties": {
+          "key_name": {
+            "description": "key_name is the name of the Azure Key Vault Key\nRequired during creation.",
+            "type": "string"
+          },
+          "key_vault_name": {
+            "description": "key_vault_name is the name of the Azure Key Vault that contains the encryption key\nRequired during creation.",
+            "type": "string"
+          },
+          "key_version": {
+            "description": "key_version is the version of the Azure Key Vault key\nRequired during creation.",
             "type": "string"
           }
         }


### PR DESCRIPTION
[ARO-19064](https://issues.redhat.com//browse/ARO-19064): Make OCM API changes for Azure Etcd data level encryption with customer managed keys.

Motivation of the chosen API design:

1. Defining a key_management_mode attribute along with a customer_managed section
We define a union type to be explicit around what’s chosen.
We are able to define per key management mode configuration.
It gives space to grow in the future around those dimensions. In the worst case we have a bit more of unnecessary indirection, but we deemed this as preferable than not being able to grow nor make the api design more confusing when that happens having a mix between different configurations belonging to different modes at the same level

2. Define an encryption_type attribute along with a kms section
We define a union type to be explicit around what’s chosen.
We are able to define per encryption type configuration.
It gives space to grow in the future around those dimensions. In the worst case we have a bit more of unnecessary indirection, but we deemed this as preferable than not being able to grow nor make the api design more confusing when that happens having a mix between different configurations belonging to different modes at the same level

3. We know that rotation related configuration will be needed in the future. 
By having a kms section we will be able to add configuration related to rotation for that encryption type in the future: For example, the backup key, similarly to what’s done in Hypershift.

4. Aside from the changes in this MR,  the existing etcd_encryption boolean property defined at the top level of the Cluster API resource will be made readonly.
For ARO-HCP, etcd encryption (both data level, which is the subject of this PR, and disk level one) will always be enabled, independently of the key management mode and the encryption algorithm used for it. Because of this, we will make this a readonly attribute for ARO-HCP. For ARO-HCP based Clusters, explicitly setting that top-level attribute, even with a value of true, will return an error.

5. Currently etcd data encryption is only supported with customer_managed keys. Creating a cluster with platform managed keys will result in a failure creating the cluster. This is mentioned in comments,  which will be removed once platform_managed keys are supported.

6. If etcd encryption related configuration data is not provided, we default to etcd data encryption with platform keys. We initially are not going to support platform managed keys but we plan to introduce it. **We are aware that this will result in a validation error on the backend side with a default payload temporarily until we implement platform managed keys. This has been an intentional and a consensus decision and tradeoff in ARO-HCP, including at ARM API level, with the reason being that in that way we do not need to change the api scheme later, causing a breaking change. The idea at the moment is also that the API in this temporary state is going to be released to a minor subset of users.**