### PR TITLE
[DRAFT] OCM-16333: add SkipValidations filed into class ControlPlaneUpgradePolicy

### DIFF
--- a/clientapi/clustersmgmt/v1/control_plane_upgrade_policy_builder.go
+++ b/clientapi/clustersmgmt/v1/control_plane_upgrade_policy_builder.go
@@ -34,6 +34,7 @@ type ControlPlaneUpgradePolicyBuilder struct {
 	nextRun                    time.Time
 	schedule                   string
 	scheduleType               ScheduleType
+	skipValidations            []string
 	state                      *UpgradePolicyStateBuilder
 	upgradeType                UpgradeType
 	version                    string
@@ -43,14 +44,14 @@ type ControlPlaneUpgradePolicyBuilder struct {
 // NewControlPlaneUpgradePolicy creates a new builder of 'control_plane_upgrade_policy' objects.
 func NewControlPlaneUpgradePolicy() *ControlPlaneUpgradePolicyBuilder {
 	return &ControlPlaneUpgradePolicyBuilder{
-		fieldSet_: make([]bool, 13),
+		fieldSet_: make([]bool, 14),
 	}
 }
 
 // Link sets the flag that indicates if this is a link.
 func (b *ControlPlaneUpgradePolicyBuilder) Link(value bool) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.fieldSet_[0] = true
 	return b
@@ -59,7 +60,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) Link(value bool) *ControlPlaneUpgrade
 // ID sets the identifier of the object.
 func (b *ControlPlaneUpgradePolicyBuilder) ID(value string) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.id = value
 	b.fieldSet_[1] = true
@@ -69,7 +70,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) ID(value string) *ControlPlaneUpgrade
 // HREF sets the link to the object.
 func (b *ControlPlaneUpgradePolicyBuilder) HREF(value string) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.href = value
 	b.fieldSet_[2] = true
@@ -93,7 +94,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) Empty() bool {
 // ClusterID sets the value of the 'cluster_ID' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) ClusterID(value string) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.clusterID = value
 	b.fieldSet_[3] = true
@@ -103,7 +104,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) ClusterID(value string) *ControlPlane
 // CreationTimestamp sets the value of the 'creation_timestamp' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) CreationTimestamp(value time.Time) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.creationTimestamp = value
 	b.fieldSet_[4] = true
@@ -113,7 +114,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) CreationTimestamp(value time.Time) *C
 // EnableMinorVersionUpgrades sets the value of the 'enable_minor_version_upgrades' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) EnableMinorVersionUpgrades(value bool) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.enableMinorVersionUpgrades = value
 	b.fieldSet_[5] = true
@@ -123,7 +124,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) EnableMinorVersionUpgrades(value bool
 // LastUpdateTimestamp sets the value of the 'last_update_timestamp' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) LastUpdateTimestamp(value time.Time) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.lastUpdateTimestamp = value
 	b.fieldSet_[6] = true
@@ -133,7 +134,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) LastUpdateTimestamp(value time.Time) 
 // NextRun sets the value of the 'next_run' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) NextRun(value time.Time) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.nextRun = value
 	b.fieldSet_[7] = true
@@ -143,7 +144,7 @@ func (b *ControlPlaneUpgradePolicyBuilder) NextRun(value time.Time) *ControlPlan
 // Schedule sets the value of the 'schedule' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) Schedule(value string) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.schedule = value
 	b.fieldSet_[8] = true
@@ -155,10 +156,21 @@ func (b *ControlPlaneUpgradePolicyBuilder) Schedule(value string) *ControlPlaneU
 // ScheduleType defines which type of scheduling should be used for the upgrade policy.
 func (b *ControlPlaneUpgradePolicyBuilder) ScheduleType(value ScheduleType) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.scheduleType = value
 	b.fieldSet_[9] = true
+	return b
+}
+
+// SkipValidations sets the value of the 'skip_validations' attribute to the given values.
+func (b *ControlPlaneUpgradePolicyBuilder) SkipValidations(values ...string) *ControlPlaneUpgradePolicyBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 14)
+	}
+	b.skipValidations = make([]string, len(values))
+	copy(b.skipValidations, values)
+	b.fieldSet_[10] = true
 	return b
 }
 
@@ -167,13 +179,13 @@ func (b *ControlPlaneUpgradePolicyBuilder) ScheduleType(value ScheduleType) *Con
 // Representation of an upgrade policy state that that is set for a cluster.
 func (b *ControlPlaneUpgradePolicyBuilder) State(value *UpgradePolicyStateBuilder) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.state = value
 	if value != nil {
-		b.fieldSet_[10] = true
+		b.fieldSet_[11] = true
 	} else {
-		b.fieldSet_[10] = false
+		b.fieldSet_[11] = false
 	}
 	return b
 }
@@ -183,20 +195,20 @@ func (b *ControlPlaneUpgradePolicyBuilder) State(value *UpgradePolicyStateBuilde
 // UpgradeType defines which type of upgrade should be used.
 func (b *ControlPlaneUpgradePolicyBuilder) UpgradeType(value UpgradeType) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.upgradeType = value
-	b.fieldSet_[11] = true
+	b.fieldSet_[12] = true
 	return b
 }
 
 // Version sets the value of the 'version' attribute to the given value.
 func (b *ControlPlaneUpgradePolicyBuilder) Version(value string) *ControlPlaneUpgradePolicyBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 13)
+		b.fieldSet_ = make([]bool, 14)
 	}
 	b.version = value
-	b.fieldSet_[12] = true
+	b.fieldSet_[13] = true
 	return b
 }
 
@@ -218,6 +230,12 @@ func (b *ControlPlaneUpgradePolicyBuilder) Copy(object *ControlPlaneUpgradePolic
 	b.nextRun = object.nextRun
 	b.schedule = object.schedule
 	b.scheduleType = object.scheduleType
+	if object.skipValidations != nil {
+		b.skipValidations = make([]string, len(object.skipValidations))
+		copy(b.skipValidations, object.skipValidations)
+	} else {
+		b.skipValidations = nil
+	}
 	if object.state != nil {
 		b.state = NewUpgradePolicyState().Copy(object.state)
 	} else {
@@ -244,6 +262,10 @@ func (b *ControlPlaneUpgradePolicyBuilder) Build() (object *ControlPlaneUpgradeP
 	object.nextRun = b.nextRun
 	object.schedule = b.schedule
 	object.scheduleType = b.scheduleType
+	if b.skipValidations != nil {
+		object.skipValidations = make([]string, len(b.skipValidations))
+		copy(object.skipValidations, b.skipValidations)
+	}
 	if b.state != nil {
 		object.state, err = b.state.Build()
 		if err != nil {

--- a/clientapi/clustersmgmt/v1/control_plane_upgrade_policy_type.go
+++ b/clientapi/clustersmgmt/v1/control_plane_upgrade_policy_type.go
@@ -48,6 +48,7 @@ type ControlPlaneUpgradePolicy struct {
 	nextRun                    time.Time
 	schedule                   string
 	scheduleType               ScheduleType
+	skipValidations            []string
 	state                      *UpgradePolicyState
 	upgradeType                UpgradeType
 	version                    string
@@ -282,12 +283,35 @@ func (o *ControlPlaneUpgradePolicy) GetScheduleType() (value ScheduleType, ok bo
 	return
 }
 
+// SkipValidations returns the value of the 'skip_validations' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Validations skipped before upgrade
+func (o *ControlPlaneUpgradePolicy) SkipValidations() []string {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+		return o.skipValidations
+	}
+	return nil
+}
+
+// GetSkipValidations returns the value of the 'skip_validations' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Validations skipped before upgrade
+func (o *ControlPlaneUpgradePolicy) GetSkipValidations() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	if ok {
+		value = o.skipValidations
+	}
+	return
+}
+
 // State returns the value of the 'state' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // State of the upgrade policy for the hosted control plane.
 func (o *ControlPlaneUpgradePolicy) State() *UpgradePolicyState {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.state
 	}
 	return nil
@@ -298,7 +322,7 @@ func (o *ControlPlaneUpgradePolicy) State() *UpgradePolicyState {
 //
 // State of the upgrade policy for the hosted control plane.
 func (o *ControlPlaneUpgradePolicy) GetState() (value *UpgradePolicyState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.state
 	}
@@ -310,7 +334,7 @@ func (o *ControlPlaneUpgradePolicy) GetState() (value *UpgradePolicyState, ok bo
 //
 // Upgrade type of the control plane.
 func (o *ControlPlaneUpgradePolicy) UpgradeType() UpgradeType {
-	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
+	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
 		return o.upgradeType
 	}
 	return UpgradeType("")
@@ -321,7 +345,7 @@ func (o *ControlPlaneUpgradePolicy) UpgradeType() UpgradeType {
 //
 // Upgrade type of the control plane.
 func (o *ControlPlaneUpgradePolicy) GetUpgradeType() (value UpgradeType, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
+	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
 	if ok {
 		value = o.upgradeType
 	}
@@ -333,7 +357,7 @@ func (o *ControlPlaneUpgradePolicy) GetUpgradeType() (value UpgradeType, ok bool
 //
 // Version is the desired upgrade version.
 func (o *ControlPlaneUpgradePolicy) Version() string {
-	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
+	if o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13] {
 		return o.version
 	}
 	return ""
@@ -344,7 +368,7 @@ func (o *ControlPlaneUpgradePolicy) Version() string {
 //
 // Version is the desired upgrade version.
 func (o *ControlPlaneUpgradePolicy) GetVersion() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
+	ok = o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13]
 	if ok {
 		value = o.version
 	}

--- a/clientapi/clustersmgmt/v1/control_plane_upgrade_policy_type_json.go
+++ b/clientapi/clustersmgmt/v1/control_plane_upgrade_policy_type_json.go
@@ -129,7 +129,16 @@ func WriteControlPlaneUpgradePolicy(object *ControlPlaneUpgradePolicy, stream *j
 		stream.WriteString(string(object.scheduleType))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.state != nil
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.skipValidations != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("skip_validations")
+		WriteStringList(object.skipValidations, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.state != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -138,7 +147,7 @@ func WriteControlPlaneUpgradePolicy(object *ControlPlaneUpgradePolicy, stream *j
 		WriteUpgradePolicyState(object.state, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11]
+	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -147,7 +156,7 @@ func WriteControlPlaneUpgradePolicy(object *ControlPlaneUpgradePolicy, stream *j
 		stream.WriteString(string(object.upgradeType))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12]
+	present_ = len(object.fieldSet_) > 13 && object.fieldSet_[13]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -173,7 +182,7 @@ func UnmarshalControlPlaneUpgradePolicy(source interface{}) (object *ControlPlan
 // ReadControlPlaneUpgradePolicy reads a value of the 'control_plane_upgrade_policy' type from the given iterator.
 func ReadControlPlaneUpgradePolicy(iterator *jsoniter.Iterator) *ControlPlaneUpgradePolicy {
 	object := &ControlPlaneUpgradePolicy{
-		fieldSet_: make([]bool, 13),
+		fieldSet_: make([]bool, 14),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -233,19 +242,23 @@ func ReadControlPlaneUpgradePolicy(iterator *jsoniter.Iterator) *ControlPlaneUpg
 			value := ScheduleType(text)
 			object.scheduleType = value
 			object.fieldSet_[9] = true
+		case "skip_validations":
+			value := ReadStringList(iterator)
+			object.skipValidations = value
+			object.fieldSet_[10] = true
 		case "state":
 			value := ReadUpgradePolicyState(iterator)
 			object.state = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		case "upgrade_type":
 			text := iterator.ReadString()
 			value := UpgradeType(text)
 			object.upgradeType = value
-			object.fieldSet_[11] = true
+			object.fieldSet_[12] = true
 		case "version":
 			value := iterator.ReadString()
 			object.version = value
-			object.fieldSet_[12] = true
+			object.fieldSet_[13] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/control_plane_upgrade_policy_type.model
+++ b/model/clusters_mgmt/v1/control_plane_upgrade_policy_type.model
@@ -45,4 +45,7 @@ class ControlPlaneUpgradePolicy {
 
 	// State of the upgrade policy for the hosted control plane.
 	State UpgradePolicyState
+
+	// Validations skipped before upgrade
+	SkipValidations []String
 }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16480,6 +16480,13 @@
             "description": "Schedule type of the control plane upgrade.",
             "$ref": "#/components/schemas/ScheduleType"
           },
+          "skip_validations": {
+            "description": "Validations skipped before upgrade",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "state": {
             "description": "State of the upgrade policy for the hosted control plane.",
             "$ref": "#/components/schemas/UpgradePolicyState"


### PR DESCRIPTION
related DDR requests this api change: https://docs.google.com/document/d/1DWNR9bvDb41Cdt2TX6E8TNmz-KSy9nRariujKSBHznU/edit?tab=t.0

for the epic https://issues.redhat.com/browse/OCM-16325 to provide API support HCP force upgrade, we propose to add `skipValidations` field into `ControlPlanUpgradePolicy` so that users can specify the validations which should be skipped before upgrade

@robpblake @etabak PTAL, thanks
