### PR TITLE
[OCM-17005] define capacity reservation parameters in the AWSNodePool type

### DIFF
--- a/clientapi/arohcp/v1alpha1/aws_capacity_reservation_builder.go
+++ b/clientapi/arohcp/v1alpha1/aws_capacity_reservation_builder.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AWS Capacity Reservation specification.
+type AWSCapacityReservationBuilder struct {
+	fieldSet_  []bool
+	id         string
+	href       string
+	id         string
+	marketType MarketType
+}
+
+// NewAWSCapacityReservation creates a new builder of 'AWS_capacity_reservation' objects.
+func NewAWSCapacityReservation() *AWSCapacityReservationBuilder {
+	return &AWSCapacityReservationBuilder{
+		fieldSet_: make([]bool, 5),
+	}
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *AWSCapacityReservationBuilder) Link(value bool) *AWSCapacityReservationBuilder {
+	b.fieldSet_[0] = true
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *AWSCapacityReservationBuilder) ID(value string) *AWSCapacityReservationBuilder {
+	b.id = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *AWSCapacityReservationBuilder) HREF(value string) *AWSCapacityReservationBuilder {
+	b.href = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSCapacityReservationBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(b.fieldSet_); i++ {
+		if b.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Id sets the value of the 'id' attribute to the given value.
+func (b *AWSCapacityReservationBuilder) Id(value string) *AWSCapacityReservationBuilder {
+	b.id = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// MarketType sets the value of the 'market_type' attribute to the given value.
+//
+// Market type for AWS Capacity Reservations.
+func (b *AWSCapacityReservationBuilder) MarketType(value MarketType) *AWSCapacityReservationBuilder {
+	b.marketType = value
+	b.fieldSet_[4] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AWSCapacityReservationBuilder) Copy(object *AWSCapacityReservation) *AWSCapacityReservationBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.id = object.id
+	b.href = object.href
+	b.id = object.id
+	b.marketType = object.marketType
+	return b
+}
+
+// Build creates a 'AWS_capacity_reservation' object using the configuration stored in the builder.
+func (b *AWSCapacityReservationBuilder) Build() (object *AWSCapacityReservation, err error) {
+	object = new(AWSCapacityReservation)
+	object.id = b.id
+	object.href = b.href
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.id = b.id
+	object.marketType = b.marketType
+	return
+}

--- a/clientapi/arohcp/v1alpha1/aws_capacity_reservation_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/aws_capacity_reservation_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AWSCapacityReservationListBuilder contains the data and logic needed to build
+// 'AWS_capacity_reservation' objects.
+type AWSCapacityReservationListBuilder struct {
+	items []*AWSCapacityReservationBuilder
+}
+
+// NewAWSCapacityReservationList creates a new builder of 'AWS_capacity_reservation' objects.
+func NewAWSCapacityReservationList() *AWSCapacityReservationListBuilder {
+	return new(AWSCapacityReservationListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AWSCapacityReservationListBuilder) Items(values ...*AWSCapacityReservationBuilder) *AWSCapacityReservationListBuilder {
+	b.items = make([]*AWSCapacityReservationBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AWSCapacityReservationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AWSCapacityReservationListBuilder) Copy(list *AWSCapacityReservationList) *AWSCapacityReservationListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AWSCapacityReservationBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAWSCapacityReservation().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'AWS_capacity_reservation' objects using the
+// configuration stored in the builder.
+func (b *AWSCapacityReservationListBuilder) Build() (list *AWSCapacityReservationList, err error) {
+	items := make([]*AWSCapacityReservation, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AWSCapacityReservationList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/aws_capacity_reservation_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/aws_capacity_reservation_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAWSCapacityReservationList writes a list of values of the 'AWS_capacity_reservation' type to
+// the given writer.
+func MarshalAWSCapacityReservationList(list []*AWSCapacityReservation, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAWSCapacityReservationList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAWSCapacityReservationList writes a list of value of the 'AWS_capacity_reservation' type to
+// the given stream.
+func WriteAWSCapacityReservationList(list []*AWSCapacityReservation, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAWSCapacityReservation(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAWSCapacityReservationList reads a list of values of the 'AWS_capacity_reservation' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAWSCapacityReservationList(source interface{}) (items []*AWSCapacityReservation, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAWSCapacityReservationList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAWSCapacityReservationList reads list of values of the ”AWS_capacity_reservation' type from
+// the given iterator.
+func ReadAWSCapacityReservationList(iterator *jsoniter.Iterator) []*AWSCapacityReservation {
+	list := []*AWSCapacityReservation{}
+	for iterator.ReadArray() {
+		item := ReadAWSCapacityReservation(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/aws_capacity_reservation_type.go
+++ b/clientapi/arohcp/v1alpha1/aws_capacity_reservation_type.go
@@ -1,0 +1,305 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AWSCapacityReservationKind is the name of the type used to represent objects
+// of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationKind = "AWSCapacityReservation"
+
+// AWSCapacityReservationLinkKind is the name of the type used to represent links
+// to objects of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationLinkKind = "AWSCapacityReservationLink"
+
+// AWSCapacityReservationNilKind is the name of the type used to nil references
+// to objects of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationNilKind = "AWSCapacityReservationNil"
+
+// AWSCapacityReservation represents the values of the 'AWS_capacity_reservation' type.
+//
+// AWS Capacity Reservation specification.
+type AWSCapacityReservation struct {
+	fieldSet_  []bool
+	id         string
+	href       string
+	id         string
+	marketType MarketType
+}
+
+// Kind returns the name of the type of the object.
+func (o *AWSCapacityReservation) Kind() string {
+	if o == nil {
+		return AWSCapacityReservationNilKind
+	}
+	if len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return AWSCapacityReservationLinkKind
+	}
+	return AWSCapacityReservationKind
+}
+
+// Link returns true if this is a link.
+func (o *AWSCapacityReservation) Link() bool {
+	return o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+}
+
+// ID returns the identifier of the object.
+func (o *AWSCapacityReservation) ID() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *AWSCapacityReservation) GetID() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *AWSCapacityReservation) HREF() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *AWSCapacityReservation) GetHREF() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AWSCapacityReservation) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(o.fieldSet_); i++ {
+		if o.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Id returns the value of the 'id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Specify the target Capacity Reservation in which the EC2 instances will be launched.
+func (o *AWSCapacityReservation) Id() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.id
+	}
+	return ""
+}
+
+// GetId returns the value of the 'id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Specify the target Capacity Reservation in which the EC2 instances will be launched.
+func (o *AWSCapacityReservation) GetId() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// MarketType returns the value of the 'market_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// marketType specifies the market type of the CapacityReservation for the EC2
+// instances. Valid values are OnDemand, CapacityBlocks.
+// "OnDemand": EC2 instances run as standard On-Demand instances.
+// "CapacityBlocks": scheduled pre-purchased compute capacity.
+func (o *AWSCapacityReservation) MarketType() MarketType {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
+		return o.marketType
+	}
+	return MarketType("")
+}
+
+// GetMarketType returns the value of the 'market_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// marketType specifies the market type of the CapacityReservation for the EC2
+// instances. Valid values are OnDemand, CapacityBlocks.
+// "OnDemand": EC2 instances run as standard On-Demand instances.
+// "CapacityBlocks": scheduled pre-purchased compute capacity.
+func (o *AWSCapacityReservation) GetMarketType() (value MarketType, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
+	if ok {
+		value = o.marketType
+	}
+	return
+}
+
+// AWSCapacityReservationListKind is the name of the type used to represent list of objects of
+// type 'AWS_capacity_reservation'.
+const AWSCapacityReservationListKind = "AWSCapacityReservationList"
+
+// AWSCapacityReservationListLinkKind is the name of the type used to represent links to list
+// of objects of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationListLinkKind = "AWSCapacityReservationListLink"
+
+// AWSCapacityReservationNilKind is the name of the type used to nil lists of objects of
+// type 'AWS_capacity_reservation'.
+const AWSCapacityReservationListNilKind = "AWSCapacityReservationListNil"
+
+// AWSCapacityReservationList is a list of values of the 'AWS_capacity_reservation' type.
+type AWSCapacityReservationList struct {
+	href  string
+	link  bool
+	items []*AWSCapacityReservation
+}
+
+// Kind returns the name of the type of the object.
+func (l *AWSCapacityReservationList) Kind() string {
+	if l == nil {
+		return AWSCapacityReservationListNilKind
+	}
+	if l.link {
+		return AWSCapacityReservationListLinkKind
+	}
+	return AWSCapacityReservationListKind
+}
+
+// Link returns true iif this is a link.
+func (l *AWSCapacityReservationList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *AWSCapacityReservationList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *AWSCapacityReservationList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *AWSCapacityReservationList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AWSCapacityReservationList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AWSCapacityReservationList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AWSCapacityReservationList) SetItems(items []*AWSCapacityReservation) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AWSCapacityReservationList) Items() []*AWSCapacityReservation {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AWSCapacityReservationList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AWSCapacityReservationList) Get(i int) *AWSCapacityReservation {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AWSCapacityReservationList) Slice() []*AWSCapacityReservation {
+	var slice []*AWSCapacityReservation
+	if l == nil {
+		slice = make([]*AWSCapacityReservation, 0)
+	} else {
+		slice = make([]*AWSCapacityReservation, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AWSCapacityReservationList) Each(f func(item *AWSCapacityReservation) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AWSCapacityReservationList) Range(f func(index int, item *AWSCapacityReservation) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/aws_capacity_reservation_type_json.go
+++ b/clientapi/arohcp/v1alpha1/aws_capacity_reservation_type_json.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAWSCapacityReservation writes a value of the 'AWS_capacity_reservation' type to the given writer.
+func MarshalAWSCapacityReservation(object *AWSCapacityReservation, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAWSCapacityReservation(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAWSCapacityReservation writes a value of the 'AWS_capacity_reservation' type to the given stream.
+func WriteAWSCapacityReservation(object *AWSCapacityReservation, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	stream.WriteObjectField("kind")
+	if len(object.fieldSet_) > 0 && object.fieldSet_[0] {
+		stream.WriteString(AWSCapacityReservationLinkKind)
+	} else {
+		stream.WriteString(AWSCapacityReservationKind)
+	}
+	count++
+	if len(object.fieldSet_) > 1 && object.fieldSet_[1] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	if len(object.fieldSet_) > 2 && object.fieldSet_[2] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
+	var present_ bool
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("market_type")
+		stream.WriteString(string(object.marketType))
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAWSCapacityReservation reads a value of the 'AWS_capacity_reservation' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAWSCapacityReservation(source interface{}) (object *AWSCapacityReservation, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAWSCapacityReservation(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAWSCapacityReservation reads a value of the 'AWS_capacity_reservation' type from the given iterator.
+func ReadAWSCapacityReservation(iterator *jsoniter.Iterator) *AWSCapacityReservation {
+	object := &AWSCapacityReservation{
+		fieldSet_: make([]bool, 5),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "kind":
+			value := iterator.ReadString()
+			if value == AWSCapacityReservationLinkKind {
+				object.fieldSet_[0] = true
+			}
+		case "id":
+			object.id = iterator.ReadString()
+			object.fieldSet_[1] = true
+		case "href":
+			object.href = iterator.ReadString()
+			object.fieldSet_[2] = true
+		case "id":
+			value := iterator.ReadString()
+			object.id = value
+			object.fieldSet_[3] = true
+		case "market_type":
+			text := iterator.ReadString()
+			value := MarketType(text)
+			object.marketType = value
+			object.fieldSet_[4] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/aws_node_pool_builder.go
+++ b/clientapi/arohcp/v1alpha1/aws_node_pool_builder.go
@@ -26,6 +26,7 @@ type AWSNodePoolBuilder struct {
 	href                       string
 	additionalSecurityGroupIds []string
 	availabilityZoneTypes      map[string]string
+	capacityReservation        *AWSCapacityReservationBuilder
 	ec2MetadataHttpTokens      Ec2MetadataHttpTokens
 	instanceProfile            string
 	instanceType               string
@@ -37,7 +38,7 @@ type AWSNodePoolBuilder struct {
 // NewAWSNodePool creates a new builder of 'AWS_node_pool' objects.
 func NewAWSNodePool() *AWSNodePoolBuilder {
 	return &AWSNodePoolBuilder{
-		fieldSet_: make([]bool, 11),
+		fieldSet_: make([]bool, 12),
 	}
 }
 
@@ -94,26 +95,39 @@ func (b *AWSNodePoolBuilder) AvailabilityZoneTypes(value map[string]string) *AWS
 	return b
 }
 
+// CapacityReservation sets the value of the 'capacity_reservation' attribute to the given value.
+//
+// AWS Capacity Reservation specification.
+func (b *AWSNodePoolBuilder) CapacityReservation(value *AWSCapacityReservationBuilder) *AWSNodePoolBuilder {
+	b.capacityReservation = value
+	if value != nil {
+		b.fieldSet_[5] = true
+	} else {
+		b.fieldSet_[5] = false
+	}
+	return b
+}
+
 // Ec2MetadataHttpTokens sets the value of the 'ec_2_metadata_http_tokens' attribute to the given value.
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSNodePoolBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSNodePoolBuilder {
 	b.ec2MetadataHttpTokens = value
-	b.fieldSet_[5] = true
+	b.fieldSet_[6] = true
 	return b
 }
 
 // InstanceProfile sets the value of the 'instance_profile' attribute to the given value.
 func (b *AWSNodePoolBuilder) InstanceProfile(value string) *AWSNodePoolBuilder {
 	b.instanceProfile = value
-	b.fieldSet_[6] = true
+	b.fieldSet_[7] = true
 	return b
 }
 
 // InstanceType sets the value of the 'instance_type' attribute to the given value.
 func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 	b.instanceType = value
-	b.fieldSet_[7] = true
+	b.fieldSet_[8] = true
 	return b
 }
 
@@ -123,9 +137,9 @@ func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBuilder {
 	b.rootVolume = value
 	if value != nil {
-		b.fieldSet_[8] = true
+		b.fieldSet_[9] = true
 	} else {
-		b.fieldSet_[8] = false
+		b.fieldSet_[9] = false
 	}
 	return b
 }
@@ -134,9 +148,9 @@ func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBui
 func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoolBuilder {
 	b.subnetOutposts = value
 	if value != nil {
-		b.fieldSet_[9] = true
+		b.fieldSet_[10] = true
 	} else {
-		b.fieldSet_[9] = false
+		b.fieldSet_[10] = false
 	}
 	return b
 }
@@ -145,9 +159,9 @@ func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoo
 func (b *AWSNodePoolBuilder) Tags(value map[string]string) *AWSNodePoolBuilder {
 	b.tags = value
 	if value != nil {
-		b.fieldSet_[10] = true
+		b.fieldSet_[11] = true
 	} else {
-		b.fieldSet_[10] = false
+		b.fieldSet_[11] = false
 	}
 	return b
 }
@@ -176,6 +190,11 @@ func (b *AWSNodePoolBuilder) Copy(object *AWSNodePool) *AWSNodePoolBuilder {
 		}
 	} else {
 		b.availabilityZoneTypes = nil
+	}
+	if object.capacityReservation != nil {
+		b.capacityReservation = NewAWSCapacityReservation().Copy(object.capacityReservation)
+	} else {
+		b.capacityReservation = nil
 	}
 	b.ec2MetadataHttpTokens = object.ec2MetadataHttpTokens
 	b.instanceProfile = object.instanceProfile
@@ -221,6 +240,12 @@ func (b *AWSNodePoolBuilder) Build() (object *AWSNodePool, err error) {
 		object.availabilityZoneTypes = make(map[string]string)
 		for k, v := range b.availabilityZoneTypes {
 			object.availabilityZoneTypes[k] = v
+		}
+	}
+	if b.capacityReservation != nil {
+		object.capacityReservation, err = b.capacityReservation.Build()
+		if err != nil {
+			return
 		}
 	}
 	object.ec2MetadataHttpTokens = b.ec2MetadataHttpTokens

--- a/clientapi/arohcp/v1alpha1/aws_node_pool_type.go
+++ b/clientapi/arohcp/v1alpha1/aws_node_pool_type.go
@@ -40,6 +40,7 @@ type AWSNodePool struct {
 	href                       string
 	additionalSecurityGroupIds []string
 	availabilityZoneTypes      map[string]string
+	capacityReservation        *AWSCapacityReservation
 	ec2MetadataHttpTokens      Ec2MetadataHttpTokens
 	instanceProfile            string
 	instanceType               string
@@ -161,12 +162,35 @@ func (o *AWSNodePool) GetAvailabilityZoneTypes() (value map[string]string, ok bo
 	return
 }
 
+// CapacityReservation returns the value of the 'capacity_reservation' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// If present it defines the AWS Capacity Reservation used for this NodePool
+func (o *AWSNodePool) CapacityReservation() *AWSCapacityReservation {
+	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+		return o.capacityReservation
+	}
+	return nil
+}
+
+// GetCapacityReservation returns the value of the 'capacity_reservation' attribute and
+// a flag indicating if the attribute has a value.
+//
+// If present it defines the AWS Capacity Reservation used for this NodePool
+func (o *AWSNodePool) GetCapacityReservation() (value *AWSCapacityReservation, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	if ok {
+		value = o.capacityReservation
+	}
+	return
+}
+
 // Ec2MetadataHttpTokens returns the value of the 'ec_2_metadata_http_tokens' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWSNodePool) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
-	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
 		return o.ec2MetadataHttpTokens
 	}
 	return Ec2MetadataHttpTokens("")
@@ -177,7 +201,7 @@ func (o *AWSNodePool) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWSNodePool) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
 	if ok {
 		value = o.ec2MetadataHttpTokens
 	}
@@ -189,7 +213,7 @@ func (o *AWSNodePool) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, o
 //
 // InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
 func (o *AWSNodePool) InstanceProfile() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
 		return o.instanceProfile
 	}
 	return ""
@@ -200,7 +224,7 @@ func (o *AWSNodePool) InstanceProfile() string {
 //
 // InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
 func (o *AWSNodePool) GetInstanceProfile() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
 	if ok {
 		value = o.instanceProfile
 	}
@@ -212,7 +236,7 @@ func (o *AWSNodePool) GetInstanceProfile() (value string, ok bool) {
 //
 // InstanceType is an ec2 instance type for node instances (e.g. m5.large).
 func (o *AWSNodePool) InstanceType() string {
-	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
 		return o.instanceType
 	}
 	return ""
@@ -223,7 +247,7 @@ func (o *AWSNodePool) InstanceType() string {
 //
 // InstanceType is an ec2 instance type for node instances (e.g. m5.large).
 func (o *AWSNodePool) GetInstanceType() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
 	if ok {
 		value = o.instanceType
 	}
@@ -235,7 +259,7 @@ func (o *AWSNodePool) GetInstanceType() (value string, ok bool) {
 //
 // AWS Volume specification to be used to set custom worker disk size
 func (o *AWSNodePool) RootVolume() *AWSVolume {
-	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
+	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
 		return o.rootVolume
 	}
 	return nil
@@ -246,7 +270,7 @@ func (o *AWSNodePool) RootVolume() *AWSVolume {
 //
 // AWS Volume specification to be used to set custom worker disk size
 func (o *AWSNodePool) GetRootVolume() (value *AWSVolume, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
+	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
 	if ok {
 		value = o.rootVolume
 	}
@@ -258,7 +282,7 @@ func (o *AWSNodePool) GetRootVolume() (value *AWSVolume, ok bool) {
 //
 // Associates nodepool subnets with AWS Outposts.
 func (o *AWSNodePool) SubnetOutposts() map[string]string {
-	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
 		return o.subnetOutposts
 	}
 	return nil
@@ -269,7 +293,7 @@ func (o *AWSNodePool) SubnetOutposts() map[string]string {
 //
 // Associates nodepool subnets with AWS Outposts.
 func (o *AWSNodePool) GetSubnetOutposts() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
 	if ok {
 		value = o.subnetOutposts
 	}
@@ -288,7 +312,7 @@ func (o *AWSNodePool) GetSubnetOutposts() (value map[string]string, ok bool) {
 // - Tag values may be between 0 and 256 characters in length
 // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
 func (o *AWSNodePool) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.tags
 	}
 	return nil
@@ -306,7 +330,7 @@ func (o *AWSNodePool) Tags() map[string]string {
 // - Tag values may be between 0 and 256 characters in length
 // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
 func (o *AWSNodePool) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.tags
 	}

--- a/clientapi/arohcp/v1alpha1/aws_node_pool_type_json.go
+++ b/clientapi/arohcp/v1alpha1/aws_node_pool_type_json.go
@@ -104,7 +104,16 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5]
+	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.capacityReservation != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("capacity_reservation")
+		WriteAWSCapacityReservation(object.capacityReservation, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -113,7 +122,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.ec2MetadataHttpTokens))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
+	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -122,7 +131,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		stream.WriteString(object.instanceProfile)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
+	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -131,7 +140,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		stream.WriteString(object.instanceType)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8] && object.rootVolume != nil
+	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.rootVolume != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -140,7 +149,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		WriteAWSVolume(object.rootVolume, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.subnetOutposts != nil
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.subnetOutposts != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -169,7 +178,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.tags != nil
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -215,7 +224,7 @@ func UnmarshalAWSNodePool(source interface{}) (object *AWSNodePool, err error) {
 // ReadAWSNodePool reads a value of the 'AWS_node_pool' type from the given iterator.
 func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 	object := &AWSNodePool{
-		fieldSet_: make([]bool, 11),
+		fieldSet_: make([]bool, 12),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -250,23 +259,27 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 			}
 			object.availabilityZoneTypes = value
 			object.fieldSet_[4] = true
+		case "capacity_reservation":
+			value := ReadAWSCapacityReservation(iterator)
+			object.capacityReservation = value
+			object.fieldSet_[5] = true
 		case "ec2_metadata_http_tokens":
 			text := iterator.ReadString()
 			value := Ec2MetadataHttpTokens(text)
 			object.ec2MetadataHttpTokens = value
-			object.fieldSet_[5] = true
+			object.fieldSet_[6] = true
 		case "instance_profile":
 			value := iterator.ReadString()
 			object.instanceProfile = value
-			object.fieldSet_[6] = true
+			object.fieldSet_[7] = true
 		case "instance_type":
 			value := iterator.ReadString()
 			object.instanceType = value
-			object.fieldSet_[7] = true
+			object.fieldSet_[8] = true
 		case "root_volume":
 			value := ReadAWSVolume(iterator)
 			object.rootVolume = value
-			object.fieldSet_[8] = true
+			object.fieldSet_[9] = true
 		case "subnet_outposts":
 			value := map[string]string{}
 			for {
@@ -278,7 +291,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 				value[key] = item
 			}
 			object.subnetOutposts = value
-			object.fieldSet_[9] = true
+			object.fieldSet_[10] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -290,7 +303,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 				value[key] = item
 			}
 			object.tags = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/arohcp/v1alpha1/market_type_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/market_type_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalMarketTypeList writes a list of values of the 'market_type' type to
+// the given writer.
+func MarshalMarketTypeList(list []MarketType, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteMarketTypeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteMarketTypeList writes a list of value of the 'market_type' type to
+// the given stream.
+func WriteMarketTypeList(list []MarketType, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalMarketTypeList reads a list of values of the 'market_type' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalMarketTypeList(source interface{}) (items []MarketType, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadMarketTypeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadMarketTypeList reads list of values of the ”market_type' type from
+// the given iterator.
+func ReadMarketTypeList(iterator *jsoniter.Iterator) []MarketType {
+	list := []MarketType{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := MarketType(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/market_type_type.go
+++ b/clientapi/arohcp/v1alpha1/market_type_type.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// MarketType represents the values of the 'market_type' enumerated type.
+type MarketType string
+
+const (
+	// Scheduled pre-purchased compute capacity.
+	MarketTypeCapacityBlocks MarketType = "capacity_blocks"
+	// EC2 instances run as standard On-Demand instances.
+	MarketTypeOnDemand MarketType = "on_demand"
+)

--- a/clientapi/clustersmgmt/v1/aws_capacity_reservation_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_capacity_reservation_builder.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AWS Capacity Reservation specification.
+type AWSCapacityReservationBuilder struct {
+	fieldSet_  []bool
+	id         string
+	href       string
+	id         string
+	marketType MarketType
+}
+
+// NewAWSCapacityReservation creates a new builder of 'AWS_capacity_reservation' objects.
+func NewAWSCapacityReservation() *AWSCapacityReservationBuilder {
+	return &AWSCapacityReservationBuilder{
+		fieldSet_: make([]bool, 5),
+	}
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *AWSCapacityReservationBuilder) Link(value bool) *AWSCapacityReservationBuilder {
+	b.fieldSet_[0] = true
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *AWSCapacityReservationBuilder) ID(value string) *AWSCapacityReservationBuilder {
+	b.id = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *AWSCapacityReservationBuilder) HREF(value string) *AWSCapacityReservationBuilder {
+	b.href = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AWSCapacityReservationBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(b.fieldSet_); i++ {
+		if b.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Id sets the value of the 'id' attribute to the given value.
+func (b *AWSCapacityReservationBuilder) Id(value string) *AWSCapacityReservationBuilder {
+	b.id = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// MarketType sets the value of the 'market_type' attribute to the given value.
+//
+// Market type for AWS Capacity Reservations.
+func (b *AWSCapacityReservationBuilder) MarketType(value MarketType) *AWSCapacityReservationBuilder {
+	b.marketType = value
+	b.fieldSet_[4] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AWSCapacityReservationBuilder) Copy(object *AWSCapacityReservation) *AWSCapacityReservationBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.id = object.id
+	b.href = object.href
+	b.id = object.id
+	b.marketType = object.marketType
+	return b
+}
+
+// Build creates a 'AWS_capacity_reservation' object using the configuration stored in the builder.
+func (b *AWSCapacityReservationBuilder) Build() (object *AWSCapacityReservation, err error) {
+	object = new(AWSCapacityReservation)
+	object.id = b.id
+	object.href = b.href
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.id = b.id
+	object.marketType = b.marketType
+	return
+}

--- a/clientapi/clustersmgmt/v1/aws_capacity_reservation_list_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_capacity_reservation_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AWSCapacityReservationListBuilder contains the data and logic needed to build
+// 'AWS_capacity_reservation' objects.
+type AWSCapacityReservationListBuilder struct {
+	items []*AWSCapacityReservationBuilder
+}
+
+// NewAWSCapacityReservationList creates a new builder of 'AWS_capacity_reservation' objects.
+func NewAWSCapacityReservationList() *AWSCapacityReservationListBuilder {
+	return new(AWSCapacityReservationListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AWSCapacityReservationListBuilder) Items(values ...*AWSCapacityReservationBuilder) *AWSCapacityReservationListBuilder {
+	b.items = make([]*AWSCapacityReservationBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AWSCapacityReservationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AWSCapacityReservationListBuilder) Copy(list *AWSCapacityReservationList) *AWSCapacityReservationListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AWSCapacityReservationBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAWSCapacityReservation().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'AWS_capacity_reservation' objects using the
+// configuration stored in the builder.
+func (b *AWSCapacityReservationListBuilder) Build() (list *AWSCapacityReservationList, err error) {
+	items := make([]*AWSCapacityReservation, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AWSCapacityReservationList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/aws_capacity_reservation_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_capacity_reservation_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAWSCapacityReservationList writes a list of values of the 'AWS_capacity_reservation' type to
+// the given writer.
+func MarshalAWSCapacityReservationList(list []*AWSCapacityReservation, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAWSCapacityReservationList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAWSCapacityReservationList writes a list of value of the 'AWS_capacity_reservation' type to
+// the given stream.
+func WriteAWSCapacityReservationList(list []*AWSCapacityReservation, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAWSCapacityReservation(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAWSCapacityReservationList reads a list of values of the 'AWS_capacity_reservation' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAWSCapacityReservationList(source interface{}) (items []*AWSCapacityReservation, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAWSCapacityReservationList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAWSCapacityReservationList reads list of values of the ”AWS_capacity_reservation' type from
+// the given iterator.
+func ReadAWSCapacityReservationList(iterator *jsoniter.Iterator) []*AWSCapacityReservation {
+	list := []*AWSCapacityReservation{}
+	for iterator.ReadArray() {
+		item := ReadAWSCapacityReservation(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/aws_capacity_reservation_type.go
+++ b/clientapi/clustersmgmt/v1/aws_capacity_reservation_type.go
@@ -1,0 +1,305 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AWSCapacityReservationKind is the name of the type used to represent objects
+// of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationKind = "AWSCapacityReservation"
+
+// AWSCapacityReservationLinkKind is the name of the type used to represent links
+// to objects of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationLinkKind = "AWSCapacityReservationLink"
+
+// AWSCapacityReservationNilKind is the name of the type used to nil references
+// to objects of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationNilKind = "AWSCapacityReservationNil"
+
+// AWSCapacityReservation represents the values of the 'AWS_capacity_reservation' type.
+//
+// AWS Capacity Reservation specification.
+type AWSCapacityReservation struct {
+	fieldSet_  []bool
+	id         string
+	href       string
+	id         string
+	marketType MarketType
+}
+
+// Kind returns the name of the type of the object.
+func (o *AWSCapacityReservation) Kind() string {
+	if o == nil {
+		return AWSCapacityReservationNilKind
+	}
+	if len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return AWSCapacityReservationLinkKind
+	}
+	return AWSCapacityReservationKind
+}
+
+// Link returns true if this is a link.
+func (o *AWSCapacityReservation) Link() bool {
+	return o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+}
+
+// ID returns the identifier of the object.
+func (o *AWSCapacityReservation) ID() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *AWSCapacityReservation) GetID() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *AWSCapacityReservation) HREF() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *AWSCapacityReservation) GetHREF() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AWSCapacityReservation) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(o.fieldSet_); i++ {
+		if o.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Id returns the value of the 'id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Specify the target Capacity Reservation in which the EC2 instances will be launched.
+func (o *AWSCapacityReservation) Id() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.id
+	}
+	return ""
+}
+
+// GetId returns the value of the 'id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Specify the target Capacity Reservation in which the EC2 instances will be launched.
+func (o *AWSCapacityReservation) GetId() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// MarketType returns the value of the 'market_type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// marketType specifies the market type of the CapacityReservation for the EC2
+// instances. Valid values are OnDemand, CapacityBlocks.
+// "OnDemand": EC2 instances run as standard On-Demand instances.
+// "CapacityBlocks": scheduled pre-purchased compute capacity.
+func (o *AWSCapacityReservation) MarketType() MarketType {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
+		return o.marketType
+	}
+	return MarketType("")
+}
+
+// GetMarketType returns the value of the 'market_type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// marketType specifies the market type of the CapacityReservation for the EC2
+// instances. Valid values are OnDemand, CapacityBlocks.
+// "OnDemand": EC2 instances run as standard On-Demand instances.
+// "CapacityBlocks": scheduled pre-purchased compute capacity.
+func (o *AWSCapacityReservation) GetMarketType() (value MarketType, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
+	if ok {
+		value = o.marketType
+	}
+	return
+}
+
+// AWSCapacityReservationListKind is the name of the type used to represent list of objects of
+// type 'AWS_capacity_reservation'.
+const AWSCapacityReservationListKind = "AWSCapacityReservationList"
+
+// AWSCapacityReservationListLinkKind is the name of the type used to represent links to list
+// of objects of type 'AWS_capacity_reservation'.
+const AWSCapacityReservationListLinkKind = "AWSCapacityReservationListLink"
+
+// AWSCapacityReservationNilKind is the name of the type used to nil lists of objects of
+// type 'AWS_capacity_reservation'.
+const AWSCapacityReservationListNilKind = "AWSCapacityReservationListNil"
+
+// AWSCapacityReservationList is a list of values of the 'AWS_capacity_reservation' type.
+type AWSCapacityReservationList struct {
+	href  string
+	link  bool
+	items []*AWSCapacityReservation
+}
+
+// Kind returns the name of the type of the object.
+func (l *AWSCapacityReservationList) Kind() string {
+	if l == nil {
+		return AWSCapacityReservationListNilKind
+	}
+	if l.link {
+		return AWSCapacityReservationListLinkKind
+	}
+	return AWSCapacityReservationListKind
+}
+
+// Link returns true iif this is a link.
+func (l *AWSCapacityReservationList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *AWSCapacityReservationList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *AWSCapacityReservationList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *AWSCapacityReservationList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AWSCapacityReservationList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AWSCapacityReservationList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AWSCapacityReservationList) SetItems(items []*AWSCapacityReservation) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AWSCapacityReservationList) Items() []*AWSCapacityReservation {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AWSCapacityReservationList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AWSCapacityReservationList) Get(i int) *AWSCapacityReservation {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AWSCapacityReservationList) Slice() []*AWSCapacityReservation {
+	var slice []*AWSCapacityReservation
+	if l == nil {
+		slice = make([]*AWSCapacityReservation, 0)
+	} else {
+		slice = make([]*AWSCapacityReservation, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AWSCapacityReservationList) Each(f func(item *AWSCapacityReservation) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AWSCapacityReservationList) Range(f func(index int, item *AWSCapacityReservation) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/aws_capacity_reservation_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_capacity_reservation_type_json.go
@@ -1,0 +1,136 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAWSCapacityReservation writes a value of the 'AWS_capacity_reservation' type to the given writer.
+func MarshalAWSCapacityReservation(object *AWSCapacityReservation, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAWSCapacityReservation(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAWSCapacityReservation writes a value of the 'AWS_capacity_reservation' type to the given stream.
+func WriteAWSCapacityReservation(object *AWSCapacityReservation, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	stream.WriteObjectField("kind")
+	if len(object.fieldSet_) > 0 && object.fieldSet_[0] {
+		stream.WriteString(AWSCapacityReservationLinkKind)
+	} else {
+		stream.WriteString(AWSCapacityReservationKind)
+	}
+	count++
+	if len(object.fieldSet_) > 1 && object.fieldSet_[1] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	if len(object.fieldSet_) > 2 && object.fieldSet_[2] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
+	var present_ bool
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("market_type")
+		stream.WriteString(string(object.marketType))
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAWSCapacityReservation reads a value of the 'AWS_capacity_reservation' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAWSCapacityReservation(source interface{}) (object *AWSCapacityReservation, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAWSCapacityReservation(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAWSCapacityReservation reads a value of the 'AWS_capacity_reservation' type from the given iterator.
+func ReadAWSCapacityReservation(iterator *jsoniter.Iterator) *AWSCapacityReservation {
+	object := &AWSCapacityReservation{
+		fieldSet_: make([]bool, 5),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "kind":
+			value := iterator.ReadString()
+			if value == AWSCapacityReservationLinkKind {
+				object.fieldSet_[0] = true
+			}
+		case "id":
+			object.id = iterator.ReadString()
+			object.fieldSet_[1] = true
+		case "href":
+			object.href = iterator.ReadString()
+			object.fieldSet_[2] = true
+		case "id":
+			value := iterator.ReadString()
+			object.id = value
+			object.fieldSet_[3] = true
+		case "market_type":
+			text := iterator.ReadString()
+			value := MarketType(text)
+			object.marketType = value
+			object.fieldSet_[4] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_builder.go
@@ -26,6 +26,7 @@ type AWSNodePoolBuilder struct {
 	href                       string
 	additionalSecurityGroupIds []string
 	availabilityZoneTypes      map[string]string
+	capacityReservation        *AWSCapacityReservationBuilder
 	ec2MetadataHttpTokens      Ec2MetadataHttpTokens
 	instanceProfile            string
 	instanceType               string
@@ -37,7 +38,7 @@ type AWSNodePoolBuilder struct {
 // NewAWSNodePool creates a new builder of 'AWS_node_pool' objects.
 func NewAWSNodePool() *AWSNodePoolBuilder {
 	return &AWSNodePoolBuilder{
-		fieldSet_: make([]bool, 11),
+		fieldSet_: make([]bool, 12),
 	}
 }
 
@@ -94,26 +95,39 @@ func (b *AWSNodePoolBuilder) AvailabilityZoneTypes(value map[string]string) *AWS
 	return b
 }
 
+// CapacityReservation sets the value of the 'capacity_reservation' attribute to the given value.
+//
+// AWS Capacity Reservation specification.
+func (b *AWSNodePoolBuilder) CapacityReservation(value *AWSCapacityReservationBuilder) *AWSNodePoolBuilder {
+	b.capacityReservation = value
+	if value != nil {
+		b.fieldSet_[5] = true
+	} else {
+		b.fieldSet_[5] = false
+	}
+	return b
+}
+
 // Ec2MetadataHttpTokens sets the value of the 'ec_2_metadata_http_tokens' attribute to the given value.
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSNodePoolBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSNodePoolBuilder {
 	b.ec2MetadataHttpTokens = value
-	b.fieldSet_[5] = true
+	b.fieldSet_[6] = true
 	return b
 }
 
 // InstanceProfile sets the value of the 'instance_profile' attribute to the given value.
 func (b *AWSNodePoolBuilder) InstanceProfile(value string) *AWSNodePoolBuilder {
 	b.instanceProfile = value
-	b.fieldSet_[6] = true
+	b.fieldSet_[7] = true
 	return b
 }
 
 // InstanceType sets the value of the 'instance_type' attribute to the given value.
 func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 	b.instanceType = value
-	b.fieldSet_[7] = true
+	b.fieldSet_[8] = true
 	return b
 }
 
@@ -123,9 +137,9 @@ func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBuilder {
 	b.rootVolume = value
 	if value != nil {
-		b.fieldSet_[8] = true
+		b.fieldSet_[9] = true
 	} else {
-		b.fieldSet_[8] = false
+		b.fieldSet_[9] = false
 	}
 	return b
 }
@@ -134,9 +148,9 @@ func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBui
 func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoolBuilder {
 	b.subnetOutposts = value
 	if value != nil {
-		b.fieldSet_[9] = true
+		b.fieldSet_[10] = true
 	} else {
-		b.fieldSet_[9] = false
+		b.fieldSet_[10] = false
 	}
 	return b
 }
@@ -145,9 +159,9 @@ func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoo
 func (b *AWSNodePoolBuilder) Tags(value map[string]string) *AWSNodePoolBuilder {
 	b.tags = value
 	if value != nil {
-		b.fieldSet_[10] = true
+		b.fieldSet_[11] = true
 	} else {
-		b.fieldSet_[10] = false
+		b.fieldSet_[11] = false
 	}
 	return b
 }
@@ -176,6 +190,11 @@ func (b *AWSNodePoolBuilder) Copy(object *AWSNodePool) *AWSNodePoolBuilder {
 		}
 	} else {
 		b.availabilityZoneTypes = nil
+	}
+	if object.capacityReservation != nil {
+		b.capacityReservation = NewAWSCapacityReservation().Copy(object.capacityReservation)
+	} else {
+		b.capacityReservation = nil
 	}
 	b.ec2MetadataHttpTokens = object.ec2MetadataHttpTokens
 	b.instanceProfile = object.instanceProfile
@@ -221,6 +240,12 @@ func (b *AWSNodePoolBuilder) Build() (object *AWSNodePool, err error) {
 		object.availabilityZoneTypes = make(map[string]string)
 		for k, v := range b.availabilityZoneTypes {
 			object.availabilityZoneTypes[k] = v
+		}
+	}
+	if b.capacityReservation != nil {
+		object.capacityReservation, err = b.capacityReservation.Build()
+		if err != nil {
+			return
 		}
 	}
 	object.ec2MetadataHttpTokens = b.ec2MetadataHttpTokens

--- a/clientapi/clustersmgmt/v1/aws_node_pool_type.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_type.go
@@ -40,6 +40,7 @@ type AWSNodePool struct {
 	href                       string
 	additionalSecurityGroupIds []string
 	availabilityZoneTypes      map[string]string
+	capacityReservation        *AWSCapacityReservation
 	ec2MetadataHttpTokens      Ec2MetadataHttpTokens
 	instanceProfile            string
 	instanceType               string
@@ -161,12 +162,35 @@ func (o *AWSNodePool) GetAvailabilityZoneTypes() (value map[string]string, ok bo
 	return
 }
 
+// CapacityReservation returns the value of the 'capacity_reservation' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// If present it defines the AWS Capacity Reservation used for this NodePool
+func (o *AWSNodePool) CapacityReservation() *AWSCapacityReservation {
+	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+		return o.capacityReservation
+	}
+	return nil
+}
+
+// GetCapacityReservation returns the value of the 'capacity_reservation' attribute and
+// a flag indicating if the attribute has a value.
+//
+// If present it defines the AWS Capacity Reservation used for this NodePool
+func (o *AWSNodePool) GetCapacityReservation() (value *AWSCapacityReservation, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	if ok {
+		value = o.capacityReservation
+	}
+	return
+}
+
 // Ec2MetadataHttpTokens returns the value of the 'ec_2_metadata_http_tokens' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWSNodePool) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
-	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
 		return o.ec2MetadataHttpTokens
 	}
 	return Ec2MetadataHttpTokens("")
@@ -177,7 +201,7 @@ func (o *AWSNodePool) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWSNodePool) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
 	if ok {
 		value = o.ec2MetadataHttpTokens
 	}
@@ -189,7 +213,7 @@ func (o *AWSNodePool) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, o
 //
 // InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
 func (o *AWSNodePool) InstanceProfile() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
 		return o.instanceProfile
 	}
 	return ""
@@ -200,7 +224,7 @@ func (o *AWSNodePool) InstanceProfile() string {
 //
 // InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
 func (o *AWSNodePool) GetInstanceProfile() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
 	if ok {
 		value = o.instanceProfile
 	}
@@ -212,7 +236,7 @@ func (o *AWSNodePool) GetInstanceProfile() (value string, ok bool) {
 //
 // InstanceType is an ec2 instance type for node instances (e.g. m5.large).
 func (o *AWSNodePool) InstanceType() string {
-	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
 		return o.instanceType
 	}
 	return ""
@@ -223,7 +247,7 @@ func (o *AWSNodePool) InstanceType() string {
 //
 // InstanceType is an ec2 instance type for node instances (e.g. m5.large).
 func (o *AWSNodePool) GetInstanceType() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
 	if ok {
 		value = o.instanceType
 	}
@@ -235,7 +259,7 @@ func (o *AWSNodePool) GetInstanceType() (value string, ok bool) {
 //
 // AWS Volume specification to be used to set custom worker disk size
 func (o *AWSNodePool) RootVolume() *AWSVolume {
-	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
+	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
 		return o.rootVolume
 	}
 	return nil
@@ -246,7 +270,7 @@ func (o *AWSNodePool) RootVolume() *AWSVolume {
 //
 // AWS Volume specification to be used to set custom worker disk size
 func (o *AWSNodePool) GetRootVolume() (value *AWSVolume, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
+	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
 	if ok {
 		value = o.rootVolume
 	}
@@ -258,7 +282,7 @@ func (o *AWSNodePool) GetRootVolume() (value *AWSVolume, ok bool) {
 //
 // Associates nodepool subnets with AWS Outposts.
 func (o *AWSNodePool) SubnetOutposts() map[string]string {
-	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
 		return o.subnetOutposts
 	}
 	return nil
@@ -269,7 +293,7 @@ func (o *AWSNodePool) SubnetOutposts() map[string]string {
 //
 // Associates nodepool subnets with AWS Outposts.
 func (o *AWSNodePool) GetSubnetOutposts() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
 	if ok {
 		value = o.subnetOutposts
 	}
@@ -288,7 +312,7 @@ func (o *AWSNodePool) GetSubnetOutposts() (value map[string]string, ok bool) {
 // - Tag values may be between 0 and 256 characters in length
 // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
 func (o *AWSNodePool) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.tags
 	}
 	return nil
@@ -306,7 +330,7 @@ func (o *AWSNodePool) Tags() map[string]string {
 // - Tag values may be between 0 and 256 characters in length
 // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
 func (o *AWSNodePool) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.tags
 	}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_type_json.go
@@ -104,7 +104,16 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5]
+	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.capacityReservation != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("capacity_reservation")
+		WriteAWSCapacityReservation(object.capacityReservation, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -113,7 +122,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.ec2MetadataHttpTokens))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
+	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -122,7 +131,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		stream.WriteString(object.instanceProfile)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
+	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -131,7 +140,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		stream.WriteString(object.instanceType)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8] && object.rootVolume != nil
+	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.rootVolume != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -140,7 +149,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		WriteAWSVolume(object.rootVolume, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.subnetOutposts != nil
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.subnetOutposts != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -169,7 +178,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.tags != nil
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -215,7 +224,7 @@ func UnmarshalAWSNodePool(source interface{}) (object *AWSNodePool, err error) {
 // ReadAWSNodePool reads a value of the 'AWS_node_pool' type from the given iterator.
 func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 	object := &AWSNodePool{
-		fieldSet_: make([]bool, 11),
+		fieldSet_: make([]bool, 12),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -250,23 +259,27 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 			}
 			object.availabilityZoneTypes = value
 			object.fieldSet_[4] = true
+		case "capacity_reservation":
+			value := ReadAWSCapacityReservation(iterator)
+			object.capacityReservation = value
+			object.fieldSet_[5] = true
 		case "ec2_metadata_http_tokens":
 			text := iterator.ReadString()
 			value := Ec2MetadataHttpTokens(text)
 			object.ec2MetadataHttpTokens = value
-			object.fieldSet_[5] = true
+			object.fieldSet_[6] = true
 		case "instance_profile":
 			value := iterator.ReadString()
 			object.instanceProfile = value
-			object.fieldSet_[6] = true
+			object.fieldSet_[7] = true
 		case "instance_type":
 			value := iterator.ReadString()
 			object.instanceType = value
-			object.fieldSet_[7] = true
+			object.fieldSet_[8] = true
 		case "root_volume":
 			value := ReadAWSVolume(iterator)
 			object.rootVolume = value
-			object.fieldSet_[8] = true
+			object.fieldSet_[9] = true
 		case "subnet_outposts":
 			value := map[string]string{}
 			for {
@@ -278,7 +291,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 				value[key] = item
 			}
 			object.subnetOutposts = value
-			object.fieldSet_[9] = true
+			object.fieldSet_[10] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -290,7 +303,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 				value[key] = item
 			}
 			object.tags = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/market_type_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/market_type_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalMarketTypeList writes a list of values of the 'market_type' type to
+// the given writer.
+func MarshalMarketTypeList(list []MarketType, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteMarketTypeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteMarketTypeList writes a list of value of the 'market_type' type to
+// the given stream.
+func WriteMarketTypeList(list []MarketType, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalMarketTypeList reads a list of values of the 'market_type' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalMarketTypeList(source interface{}) (items []MarketType, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadMarketTypeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadMarketTypeList reads list of values of the ”market_type' type from
+// the given iterator.
+func ReadMarketTypeList(iterator *jsoniter.Iterator) []MarketType {
+	list := []MarketType{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := MarketType(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/market_type_type.go
+++ b/clientapi/clustersmgmt/v1/market_type_type.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// MarketType represents the values of the 'market_type' enumerated type.
+type MarketType string
+
+const (
+	// Scheduled pre-purchased compute capacity.
+	MarketTypeCapacityBlocks MarketType = "capacity_blocks"
+	// EC2 instances run as standard On-Demand instances.
+	MarketTypeOnDemand MarketType = "on_demand"
+)

--- a/model/clusters_mgmt/v1/aws_capacity_reservation_type.model
+++ b/model/clusters_mgmt/v1/aws_capacity_reservation_type.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// AWS Capacity Reservation specification.
+class AWSCapacityReservation {
+    // Specify the target Capacity Reservation in which the EC2 instances will be launched.
+    Id String
+
+    // marketType specifies the market type of the CapacityReservation for the EC2
+    // instances. Valid values are OnDemand, CapacityBlocks.
+    // "OnDemand": EC2 instances run as standard On-Demand instances.
+    // "CapacityBlocks": scheduled pre-purchased compute capacity.
+    MarketType MarketType
+} 

--- a/model/clusters_mgmt/v1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_type.model
@@ -47,4 +47,8 @@ class AWSNodePool {
     
     // AWS Volume specification to be used to set custom worker disk size
     RootVolume AWSVolume
+
+    // If present it defines the AWS Capacity Reservation used for this NodePool
+    @json(name = "capacity_reservation")
+    CapacityReservation AWSCapacityReservation
 }

--- a/model/clusters_mgmt/v1/market_type.model
+++ b/model/clusters_mgmt/v1/market_type.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Market type for AWS Capacity Reservations.
+enum MarketType {
+    // EC2 instances run as standard On-Demand instances.
+    OnDemand
+
+    // Scheduled pre-purchased compute capacity.
+    CapacityBlocks
+} 

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -1405,6 +1405,31 @@
           }
         }
       },
+      "AWSCapacityReservation": {
+        "description": "AWS Capacity Reservation specification.",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'AWSCapacityReservation' if this is a complete object or 'AWSCapacityReservationLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Specify the target Capacity Reservation in which the EC2 instances will be launched.",
+            "type": "string"
+          },
+          "market_type": {
+            "description": "marketType specifies the market type of the CapacityReservation for the EC2\ninstances. Valid values are OnDemand, CapacityBlocks.\n\"OnDemand\": EC2 instances run as standard On-Demand instances.\n\"CapacityBlocks\": scheduled pre-purchased compute capacity.",
+            "$ref": "#/components/schemas/MarketType"
+          }
+        }
+      },
       "AWSNodePool": {
         "description": "Representation of aws node pool specific parameters.",
         "properties": {
@@ -1433,6 +1458,10 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "capacity_reservation": {
+            "description": "If present it defines the AWS Capacity Reservation used for this NodePool",
+            "$ref": "#/components/schemas/AWSCapacityReservation"
           },
           "ec2_metadata_http_tokens": {
             "description": "Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances",
@@ -3251,6 +3280,14 @@
             "type": "boolean"
           }
         }
+      },
+      "MarketType": {
+        "description": "Market type for AWS Capacity Reservations.",
+        "type": "string",
+        "enum": [
+          "capacity_blocks",
+          "on_demand"
+        ]
       },
       "Network": {
         "description": "Network configuration of a cluster.",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -13269,6 +13269,31 @@
           }
         }
       },
+      "AWSCapacityReservation": {
+        "description": "AWS Capacity Reservation specification.",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'AWSCapacityReservation' if this is a complete object or 'AWSCapacityReservationLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Specify the target Capacity Reservation in which the EC2 instances will be launched.",
+            "type": "string"
+          },
+          "market_type": {
+            "description": "marketType specifies the market type of the CapacityReservation for the EC2\ninstances. Valid values are OnDemand, CapacityBlocks.\n\"OnDemand\": EC2 instances run as standard On-Demand instances.\n\"CapacityBlocks\": scheduled pre-purchased compute capacity.",
+            "$ref": "#/components/schemas/MarketType"
+          }
+        }
+      },
       "AWSFlavour": {
         "description": "Specification for different classes of nodes inside a flavour.",
         "properties": {
@@ -13461,6 +13486,10 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "capacity_reservation": {
+            "description": "If present it defines the AWS Capacity Reservation used for this NodePool",
+            "$ref": "#/components/schemas/AWSCapacityReservation"
           },
           "ec2_metadata_http_tokens": {
             "description": "Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances",
@@ -17556,6 +17585,14 @@
             }
           }
         }
+      },
+      "MarketType": {
+        "description": "Market type for AWS Capacity Reservations.",
+        "type": "string",
+        "enum": [
+          "capacity_blocks",
+          "on_demand"
+        ]
       },
       "NamespaceOwnershipPolicy": {
         "description": "Type of Namespace Ownership Policy.",


### PR DESCRIPTION
Add a new field to the AWSNodePool type to allow for usage of AWS Capacity Reservations.