### PR TITLE
ARO-19796: OCM API changes - mark cluster etcd_encryption flag as readonly

### DIFF
--- a/clientapi/arohcp/v1alpha1/cluster_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type.go
@@ -718,6 +718,7 @@ func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
 //
 // Indicates whether that etcd is encrypted or not.
 // This is set only during cluster creation.
+// For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) EtcdEncryption() bool {
 	if o != nil && o.bitmap_&33554432 != 0 {
 		return o.etcdEncryption
@@ -730,6 +731,7 @@ func (o *Cluster) EtcdEncryption() bool {
 //
 // Indicates whether that etcd is encrypted or not.
 // This is set only during cluster creation.
+// For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
 	ok = o != nil && o.bitmap_&33554432 != 0
 	if ok {

--- a/clientapi/clustersmgmt/v1/cluster_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_type.go
@@ -716,6 +716,7 @@ func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
 //
 // Indicates whether that etcd is encrypted or not.
 // This is set only during cluster creation.
+// For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) EtcdEncryption() bool {
 	if o != nil && o.bitmap_&33554432 != 0 {
 		return o.etcdEncryption
@@ -728,6 +729,7 @@ func (o *Cluster) EtcdEncryption() bool {
 //
 // Indicates whether that etcd is encrypted or not.
 // This is set only during cluster creation.
+// For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
 	ok = o != nil && o.bitmap_&33554432 != 0
 	if ok {

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -213,6 +213,7 @@ class Cluster {
 
 	// Indicates whether that etcd is encrypted or not.
 	// This is set only during cluster creation.
+	// For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 	EtcdEncryption Boolean
 
 	// Billing model for cluster resources.

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -2244,7 +2244,7 @@
             "type": "string"
           },
           "etcd_encryption": {
-            "description": "Indicates whether that etcd is encrypted or not.\nThis is set only during cluster creation.",
+            "description": "Indicates whether that etcd is encrypted or not.\nThis is set only during cluster creation.\nFor ARO-HCP Clusters, this is a readonly attribute, always set to true.",
             "type": "boolean"
           },
           "expiration_timestamp": {

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -15562,7 +15562,7 @@
             "type": "string"
           },
           "etcd_encryption": {
-            "description": "Indicates whether that etcd is encrypted or not.\nThis is set only during cluster creation.",
+            "description": "Indicates whether that etcd is encrypted or not.\nThis is set only during cluster creation.\nFor ARO-HCP Clusters, this is a readonly attribute, always set to true.",
             "type": "boolean"
           },
           "expiration_timestamp": {


### PR DESCRIPTION
[ARO-19796](https://issues.redhat.com//browse/ARO-19796): OCM API changes - mark cluster etcd_encryption flag as readonly for ARO-HCP clusters as part of Azure Etcd data level encryption with customer managed keys.

Please refer to [DDR](https://docs.google.com/document/d/1c4wDdHoRnKEDEc6zaQfbf9VmQBzUEbfPC4HK2I6MZNA/edit?usp=sharing) API changes section for details. 