### PR TITLE
OCM-15222 | feat: Added API for AutoNode Support

### DIFF
--- a/clientapi/arohcp/v1alpha1/aws_auto_node_builder.go
+++ b/clientapi/arohcp/v1alpha1/aws_auto_node_builder.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+type AwsAutoNodeBuilder struct {
+	fieldSet_ []bool
+	roleArn   string
+}
+
+// NewAwsAutoNode creates a new builder of 'aws_auto_node' objects.
+func NewAwsAutoNode() *AwsAutoNodeBuilder {
+	return &AwsAutoNodeBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AwsAutoNodeBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// RoleArn sets the value of the 'role_arn' attribute to the given value.
+func (b *AwsAutoNodeBuilder) RoleArn(value string) *AwsAutoNodeBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.roleArn = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AwsAutoNodeBuilder) Copy(object *AwsAutoNode) *AwsAutoNodeBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.roleArn = object.roleArn
+	return b
+}
+
+// Build creates a 'aws_auto_node' object using the configuration stored in the builder.
+func (b *AwsAutoNodeBuilder) Build() (object *AwsAutoNode, err error) {
+	object = new(AwsAutoNode)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.roleArn = b.roleArn
+	return
+}

--- a/clientapi/arohcp/v1alpha1/aws_auto_node_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/aws_auto_node_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AwsAutoNodeListBuilder contains the data and logic needed to build
+// 'aws_auto_node' objects.
+type AwsAutoNodeListBuilder struct {
+	items []*AwsAutoNodeBuilder
+}
+
+// NewAwsAutoNodeList creates a new builder of 'aws_auto_node' objects.
+func NewAwsAutoNodeList() *AwsAutoNodeListBuilder {
+	return new(AwsAutoNodeListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AwsAutoNodeListBuilder) Items(values ...*AwsAutoNodeBuilder) *AwsAutoNodeListBuilder {
+	b.items = make([]*AwsAutoNodeBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AwsAutoNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AwsAutoNodeListBuilder) Copy(list *AwsAutoNodeList) *AwsAutoNodeListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AwsAutoNodeBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAwsAutoNode().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'aws_auto_node' objects using the
+// configuration stored in the builder.
+func (b *AwsAutoNodeListBuilder) Build() (list *AwsAutoNodeList, err error) {
+	items := make([]*AwsAutoNode, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AwsAutoNodeList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/aws_auto_node_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/aws_auto_node_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAwsAutoNodeList writes a list of values of the 'aws_auto_node' type to
+// the given writer.
+func MarshalAwsAutoNodeList(list []*AwsAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAwsAutoNodeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAwsAutoNodeList writes a list of value of the 'aws_auto_node' type to
+// the given stream.
+func WriteAwsAutoNodeList(list []*AwsAutoNode, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAwsAutoNode(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAwsAutoNodeList reads a list of values of the 'aws_auto_node' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAwsAutoNodeList(source interface{}) (items []*AwsAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAwsAutoNodeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAwsAutoNodeList reads list of values of the ”aws_auto_node' type from
+// the given iterator.
+func ReadAwsAutoNodeList(iterator *jsoniter.Iterator) []*AwsAutoNode {
+	list := []*AwsAutoNode{}
+	for iterator.ReadArray() {
+		item := ReadAwsAutoNode(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/aws_auto_node_type.go
+++ b/clientapi/arohcp/v1alpha1/aws_auto_node_type.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AwsAutoNode represents the values of the 'aws_auto_node' type.
+//
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+type AwsAutoNode struct {
+	fieldSet_ []bool
+	roleArn   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AwsAutoNode) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// RoleArn returns the value of the 'role_arn' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+// controller.
+// The role must exist prior to enabling AutoNode on the cluster.
+func (o *AwsAutoNode) RoleArn() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.roleArn
+	}
+	return ""
+}
+
+// GetRoleArn returns the value of the 'role_arn' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+// controller.
+// The role must exist prior to enabling AutoNode on the cluster.
+func (o *AwsAutoNode) GetRoleArn() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.roleArn
+	}
+	return
+}
+
+// AwsAutoNodeListKind is the name of the type used to represent list of objects of
+// type 'aws_auto_node'.
+const AwsAutoNodeListKind = "AwsAutoNodeList"
+
+// AwsAutoNodeListLinkKind is the name of the type used to represent links to list
+// of objects of type 'aws_auto_node'.
+const AwsAutoNodeListLinkKind = "AwsAutoNodeListLink"
+
+// AwsAutoNodeNilKind is the name of the type used to nil lists of objects of
+// type 'aws_auto_node'.
+const AwsAutoNodeListNilKind = "AwsAutoNodeListNil"
+
+// AwsAutoNodeList is a list of values of the 'aws_auto_node' type.
+type AwsAutoNodeList struct {
+	href  string
+	link  bool
+	items []*AwsAutoNode
+}
+
+// Len returns the length of the list.
+func (l *AwsAutoNodeList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AwsAutoNodeList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AwsAutoNodeList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AwsAutoNodeList) SetItems(items []*AwsAutoNode) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AwsAutoNodeList) Items() []*AwsAutoNode {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AwsAutoNodeList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AwsAutoNodeList) Get(i int) *AwsAutoNode {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AwsAutoNodeList) Slice() []*AwsAutoNode {
+	var slice []*AwsAutoNode
+	if l == nil {
+		slice = make([]*AwsAutoNode, 0)
+	} else {
+		slice = make([]*AwsAutoNode, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AwsAutoNodeList) Each(f func(item *AwsAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AwsAutoNodeList) Range(f func(index int, item *AwsAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/aws_auto_node_type_json.go
+++ b/clientapi/arohcp/v1alpha1/aws_auto_node_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAwsAutoNode writes a value of the 'aws_auto_node' type to the given writer.
+func MarshalAwsAutoNode(object *AwsAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAwsAutoNode(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAwsAutoNode writes a value of the 'aws_auto_node' type to the given stream.
+func WriteAwsAutoNode(object *AwsAutoNode, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("role_arn")
+		stream.WriteString(object.roleArn)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAwsAutoNode reads a value of the 'aws_auto_node' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAwsAutoNode(source interface{}) (object *AwsAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAwsAutoNode(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAwsAutoNode reads a value of the 'aws_auto_node' type from the given iterator.
+func ReadAwsAutoNode(iterator *jsoniter.Iterator) *AwsAutoNode {
+	object := &AwsAutoNode{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "role_arn":
+			value := iterator.ReadString()
+			object.roleArn = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/aws_builder.go
+++ b/clientapi/arohcp/v1alpha1/aws_builder.go
@@ -31,6 +31,7 @@ type AWSBuilder struct {
 	additionalControlPlaneSecurityGroupIds []string
 	additionalInfraSecurityGroupIds        []string
 	auditLog                               *AuditLogBuilder
+	autoNode                               *AwsAutoNodeBuilder
 	billingAccountID                       string
 	ec2MetadataHttpTokens                  Ec2MetadataHttpTokens
 	etcdEncryption                         *AwsEtcdEncryptionBuilder
@@ -48,7 +49,7 @@ type AWSBuilder struct {
 // NewAWS creates a new builder of 'AWS' objects.
 func NewAWS() *AWSBuilder {
 	return &AWSBuilder{
-		fieldSet_: make([]bool, 21),
+		fieldSet_: make([]bool, 22),
 	}
 }
 
@@ -68,7 +69,7 @@ func (b *AWSBuilder) Empty() bool {
 // KMSKeyArn sets the value of the 'KMS_key_arn' attribute to the given value.
 func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.kmsKeyArn = value
 	b.fieldSet_[0] = true
@@ -80,7 +81,7 @@ func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.sts = value
 	if value != nil {
@@ -94,7 +95,7 @@ func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 // AccessKeyID sets the value of the 'access_key_ID' attribute to the given value.
 func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.accessKeyID = value
 	b.fieldSet_[2] = true
@@ -104,7 +105,7 @@ func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 // AccountID sets the value of the 'account_ID' attribute to the given value.
 func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.accountID = value
 	b.fieldSet_[3] = true
@@ -114,7 +115,7 @@ func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 // AdditionalAllowedPrincipals sets the value of the 'additional_allowed_principals' attribute to the given values.
 func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalAllowedPrincipals = make([]string, len(values))
 	copy(b.additionalAllowedPrincipals, values)
@@ -125,7 +126,7 @@ func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 // AdditionalComputeSecurityGroupIds sets the value of the 'additional_compute_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalComputeSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalComputeSecurityGroupIds, values)
@@ -136,7 +137,7 @@ func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBui
 // AdditionalControlPlaneSecurityGroupIds sets the value of the 'additional_control_plane_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalControlPlaneSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalControlPlaneSecurityGroupIds, values)
@@ -147,7 +148,7 @@ func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *A
 // AdditionalInfraSecurityGroupIds sets the value of the 'additional_infra_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalInfraSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalInfraSecurityGroupIds, values)
@@ -160,7 +161,7 @@ func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuild
 // Contains the necessary attributes to support audit log forwarding
 func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.auditLog = value
 	if value != nil {
@@ -171,13 +172,29 @@ func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 	return b
 }
 
+// AutoNode sets the value of the 'auto_node' attribute to the given value.
+//
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+func (b *AWSBuilder) AutoNode(value *AwsAutoNodeBuilder) *AWSBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 22)
+	}
+	b.autoNode = value
+	if value != nil {
+		b.fieldSet_[9] = true
+	} else {
+		b.fieldSet_[9] = false
+	}
+	return b
+}
+
 // BillingAccountID sets the value of the 'billing_account_ID' attribute to the given value.
 func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.billingAccountID = value
-	b.fieldSet_[9] = true
+	b.fieldSet_[10] = true
 	return b
 }
 
@@ -186,10 +203,10 @@ func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.ec2MetadataHttpTokens = value
-	b.fieldSet_[10] = true
+	b.fieldSet_[11] = true
 	return b
 }
 
@@ -198,13 +215,13 @@ func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuil
 // Contains the necessary attributes to support etcd encryption for AWS based clusters.
 func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.etcdEncryption = value
 	if value != nil {
-		b.fieldSet_[11] = true
+		b.fieldSet_[12] = true
 	} else {
-		b.fieldSet_[11] = false
+		b.fieldSet_[12] = false
 	}
 	return b
 }
@@ -212,40 +229,40 @@ func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder
 // HcpInternalCommunicationHostedZoneId sets the value of the 'hcp_internal_communication_hosted_zone_id' attribute to the given value.
 func (b *AWSBuilder) HcpInternalCommunicationHostedZoneId(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.hcpInternalCommunicationHostedZoneId = value
-	b.fieldSet_[12] = true
+	b.fieldSet_[13] = true
 	return b
 }
 
 // PrivateHostedZoneID sets the value of the 'private_hosted_zone_ID' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateHostedZoneID = value
-	b.fieldSet_[13] = true
+	b.fieldSet_[14] = true
 	return b
 }
 
 // PrivateHostedZoneRoleARN sets the value of the 'private_hosted_zone_role_ARN' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneRoleARN(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateHostedZoneRoleARN = value
-	b.fieldSet_[14] = true
+	b.fieldSet_[15] = true
 	return b
 }
 
 // PrivateLink sets the value of the 'private_link' attribute to the given value.
 func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateLink = value
-	b.fieldSet_[15] = true
+	b.fieldSet_[16] = true
 	return b
 }
 
@@ -254,13 +271,13 @@ func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 // Manages the configuration for the Private Links.
 func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigurationBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateLinkConfiguration = value
 	if value != nil {
-		b.fieldSet_[16] = true
+		b.fieldSet_[17] = true
 	} else {
-		b.fieldSet_[16] = false
+		b.fieldSet_[17] = false
 	}
 	return b
 }
@@ -268,34 +285,34 @@ func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigura
 // SecretAccessKey sets the value of the 'secret_access_key' attribute to the given value.
 func (b *AWSBuilder) SecretAccessKey(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.secretAccessKey = value
-	b.fieldSet_[17] = true
+	b.fieldSet_[18] = true
 	return b
 }
 
 // SubnetIDs sets the value of the 'subnet_IDs' attribute to the given values.
 func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.subnetIDs = make([]string, len(values))
 	copy(b.subnetIDs, values)
-	b.fieldSet_[18] = true
+	b.fieldSet_[19] = true
 	return b
 }
 
 // Tags sets the value of the 'tags' attribute to the given value.
 func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.tags = value
 	if value != nil {
-		b.fieldSet_[19] = true
+		b.fieldSet_[20] = true
 	} else {
-		b.fieldSet_[19] = false
+		b.fieldSet_[20] = false
 	}
 	return b
 }
@@ -303,10 +320,10 @@ func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 // VpcEndpointRoleArn sets the value of the 'vpc_endpoint_role_arn' attribute to the given value.
 func (b *AWSBuilder) VpcEndpointRoleArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.vpcEndpointRoleArn = value
-	b.fieldSet_[20] = true
+	b.fieldSet_[21] = true
 	return b
 }
 
@@ -355,6 +372,11 @@ func (b *AWSBuilder) Copy(object *AWS) *AWSBuilder {
 		b.auditLog = NewAuditLog().Copy(object.auditLog)
 	} else {
 		b.auditLog = nil
+	}
+	if object.autoNode != nil {
+		b.autoNode = NewAwsAutoNode().Copy(object.autoNode)
+	} else {
+		b.autoNode = nil
 	}
 	b.billingAccountID = object.billingAccountID
 	b.ec2MetadataHttpTokens = object.ec2MetadataHttpTokens
@@ -425,6 +447,12 @@ func (b *AWSBuilder) Build() (object *AWS, err error) {
 	}
 	if b.auditLog != nil {
 		object.auditLog, err = b.auditLog.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.autoNode != nil {
+		object.autoNode, err = b.autoNode.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/arohcp/v1alpha1/aws_type.go
+++ b/clientapi/arohcp/v1alpha1/aws_type.go
@@ -33,6 +33,7 @@ type AWS struct {
 	additionalControlPlaneSecurityGroupIds []string
 	additionalInfraSecurityGroupIds        []string
 	auditLog                               *AuditLog
+	autoNode                               *AwsAutoNode
 	billingAccountID                       string
 	ec2MetadataHttpTokens                  Ec2MetadataHttpTokens
 	etcdEncryption                         *AwsEtcdEncryption
@@ -267,12 +268,35 @@ func (o *AWS) GetAuditLog() (value *AuditLog, ok bool) {
 	return
 }
 
+// AutoNode returns the value of the 'auto_node' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// AWS specific configuration for AutoNode
+func (o *AWS) AutoNode() *AwsAutoNode {
+	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+		return o.autoNode
+	}
+	return nil
+}
+
+// GetAutoNode returns the value of the 'auto_node' attribute and
+// a flag indicating if the attribute has a value.
+//
+// AWS specific configuration for AutoNode
+func (o *AWS) GetAutoNode() (value *AwsAutoNode, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	if ok {
+		value = o.autoNode
+	}
+	return
+}
+
 // BillingAccountID returns the value of the 'billing_account_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // BillingAccountID is the account used for billing subscriptions purchased via the marketplace
 func (o *AWS) BillingAccountID() string {
-	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
 		return o.billingAccountID
 	}
 	return ""
@@ -283,7 +307,7 @@ func (o *AWS) BillingAccountID() string {
 //
 // BillingAccountID is the account used for billing subscriptions purchased via the marketplace
 func (o *AWS) GetBillingAccountID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
 	if ok {
 		value = o.billingAccountID
 	}
@@ -295,7 +319,7 @@ func (o *AWS) GetBillingAccountID() (value string, ok bool) {
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWS) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.ec2MetadataHttpTokens
 	}
 	return Ec2MetadataHttpTokens("")
@@ -306,7 +330,7 @@ func (o *AWS) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWS) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.ec2MetadataHttpTokens
 	}
@@ -318,7 +342,7 @@ func (o *AWS) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, ok bool) 
 //
 // Related etcd encryption configuration
 func (o *AWS) EtcdEncryption() *AwsEtcdEncryption {
-	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
+	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
 		return o.etcdEncryption
 	}
 	return nil
@@ -329,7 +353,7 @@ func (o *AWS) EtcdEncryption() *AwsEtcdEncryption {
 //
 // Related etcd encryption configuration
 func (o *AWS) GetEtcdEncryption() (value *AwsEtcdEncryption, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
+	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
 	if ok {
 		value = o.etcdEncryption
 	}
@@ -341,7 +365,7 @@ func (o *AWS) GetEtcdEncryption() (value *AwsEtcdEncryption, ok bool) {
 //
 // ID of local private hosted zone for hypershift internal communication.
 func (o *AWS) HcpInternalCommunicationHostedZoneId() string {
-	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
+	if o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13] {
 		return o.hcpInternalCommunicationHostedZoneId
 	}
 	return ""
@@ -352,7 +376,7 @@ func (o *AWS) HcpInternalCommunicationHostedZoneId() string {
 //
 // ID of local private hosted zone for hypershift internal communication.
 func (o *AWS) GetHcpInternalCommunicationHostedZoneId() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
+	ok = o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13]
 	if ok {
 		value = o.hcpInternalCommunicationHostedZoneId
 	}
@@ -364,7 +388,7 @@ func (o *AWS) GetHcpInternalCommunicationHostedZoneId() (value string, ok bool) 
 //
 // ID of private hosted zone.
 func (o *AWS) PrivateHostedZoneID() string {
-	if o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13] {
+	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
 		return o.privateHostedZoneID
 	}
 	return ""
@@ -375,7 +399,7 @@ func (o *AWS) PrivateHostedZoneID() string {
 //
 // ID of private hosted zone.
 func (o *AWS) GetPrivateHostedZoneID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13]
+	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
 	if ok {
 		value = o.privateHostedZoneID
 	}
@@ -387,7 +411,7 @@ func (o *AWS) GetPrivateHostedZoneID() (value string, ok bool) {
 //
 // Role ARN for private hosted zone.
 func (o *AWS) PrivateHostedZoneRoleARN() string {
-	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
+	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
 		return o.privateHostedZoneRoleARN
 	}
 	return ""
@@ -398,7 +422,7 @@ func (o *AWS) PrivateHostedZoneRoleARN() string {
 //
 // Role ARN for private hosted zone.
 func (o *AWS) GetPrivateHostedZoneRoleARN() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
+	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
 	if ok {
 		value = o.privateHostedZoneRoleARN
 	}
@@ -410,7 +434,7 @@ func (o *AWS) GetPrivateHostedZoneRoleARN() (value string, ok bool) {
 //
 // Sets cluster to be inaccessible externally.
 func (o *AWS) PrivateLink() bool {
-	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
+	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
 		return o.privateLink
 	}
 	return false
@@ -421,7 +445,7 @@ func (o *AWS) PrivateLink() bool {
 //
 // Sets cluster to be inaccessible externally.
 func (o *AWS) GetPrivateLink() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
+	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
 	if ok {
 		value = o.privateLink
 	}
@@ -433,7 +457,7 @@ func (o *AWS) GetPrivateLink() (value bool, ok bool) {
 //
 // Manages additional configuration for Private Links.
 func (o *AWS) PrivateLinkConfiguration() *PrivateLinkClusterConfiguration {
-	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
+	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
 		return o.privateLinkConfiguration
 	}
 	return nil
@@ -444,7 +468,7 @@ func (o *AWS) PrivateLinkConfiguration() *PrivateLinkClusterConfiguration {
 //
 // Manages additional configuration for Private Links.
 func (o *AWS) GetPrivateLinkConfiguration() (value *PrivateLinkClusterConfiguration, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
+	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
 	if ok {
 		value = o.privateLinkConfiguration
 	}
@@ -456,7 +480,7 @@ func (o *AWS) GetPrivateLinkConfiguration() (value *PrivateLinkClusterConfigurat
 //
 // AWS secret access key.
 func (o *AWS) SecretAccessKey() string {
-	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
+	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
 		return o.secretAccessKey
 	}
 	return ""
@@ -467,7 +491,7 @@ func (o *AWS) SecretAccessKey() string {
 //
 // AWS secret access key.
 func (o *AWS) GetSecretAccessKey() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
+	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
 	if ok {
 		value = o.secretAccessKey
 	}
@@ -479,7 +503,7 @@ func (o *AWS) GetSecretAccessKey() (value string, ok bool) {
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) SubnetIDs() []string {
-	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
+	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
 		return o.subnetIDs
 	}
 	return nil
@@ -490,7 +514,7 @@ func (o *AWS) SubnetIDs() []string {
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
+	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
 	if ok {
 		value = o.subnetIDs
 	}
@@ -502,7 +526,7 @@ func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
+	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
 		return o.tags
 	}
 	return nil
@@ -513,7 +537,7 @@ func (o *AWS) Tags() map[string]string {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
+	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
 	if ok {
 		value = o.tags
 	}
@@ -525,7 +549,7 @@ func (o *AWS) GetTags() (value map[string]string, ok bool) {
 //
 // Role ARN for VPC Endpoint Service cross account role.
 func (o *AWS) VpcEndpointRoleArn() string {
-	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
+	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
 		return o.vpcEndpointRoleArn
 	}
 	return ""
@@ -536,7 +560,7 @@ func (o *AWS) VpcEndpointRoleArn() string {
 //
 // Role ARN for VPC Endpoint Service cross account role.
 func (o *AWS) GetVpcEndpointRoleArn() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
+	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
 	if ok {
 		value = o.vpcEndpointRoleArn
 	}

--- a/clientapi/arohcp/v1alpha1/aws_type_json.go
+++ b/clientapi/arohcp/v1alpha1/aws_type_json.go
@@ -124,7 +124,16 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteAuditLog(object.auditLog, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9]
+	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.autoNode != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("auto_node")
+		WriteAwsAutoNode(object.autoNode, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -133,7 +142,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.billingAccountID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10]
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -142,7 +151,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.ec2MetadataHttpTokens))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.etcdEncryption != nil
+	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12] && object.etcdEncryption != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -151,7 +160,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteAwsEtcdEncryption(object.etcdEncryption, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12]
+	present_ = len(object.fieldSet_) > 13 && object.fieldSet_[13]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -160,7 +169,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.hcpInternalCommunicationHostedZoneId)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 13 && object.fieldSet_[13]
+	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -169,7 +178,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.privateHostedZoneID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14]
+	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -178,7 +187,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.privateHostedZoneRoleARN)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15]
+	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -187,7 +196,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteBool(object.privateLink)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16] && object.privateLinkConfiguration != nil
+	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17] && object.privateLinkConfiguration != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -196,7 +205,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WritePrivateLinkClusterConfiguration(object.privateLinkConfiguration, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17]
+	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -205,7 +214,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.secretAccessKey)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18] && object.subnetIDs != nil
+	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.subnetIDs != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -214,7 +223,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteStringList(object.subnetIDs, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.tags != nil
+	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -243,7 +252,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20]
+	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -269,7 +278,7 @@ func UnmarshalAWS(source interface{}) (object *AWS, err error) {
 // ReadAWS reads a value of the 'AWS' type from the given iterator.
 func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 	object := &AWS{
-		fieldSet_: make([]bool, 21),
+		fieldSet_: make([]bool, 22),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -313,47 +322,51 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 			value := ReadAuditLog(iterator)
 			object.auditLog = value
 			object.fieldSet_[8] = true
+		case "auto_node":
+			value := ReadAwsAutoNode(iterator)
+			object.autoNode = value
+			object.fieldSet_[9] = true
 		case "billing_account_id":
 			value := iterator.ReadString()
 			object.billingAccountID = value
-			object.fieldSet_[9] = true
+			object.fieldSet_[10] = true
 		case "ec2_metadata_http_tokens":
 			text := iterator.ReadString()
 			value := Ec2MetadataHttpTokens(text)
 			object.ec2MetadataHttpTokens = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		case "etcd_encryption":
 			value := ReadAwsEtcdEncryption(iterator)
 			object.etcdEncryption = value
-			object.fieldSet_[11] = true
+			object.fieldSet_[12] = true
 		case "hcp_internal_communication_hosted_zone_id":
 			value := iterator.ReadString()
 			object.hcpInternalCommunicationHostedZoneId = value
-			object.fieldSet_[12] = true
+			object.fieldSet_[13] = true
 		case "private_hosted_zone_id":
 			value := iterator.ReadString()
 			object.privateHostedZoneID = value
-			object.fieldSet_[13] = true
+			object.fieldSet_[14] = true
 		case "private_hosted_zone_role_arn":
 			value := iterator.ReadString()
 			object.privateHostedZoneRoleARN = value
-			object.fieldSet_[14] = true
+			object.fieldSet_[15] = true
 		case "private_link":
 			value := iterator.ReadBool()
 			object.privateLink = value
-			object.fieldSet_[15] = true
+			object.fieldSet_[16] = true
 		case "private_link_configuration":
 			value := ReadPrivateLinkClusterConfiguration(iterator)
 			object.privateLinkConfiguration = value
-			object.fieldSet_[16] = true
+			object.fieldSet_[17] = true
 		case "secret_access_key":
 			value := iterator.ReadString()
 			object.secretAccessKey = value
-			object.fieldSet_[17] = true
+			object.fieldSet_[18] = true
 		case "subnet_ids":
 			value := ReadStringList(iterator)
 			object.subnetIDs = value
-			object.fieldSet_[18] = true
+			object.fieldSet_[19] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -365,11 +378,11 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 				value[key] = item
 			}
 			object.tags = value
-			object.fieldSet_[19] = true
+			object.fieldSet_[20] = true
 		case "vpc_endpoint_role_arn":
 			value := iterator.ReadString()
 			object.vpcEndpointRoleArn = value
-			object.fieldSet_[20] = true
+			object.fieldSet_[21] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_builder.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// The AutoNode configuration for the Cluster.
+type ClusterAutoNodeBuilder struct {
+	fieldSet_ []bool
+	mode      string
+	status    *ClusterAutoNodeStatusBuilder
+}
+
+// NewClusterAutoNode creates a new builder of 'cluster_auto_node' objects.
+func NewClusterAutoNode() *ClusterAutoNodeBuilder {
+	return &ClusterAutoNodeBuilder{
+		fieldSet_: make([]bool, 2),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAutoNodeBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Mode sets the value of the 'mode' attribute to the given value.
+func (b *ClusterAutoNodeBuilder) Mode(value string) *ClusterAutoNodeBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.mode = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Status sets the value of the 'status' attribute to the given value.
+//
+// Additional status information on the AutoNode configuration on this Cluster
+func (b *ClusterAutoNodeBuilder) Status(value *ClusterAutoNodeStatusBuilder) *ClusterAutoNodeBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.status = value
+	if value != nil {
+		b.fieldSet_[1] = true
+	} else {
+		b.fieldSet_[1] = false
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ClusterAutoNodeBuilder) Copy(object *ClusterAutoNode) *ClusterAutoNodeBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.mode = object.mode
+	if object.status != nil {
+		b.status = NewClusterAutoNodeStatus().Copy(object.status)
+	} else {
+		b.status = nil
+	}
+	return b
+}
+
+// Build creates a 'cluster_auto_node' object using the configuration stored in the builder.
+func (b *ClusterAutoNodeBuilder) Build() (object *ClusterAutoNode, err error) {
+	object = new(ClusterAutoNode)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.mode = b.mode
+	if b.status != nil {
+		object.status, err = b.status.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClusterAutoNodeListBuilder contains the data and logic needed to build
+// 'cluster_auto_node' objects.
+type ClusterAutoNodeListBuilder struct {
+	items []*ClusterAutoNodeBuilder
+}
+
+// NewClusterAutoNodeList creates a new builder of 'cluster_auto_node' objects.
+func NewClusterAutoNodeList() *ClusterAutoNodeListBuilder {
+	return new(ClusterAutoNodeListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ClusterAutoNodeListBuilder) Items(values ...*ClusterAutoNodeBuilder) *ClusterAutoNodeListBuilder {
+	b.items = make([]*ClusterAutoNodeBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ClusterAutoNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ClusterAutoNodeListBuilder) Copy(list *ClusterAutoNodeList) *ClusterAutoNodeListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ClusterAutoNodeBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewClusterAutoNode().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'cluster_auto_node' objects using the
+// configuration stored in the builder.
+func (b *ClusterAutoNodeListBuilder) Build() (list *ClusterAutoNodeList, err error) {
+	items := make([]*ClusterAutoNode, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterAutoNodeList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNodeList writes a list of values of the 'cluster_auto_node' type to
+// the given writer.
+func MarshalClusterAutoNodeList(list []*ClusterAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNodeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNodeList writes a list of value of the 'cluster_auto_node' type to
+// the given stream.
+func WriteClusterAutoNodeList(list []*ClusterAutoNode, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteClusterAutoNode(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalClusterAutoNodeList reads a list of values of the 'cluster_auto_node' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNodeList(source interface{}) (items []*ClusterAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadClusterAutoNodeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNodeList reads list of values of the ”cluster_auto_node' type from
+// the given iterator.
+func ReadClusterAutoNodeList(iterator *jsoniter.Iterator) []*ClusterAutoNode {
+	list := []*ClusterAutoNode{}
+	for iterator.ReadArray() {
+		item := ReadClusterAutoNode(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_status_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_status_builder.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// Additional status information on the AutoNode configuration on this Cluster
+type ClusterAutoNodeStatusBuilder struct {
+	fieldSet_ []bool
+	message   string
+}
+
+// NewClusterAutoNodeStatus creates a new builder of 'cluster_auto_node_status' objects.
+func NewClusterAutoNodeStatus() *ClusterAutoNodeStatusBuilder {
+	return &ClusterAutoNodeStatusBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAutoNodeStatusBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Message sets the value of the 'message' attribute to the given value.
+func (b *ClusterAutoNodeStatusBuilder) Message(value string) *ClusterAutoNodeStatusBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.message = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ClusterAutoNodeStatusBuilder) Copy(object *ClusterAutoNodeStatus) *ClusterAutoNodeStatusBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.message = object.message
+	return b
+}
+
+// Build creates a 'cluster_auto_node_status' object using the configuration stored in the builder.
+func (b *ClusterAutoNodeStatusBuilder) Build() (object *ClusterAutoNodeStatus, err error) {
+	object = new(ClusterAutoNodeStatus)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.message = b.message
+	return
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_status_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_status_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClusterAutoNodeStatusListBuilder contains the data and logic needed to build
+// 'cluster_auto_node_status' objects.
+type ClusterAutoNodeStatusListBuilder struct {
+	items []*ClusterAutoNodeStatusBuilder
+}
+
+// NewClusterAutoNodeStatusList creates a new builder of 'cluster_auto_node_status' objects.
+func NewClusterAutoNodeStatusList() *ClusterAutoNodeStatusListBuilder {
+	return new(ClusterAutoNodeStatusListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ClusterAutoNodeStatusListBuilder) Items(values ...*ClusterAutoNodeStatusBuilder) *ClusterAutoNodeStatusListBuilder {
+	b.items = make([]*ClusterAutoNodeStatusBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ClusterAutoNodeStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ClusterAutoNodeStatusListBuilder) Copy(list *ClusterAutoNodeStatusList) *ClusterAutoNodeStatusListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ClusterAutoNodeStatusBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewClusterAutoNodeStatus().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'cluster_auto_node_status' objects using the
+// configuration stored in the builder.
+func (b *ClusterAutoNodeStatusListBuilder) Build() (list *ClusterAutoNodeStatusList, err error) {
+	items := make([]*ClusterAutoNodeStatus, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterAutoNodeStatusList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_status_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_status_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNodeStatusList writes a list of values of the 'cluster_auto_node_status' type to
+// the given writer.
+func MarshalClusterAutoNodeStatusList(list []*ClusterAutoNodeStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNodeStatusList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNodeStatusList writes a list of value of the 'cluster_auto_node_status' type to
+// the given stream.
+func WriteClusterAutoNodeStatusList(list []*ClusterAutoNodeStatus, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteClusterAutoNodeStatus(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalClusterAutoNodeStatusList reads a list of values of the 'cluster_auto_node_status' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNodeStatusList(source interface{}) (items []*ClusterAutoNodeStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadClusterAutoNodeStatusList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNodeStatusList reads list of values of the ”cluster_auto_node_status' type from
+// the given iterator.
+func ReadClusterAutoNodeStatusList(iterator *jsoniter.Iterator) []*ClusterAutoNodeStatus {
+	list := []*ClusterAutoNodeStatus{}
+	for iterator.ReadArray() {
+		item := ReadClusterAutoNodeStatus(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_status_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_status_type.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClusterAutoNodeStatus represents the values of the 'cluster_auto_node_status' type.
+//
+// Additional status information on the AutoNode configuration on this Cluster
+type ClusterAutoNodeStatus struct {
+	fieldSet_ []bool
+	message   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAutoNodeStatus) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Message returns the value of the 'message' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Messages relating to the status of the AutoNode installation on this Cluster
+func (o *ClusterAutoNodeStatus) Message() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.message
+	}
+	return ""
+}
+
+// GetMessage returns the value of the 'message' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Messages relating to the status of the AutoNode installation on this Cluster
+func (o *ClusterAutoNodeStatus) GetMessage() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.message
+	}
+	return
+}
+
+// ClusterAutoNodeStatusListKind is the name of the type used to represent list of objects of
+// type 'cluster_auto_node_status'.
+const ClusterAutoNodeStatusListKind = "ClusterAutoNodeStatusList"
+
+// ClusterAutoNodeStatusListLinkKind is the name of the type used to represent links to list
+// of objects of type 'cluster_auto_node_status'.
+const ClusterAutoNodeStatusListLinkKind = "ClusterAutoNodeStatusListLink"
+
+// ClusterAutoNodeStatusNilKind is the name of the type used to nil lists of objects of
+// type 'cluster_auto_node_status'.
+const ClusterAutoNodeStatusListNilKind = "ClusterAutoNodeStatusListNil"
+
+// ClusterAutoNodeStatusList is a list of values of the 'cluster_auto_node_status' type.
+type ClusterAutoNodeStatusList struct {
+	href  string
+	link  bool
+	items []*ClusterAutoNodeStatus
+}
+
+// Len returns the length of the list.
+func (l *ClusterAutoNodeStatusList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeStatusList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeStatusList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeStatusList) SetItems(items []*ClusterAutoNodeStatus) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ClusterAutoNodeStatusList) Items() []*ClusterAutoNodeStatus {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAutoNodeStatusList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAutoNodeStatusList) Get(i int) *ClusterAutoNodeStatus {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ClusterAutoNodeStatusList) Slice() []*ClusterAutoNodeStatus {
+	var slice []*ClusterAutoNodeStatus
+	if l == nil {
+		slice = make([]*ClusterAutoNodeStatus, 0)
+	} else {
+		slice = make([]*ClusterAutoNodeStatus, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ClusterAutoNodeStatusList) Each(f func(item *ClusterAutoNodeStatus) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ClusterAutoNodeStatusList) Range(f func(index int, item *ClusterAutoNodeStatus) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_status_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_status_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNodeStatus writes a value of the 'cluster_auto_node_status' type to the given writer.
+func MarshalClusterAutoNodeStatus(object *ClusterAutoNodeStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNodeStatus(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNodeStatus writes a value of the 'cluster_auto_node_status' type to the given stream.
+func WriteClusterAutoNodeStatus(object *ClusterAutoNodeStatus, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("message")
+		stream.WriteString(object.message)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalClusterAutoNodeStatus reads a value of the 'cluster_auto_node_status' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNodeStatus(source interface{}) (object *ClusterAutoNodeStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadClusterAutoNodeStatus(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNodeStatus reads a value of the 'cluster_auto_node_status' type from the given iterator.
+func ReadClusterAutoNodeStatus(iterator *jsoniter.Iterator) *ClusterAutoNodeStatus {
+	object := &ClusterAutoNodeStatus{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "message":
+			value := iterator.ReadString()
+			object.message = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_type.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// ClusterAutoNode represents the values of the 'cluster_auto_node' type.
+//
+// The AutoNode configuration for the Cluster.
+type ClusterAutoNode struct {
+	fieldSet_ []bool
+	mode      string
+	status    *ClusterAutoNodeStatus
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAutoNode) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Mode returns the value of the 'mode' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Mode indicates the current state of AutoNode on this cluster.
+// Valid values: "enabled", "disabled".
+func (o *ClusterAutoNode) Mode() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.mode
+	}
+	return ""
+}
+
+// GetMode returns the value of the 'mode' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Mode indicates the current state of AutoNode on this cluster.
+// Valid values: "enabled", "disabled".
+func (o *ClusterAutoNode) GetMode() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.mode
+	}
+	return
+}
+
+// Status returns the value of the 'status' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+func (o *ClusterAutoNode) Status() *ClusterAutoNodeStatus {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.status
+	}
+	return nil
+}
+
+// GetStatus returns the value of the 'status' attribute and
+// a flag indicating if the attribute has a value.
+func (o *ClusterAutoNode) GetStatus() (value *ClusterAutoNodeStatus, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.status
+	}
+	return
+}
+
+// ClusterAutoNodeListKind is the name of the type used to represent list of objects of
+// type 'cluster_auto_node'.
+const ClusterAutoNodeListKind = "ClusterAutoNodeList"
+
+// ClusterAutoNodeListLinkKind is the name of the type used to represent links to list
+// of objects of type 'cluster_auto_node'.
+const ClusterAutoNodeListLinkKind = "ClusterAutoNodeListLink"
+
+// ClusterAutoNodeNilKind is the name of the type used to nil lists of objects of
+// type 'cluster_auto_node'.
+const ClusterAutoNodeListNilKind = "ClusterAutoNodeListNil"
+
+// ClusterAutoNodeList is a list of values of the 'cluster_auto_node' type.
+type ClusterAutoNodeList struct {
+	href  string
+	link  bool
+	items []*ClusterAutoNode
+}
+
+// Len returns the length of the list.
+func (l *ClusterAutoNodeList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeList) SetItems(items []*ClusterAutoNode) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ClusterAutoNodeList) Items() []*ClusterAutoNode {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAutoNodeList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAutoNodeList) Get(i int) *ClusterAutoNode {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ClusterAutoNodeList) Slice() []*ClusterAutoNode {
+	var slice []*ClusterAutoNode
+	if l == nil {
+		slice = make([]*ClusterAutoNode, 0)
+	} else {
+		slice = make([]*ClusterAutoNode, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ClusterAutoNodeList) Each(f func(item *ClusterAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ClusterAutoNodeList) Range(f func(index int, item *ClusterAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/cluster_auto_node_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_auto_node_type_json.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNode writes a value of the 'cluster_auto_node' type to the given writer.
+func MarshalClusterAutoNode(object *ClusterAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNode(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNode writes a value of the 'cluster_auto_node' type to the given stream.
+func WriteClusterAutoNode(object *ClusterAutoNode, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("mode")
+		stream.WriteString(object.mode)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.status != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("status")
+		WriteClusterAutoNodeStatus(object.status, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalClusterAutoNode reads a value of the 'cluster_auto_node' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNode(source interface{}) (object *ClusterAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadClusterAutoNode(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNode reads a value of the 'cluster_auto_node' type from the given iterator.
+func ReadClusterAutoNode(iterator *jsoniter.Iterator) *ClusterAutoNode {
+	object := &ClusterAutoNode{
+		fieldSet_: make([]bool, 2),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "mode":
+			value := iterator.ReadString()
+			object.mode = value
+			object.fieldSet_[0] = true
+		case "status":
+			value := ReadClusterAutoNodeStatus(iterator)
+			object.status = value
+			object.fieldSet_[1] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/cluster_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_builder.go
@@ -78,6 +78,7 @@ type ClusterBuilder struct {
 	gcpNetwork                        *GCPNetworkBuilder
 	additionalTrustBundle             string
 	addons                            *v1.AddOnInstallationListBuilder
+	autoNode                          *ClusterAutoNodeBuilder
 	autoscaler                        *v1.ClusterAutoscalerBuilder
 	azure                             *AzureBuilder
 	billingModel                      BillingModel
@@ -133,14 +134,14 @@ type ClusterBuilder struct {
 // NewCluster creates a new builder of 'cluster' objects.
 func NewCluster() *ClusterBuilder {
 	return &ClusterBuilder{
-		fieldSet_: make([]bool, 63),
+		fieldSet_: make([]bool, 64),
 	}
 }
 
 // Link sets the flag that indicates if this is a link.
 func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.fieldSet_[0] = true
 	return b
@@ -149,7 +150,7 @@ func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 // ID sets the identifier of the object.
 func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.id = value
 	b.fieldSet_[1] = true
@@ -159,7 +160,7 @@ func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 // HREF sets the link to the object.
 func (b *ClusterBuilder) HREF(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.href = value
 	b.fieldSet_[2] = true
@@ -186,7 +187,7 @@ func (b *ClusterBuilder) Empty() bool {
 // Information about the API of a cluster.
 func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.api = value
 	if value != nil {
@@ -202,7 +203,7 @@ func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 // _Amazon Web Services_ specific settings of a cluster.
 func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.aws = value
 	if value != nil {
@@ -216,7 +217,7 @@ func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 // AWSInfrastructureAccessRoleGrants sets the value of the 'AWS_infrastructure_access_role_grants' attribute to the given values.
 func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *v1.AWSInfrastructureAccessRoleGrantListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.awsInfrastructureAccessRoleGrants = value
 	b.fieldSet_[5] = true
@@ -226,7 +227,7 @@ func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *v1.AWSInfrastr
 // CCS sets the value of the 'CCS' attribute to the given value.
 func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.ccs = value
 	if value != nil {
@@ -242,7 +243,7 @@ func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 // DNS settings of the cluster.
 func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.dns = value
 	if value != nil {
@@ -256,7 +257,7 @@ func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 // FIPS sets the value of the 'FIPS' attribute to the given value.
 func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.fips = value
 	b.fieldSet_[8] = true
@@ -268,7 +269,7 @@ func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 // Google cloud platform settings of a cluster.
 func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcp = value
 	if value != nil {
@@ -284,7 +285,7 @@ func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 // GCP Encryption Key for CCS clusters.
 func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcpEncryptionKey = value
 	if value != nil {
@@ -300,7 +301,7 @@ func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *Clust
 // GCP Network configuration of a cluster.
 func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcpNetwork = value
 	if value != nil {
@@ -314,7 +315,7 @@ func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 // AdditionalTrustBundle sets the value of the 'additional_trust_bundle' attribute to the given value.
 func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.additionalTrustBundle = value
 	b.fieldSet_[12] = true
@@ -324,10 +325,26 @@ func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 // Addons sets the value of the 'addons' attribute to the given values.
 func (b *ClusterBuilder) Addons(value *v1.AddOnInstallationListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.addons = value
 	b.fieldSet_[13] = true
+	return b
+}
+
+// AutoNode sets the value of the 'auto_node' attribute to the given value.
+//
+// The AutoNode configuration for the Cluster.
+func (b *ClusterBuilder) AutoNode(value *ClusterAutoNodeBuilder) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 64)
+	}
+	b.autoNode = value
+	if value != nil {
+		b.fieldSet_[14] = true
+	} else {
+		b.fieldSet_[14] = false
+	}
 	return b
 }
 
@@ -336,13 +353,13 @@ func (b *ClusterBuilder) Addons(value *v1.AddOnInstallationListBuilder) *Cluster
 // Cluster-wide autoscaling configuration.
 func (b *ClusterBuilder) Autoscaler(value *v1.ClusterAutoscalerBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.autoscaler = value
 	if value != nil {
-		b.fieldSet_[14] = true
+		b.fieldSet_[15] = true
 	} else {
-		b.fieldSet_[14] = false
+		b.fieldSet_[15] = false
 	}
 	return b
 }
@@ -352,13 +369,13 @@ func (b *ClusterBuilder) Autoscaler(value *v1.ClusterAutoscalerBuilder) *Cluster
 // Microsoft Azure settings of a cluster.
 func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.azure = value
 	if value != nil {
-		b.fieldSet_[15] = true
+		b.fieldSet_[16] = true
 	} else {
-		b.fieldSet_[15] = false
+		b.fieldSet_[16] = false
 	}
 	return b
 }
@@ -368,10 +385,10 @@ func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 // Billing model for cluster resources.
 func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.billingModel = value
-	b.fieldSet_[16] = true
+	b.fieldSet_[17] = true
 	return b
 }
 
@@ -380,13 +397,13 @@ func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 // ByoOidc configuration.
 func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.byoOidc = value
 	if value != nil {
-		b.fieldSet_[17] = true
+		b.fieldSet_[18] = true
 	} else {
-		b.fieldSet_[17] = false
+		b.fieldSet_[18] = false
 	}
 	return b
 }
@@ -396,13 +413,13 @@ func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 // Cloud provider.
 func (b *ClusterBuilder) CloudProvider(value *v1.CloudProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.cloudProvider = value
 	if value != nil {
-		b.fieldSet_[18] = true
+		b.fieldSet_[19] = true
 	} else {
-		b.fieldSet_[18] = false
+		b.fieldSet_[19] = false
 	}
 	return b
 }
@@ -412,13 +429,13 @@ func (b *ClusterBuilder) CloudProvider(value *v1.CloudProviderBuilder) *ClusterB
 // Information about the console of a cluster.
 func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.console = value
 	if value != nil {
-		b.fieldSet_[19] = true
+		b.fieldSet_[20] = true
 	} else {
-		b.fieldSet_[19] = false
+		b.fieldSet_[20] = false
 	}
 	return b
 }
@@ -426,10 +443,10 @@ func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 // CreationTimestamp sets the value of the 'creation_timestamp' attribute to the given value.
 func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.creationTimestamp = value
-	b.fieldSet_[20] = true
+	b.fieldSet_[21] = true
 	return b
 }
 
@@ -438,13 +455,13 @@ func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 // DeleteProtection configuration.
 func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.deleteProtection = value
 	if value != nil {
-		b.fieldSet_[21] = true
+		b.fieldSet_[22] = true
 	} else {
-		b.fieldSet_[21] = false
+		b.fieldSet_[22] = false
 	}
 	return b
 }
@@ -452,50 +469,50 @@ func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *Clust
 // DisableUserWorkloadMonitoring sets the value of the 'disable_user_workload_monitoring' attribute to the given value.
 func (b *ClusterBuilder) DisableUserWorkloadMonitoring(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.disableUserWorkloadMonitoring = value
-	b.fieldSet_[22] = true
+	b.fieldSet_[23] = true
 	return b
 }
 
 // DomainPrefix sets the value of the 'domain_prefix' attribute to the given value.
 func (b *ClusterBuilder) DomainPrefix(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.domainPrefix = value
-	b.fieldSet_[23] = true
+	b.fieldSet_[24] = true
 	return b
 }
 
 // EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
 func (b *ClusterBuilder) EtcdEncryption(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.etcdEncryption = value
-	b.fieldSet_[24] = true
+	b.fieldSet_[25] = true
 	return b
 }
 
 // ExpirationTimestamp sets the value of the 'expiration_timestamp' attribute to the given value.
 func (b *ClusterBuilder) ExpirationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.expirationTimestamp = value
-	b.fieldSet_[25] = true
+	b.fieldSet_[26] = true
 	return b
 }
 
 // ExternalID sets the value of the 'external_ID' attribute to the given value.
 func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalID = value
-	b.fieldSet_[26] = true
+	b.fieldSet_[27] = true
 	return b
 }
 
@@ -504,13 +521,13 @@ func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 // Represents an external authentication configuration
 func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalAuthConfig = value
 	if value != nil {
-		b.fieldSet_[27] = true
+		b.fieldSet_[28] = true
 	} else {
-		b.fieldSet_[27] = false
+		b.fieldSet_[28] = false
 	}
 	return b
 }
@@ -520,13 +537,13 @@ func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *C
 // Representation of cluster external configuration.
 func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalConfiguration = value
 	if value != nil {
-		b.fieldSet_[28] = true
+		b.fieldSet_[29] = true
 	} else {
-		b.fieldSet_[28] = false
+		b.fieldSet_[29] = false
 	}
 	return b
 }
@@ -537,13 +554,13 @@ func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuild
 // with 10 infra nodes and 1000 compute nodes.
 func (b *ClusterBuilder) Flavour(value *v1.FlavourBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.flavour = value
 	if value != nil {
-		b.fieldSet_[29] = true
+		b.fieldSet_[30] = true
 	} else {
-		b.fieldSet_[29] = false
+		b.fieldSet_[30] = false
 	}
 	return b
 }
@@ -551,10 +568,10 @@ func (b *ClusterBuilder) Flavour(value *v1.FlavourBuilder) *ClusterBuilder {
 // Groups sets the value of the 'groups' attribute to the given values.
 func (b *ClusterBuilder) Groups(value *v1.GroupListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.groups = value
-	b.fieldSet_[30] = true
+	b.fieldSet_[31] = true
 	return b
 }
 
@@ -563,10 +580,10 @@ func (b *ClusterBuilder) Groups(value *v1.GroupListBuilder) *ClusterBuilder {
 // ClusterHealthState indicates the health of a cluster.
 func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.healthState = value
-	b.fieldSet_[31] = true
+	b.fieldSet_[32] = true
 	return b
 }
 
@@ -575,13 +592,13 @@ func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 // Details for `htpasswd` identity providers.
 func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.htpasswd = value
 	if value != nil {
-		b.fieldSet_[32] = true
+		b.fieldSet_[33] = true
 	} else {
-		b.fieldSet_[32] = false
+		b.fieldSet_[33] = false
 	}
 	return b
 }
@@ -591,13 +608,13 @@ func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *Clust
 // Hypershift configuration.
 func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.hypershift = value
 	if value != nil {
-		b.fieldSet_[33] = true
+		b.fieldSet_[34] = true
 	} else {
-		b.fieldSet_[33] = false
+		b.fieldSet_[34] = false
 	}
 	return b
 }
@@ -605,10 +622,10 @@ func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 // IdentityProviders sets the value of the 'identity_providers' attribute to the given values.
 func (b *ClusterBuilder) IdentityProviders(value *v1.IdentityProviderListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.identityProviders = value
-	b.fieldSet_[34] = true
+	b.fieldSet_[35] = true
 	return b
 }
 
@@ -617,13 +634,13 @@ func (b *ClusterBuilder) IdentityProviders(value *v1.IdentityProviderListBuilder
 // ClusterImageRegistry represents the configuration for the cluster's internal image registry.
 func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.imageRegistry = value
 	if value != nil {
-		b.fieldSet_[35] = true
+		b.fieldSet_[36] = true
 	} else {
-		b.fieldSet_[35] = false
+		b.fieldSet_[36] = false
 	}
 	return b
 }
@@ -631,30 +648,30 @@ func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *Clus
 // InflightChecks sets the value of the 'inflight_checks' attribute to the given values.
 func (b *ClusterBuilder) InflightChecks(value *InflightCheckListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.inflightChecks = value
-	b.fieldSet_[36] = true
+	b.fieldSet_[37] = true
 	return b
 }
 
 // InfraID sets the value of the 'infra_ID' attribute to the given value.
 func (b *ClusterBuilder) InfraID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.infraID = value
-	b.fieldSet_[37] = true
+	b.fieldSet_[38] = true
 	return b
 }
 
 // Ingresses sets the value of the 'ingresses' attribute to the given values.
 func (b *ClusterBuilder) Ingresses(value *v1.IngressListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.ingresses = value
-	b.fieldSet_[38] = true
+	b.fieldSet_[39] = true
 	return b
 }
 
@@ -664,13 +681,13 @@ func (b *ClusterBuilder) Ingresses(value *v1.IngressListBuilder) *ClusterBuilder
 // KubeletConfig that can be managed by users
 func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.kubeletConfig = value
 	if value != nil {
-		b.fieldSet_[39] = true
+		b.fieldSet_[40] = true
 	} else {
-		b.fieldSet_[39] = false
+		b.fieldSet_[40] = false
 	}
 	return b
 }
@@ -678,30 +695,30 @@ func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuil
 // LoadBalancerQuota sets the value of the 'load_balancer_quota' attribute to the given value.
 func (b *ClusterBuilder) LoadBalancerQuota(value int) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.loadBalancerQuota = value
-	b.fieldSet_[40] = true
+	b.fieldSet_[41] = true
 	return b
 }
 
 // MachinePools sets the value of the 'machine_pools' attribute to the given values.
 func (b *ClusterBuilder) MachinePools(value *v1.MachinePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.machinePools = value
-	b.fieldSet_[41] = true
+	b.fieldSet_[42] = true
 	return b
 }
 
 // Managed sets the value of the 'managed' attribute to the given value.
 func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.managed = value
-	b.fieldSet_[42] = true
+	b.fieldSet_[43] = true
 	return b
 }
 
@@ -710,13 +727,13 @@ func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.managedService = value
 	if value != nil {
-		b.fieldSet_[43] = true
+		b.fieldSet_[44] = true
 	} else {
-		b.fieldSet_[43] = false
+		b.fieldSet_[44] = false
 	}
 	return b
 }
@@ -724,30 +741,30 @@ func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBu
 // MultiAZ sets the value of the 'multi_AZ' attribute to the given value.
 func (b *ClusterBuilder) MultiAZ(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.multiAZ = value
-	b.fieldSet_[44] = true
+	b.fieldSet_[45] = true
 	return b
 }
 
 // MultiArchEnabled sets the value of the 'multi_arch_enabled' attribute to the given value.
 func (b *ClusterBuilder) MultiArchEnabled(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.multiArchEnabled = value
-	b.fieldSet_[45] = true
+	b.fieldSet_[46] = true
 	return b
 }
 
 // Name sets the value of the 'name' attribute to the given value.
 func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.name = value
-	b.fieldSet_[46] = true
+	b.fieldSet_[47] = true
 	return b
 }
 
@@ -756,13 +773,13 @@ func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 // Network configuration of a cluster.
 func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.network = value
 	if value != nil {
-		b.fieldSet_[47] = true
+		b.fieldSet_[48] = true
 	} else {
-		b.fieldSet_[47] = false
+		b.fieldSet_[48] = false
 	}
 	return b
 }
@@ -789,13 +806,13 @@ func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodeDrainGracePeriod = value
 	if value != nil {
-		b.fieldSet_[48] = true
+		b.fieldSet_[49] = true
 	} else {
-		b.fieldSet_[48] = false
+		b.fieldSet_[49] = false
 	}
 	return b
 }
@@ -803,10 +820,10 @@ func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuild
 // NodePools sets the value of the 'node_pools' attribute to the given values.
 func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodePools = value
-	b.fieldSet_[49] = true
+	b.fieldSet_[50] = true
 	return b
 }
 
@@ -815,13 +832,13 @@ func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 // Counts of different classes of nodes inside a cluster.
 func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodes = value
 	if value != nil {
-		b.fieldSet_[50] = true
+		b.fieldSet_[51] = true
 	} else {
-		b.fieldSet_[50] = false
+		b.fieldSet_[51] = false
 	}
 	return b
 }
@@ -829,10 +846,10 @@ func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 // OpenshiftVersion sets the value of the 'openshift_version' attribute to the given value.
 func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.openshiftVersion = value
-	b.fieldSet_[51] = true
+	b.fieldSet_[52] = true
 	return b
 }
 
@@ -841,13 +858,13 @@ func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
 // Representation of an product that can be selected as a cluster type.
 func (b *ClusterBuilder) Product(value *v1.ProductBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.product = value
 	if value != nil {
-		b.fieldSet_[52] = true
+		b.fieldSet_[53] = true
 	} else {
-		b.fieldSet_[52] = false
+		b.fieldSet_[53] = false
 	}
 	return b
 }
@@ -855,13 +872,13 @@ func (b *ClusterBuilder) Product(value *v1.ProductBuilder) *ClusterBuilder {
 // Properties sets the value of the 'properties' attribute to the given value.
 func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.properties = value
 	if value != nil {
-		b.fieldSet_[53] = true
+		b.fieldSet_[54] = true
 	} else {
-		b.fieldSet_[53] = false
+		b.fieldSet_[54] = false
 	}
 	return b
 }
@@ -871,13 +888,13 @@ func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 // Contains the properties of the provision shard, including AWS and GCP related configurations
 func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.provisionShard = value
 	if value != nil {
-		b.fieldSet_[54] = true
+		b.fieldSet_[55] = true
 	} else {
-		b.fieldSet_[54] = false
+		b.fieldSet_[55] = false
 	}
 	return b
 }
@@ -887,13 +904,13 @@ func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBu
 // Proxy configuration of a cluster.
 func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.proxy = value
 	if value != nil {
-		b.fieldSet_[55] = true
+		b.fieldSet_[56] = true
 	} else {
-		b.fieldSet_[55] = false
+		b.fieldSet_[56] = false
 	}
 	return b
 }
@@ -903,13 +920,13 @@ func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 // Description of a region of a cloud provider.
 func (b *ClusterBuilder) Region(value *v1.CloudRegionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.region = value
 	if value != nil {
-		b.fieldSet_[56] = true
+		b.fieldSet_[57] = true
 	} else {
-		b.fieldSet_[56] = false
+		b.fieldSet_[57] = false
 	}
 	return b
 }
@@ -935,13 +952,13 @@ func (b *ClusterBuilder) Region(value *v1.CloudRegionBuilder) *ClusterBuilder {
 // ```
 func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.registryConfig = value
 	if value != nil {
-		b.fieldSet_[57] = true
+		b.fieldSet_[58] = true
 	} else {
-		b.fieldSet_[57] = false
+		b.fieldSet_[58] = false
 	}
 	return b
 }
@@ -951,10 +968,10 @@ func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *Cl
 // Overall state of a cluster.
 func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.state = value
-	b.fieldSet_[58] = true
+	b.fieldSet_[59] = true
 	return b
 }
 
@@ -963,13 +980,13 @@ func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 // Detailed status of a cluster.
 func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.status = value
 	if value != nil {
-		b.fieldSet_[59] = true
+		b.fieldSet_[60] = true
 	} else {
-		b.fieldSet_[59] = false
+		b.fieldSet_[60] = false
 	}
 	return b
 }
@@ -996,13 +1013,13 @@ func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.storageQuota = value
 	if value != nil {
-		b.fieldSet_[60] = true
+		b.fieldSet_[61] = true
 	} else {
-		b.fieldSet_[60] = false
+		b.fieldSet_[61] = false
 	}
 	return b
 }
@@ -1012,13 +1029,13 @@ func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 // Definition of a subscription.
 func (b *ClusterBuilder) Subscription(value *v1.SubscriptionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.subscription = value
 	if value != nil {
-		b.fieldSet_[61] = true
+		b.fieldSet_[62] = true
 	} else {
-		b.fieldSet_[61] = false
+		b.fieldSet_[62] = false
 	}
 	return b
 }
@@ -1028,13 +1045,13 @@ func (b *ClusterBuilder) Subscription(value *v1.SubscriptionBuilder) *ClusterBui
 // Representation of an _OpenShift_ version.
 func (b *ClusterBuilder) Version(value *VersionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.version = value
 	if value != nil {
-		b.fieldSet_[62] = true
+		b.fieldSet_[63] = true
 	} else {
-		b.fieldSet_[62] = false
+		b.fieldSet_[63] = false
 	}
 	return b
 }
@@ -1096,6 +1113,11 @@ func (b *ClusterBuilder) Copy(object *Cluster) *ClusterBuilder {
 		b.addons = v1.NewAddOnInstallationList().Copy(object.addons)
 	} else {
 		b.addons = nil
+	}
+	if object.autoNode != nil {
+		b.autoNode = NewClusterAutoNode().Copy(object.autoNode)
+	} else {
+		b.autoNode = nil
 	}
 	if object.autoscaler != nil {
 		b.autoscaler = v1.NewClusterAutoscaler().Copy(object.autoscaler)
@@ -1345,6 +1367,12 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 	object.additionalTrustBundle = b.additionalTrustBundle
 	if b.addons != nil {
 		object.addons, err = b.addons.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.autoNode != nil {
+		object.autoNode, err = b.autoNode.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/arohcp/v1alpha1/cluster_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type.go
@@ -92,6 +92,7 @@ type Cluster struct {
 	gcpNetwork                        *GCPNetwork
 	additionalTrustBundle             string
 	addons                            *v1.AddOnInstallationList
+	autoNode                          *ClusterAutoNode
 	autoscaler                        *v1.ClusterAutoscaler
 	azure                             *Azure
 	billingModel                      BillingModel
@@ -464,12 +465,37 @@ func (o *Cluster) GetAddons() (value *v1.AddOnInstallationList, ok bool) {
 	return
 }
 
+// AutoNode returns the value of the 'auto_node' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The AutoNode settings for this cluster.
+// This is currently only supported for ROSA HCP
+func (o *Cluster) AutoNode() *ClusterAutoNode {
+	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
+		return o.autoNode
+	}
+	return nil
+}
+
+// GetAutoNode returns the value of the 'auto_node' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The AutoNode settings for this cluster.
+// This is currently only supported for ROSA HCP
+func (o *Cluster) GetAutoNode() (value *ClusterAutoNode, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
+	if ok {
+		value = o.autoNode
+	}
+	return
+}
+
 // Autoscaler returns the value of the 'autoscaler' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Link to an optional _ClusterAutoscaler_ that is coupled with the cluster.
 func (o *Cluster) Autoscaler() *v1.ClusterAutoscaler {
-	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
+	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
 		return o.autoscaler
 	}
 	return nil
@@ -480,7 +506,7 @@ func (o *Cluster) Autoscaler() *v1.ClusterAutoscaler {
 //
 // Link to an optional _ClusterAutoscaler_ that is coupled with the cluster.
 func (o *Cluster) GetAutoscaler() (value *v1.ClusterAutoscaler, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
+	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
 	if ok {
 		value = o.autoscaler
 	}
@@ -492,7 +518,7 @@ func (o *Cluster) GetAutoscaler() (value *v1.ClusterAutoscaler, ok bool) {
 //
 // Microsoft Azure settings of the cluster.
 func (o *Cluster) Azure() *Azure {
-	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
+	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
 		return o.azure
 	}
 	return nil
@@ -503,7 +529,7 @@ func (o *Cluster) Azure() *Azure {
 //
 // Microsoft Azure settings of the cluster.
 func (o *Cluster) GetAzure() (value *Azure, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
+	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
 	if ok {
 		value = o.azure
 	}
@@ -515,7 +541,7 @@ func (o *Cluster) GetAzure() (value *Azure, ok bool) {
 //
 // Billing model for cluster resources.
 func (o *Cluster) BillingModel() BillingModel {
-	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
+	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
 		return o.billingModel
 	}
 	return BillingModel("")
@@ -526,7 +552,7 @@ func (o *Cluster) BillingModel() BillingModel {
 //
 // Billing model for cluster resources.
 func (o *Cluster) GetBillingModel() (value BillingModel, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
+	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
 	if ok {
 		value = o.billingModel
 	}
@@ -538,7 +564,7 @@ func (o *Cluster) GetBillingModel() (value BillingModel, ok bool) {
 //
 // Contains information about BYO OIDC.
 func (o *Cluster) ByoOidc() *ByoOidc {
-	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
+	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
 		return o.byoOidc
 	}
 	return nil
@@ -549,7 +575,7 @@ func (o *Cluster) ByoOidc() *ByoOidc {
 //
 // Contains information about BYO OIDC.
 func (o *Cluster) GetByoOidc() (value *ByoOidc, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
+	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
 	if ok {
 		value = o.byoOidc
 	}
@@ -561,7 +587,7 @@ func (o *Cluster) GetByoOidc() (value *ByoOidc, ok bool) {
 //
 // Link to the cloud provider where the cluster is installed.
 func (o *Cluster) CloudProvider() *v1.CloudProvider {
-	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
+	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
 		return o.cloudProvider
 	}
 	return nil
@@ -572,7 +598,7 @@ func (o *Cluster) CloudProvider() *v1.CloudProvider {
 //
 // Link to the cloud provider where the cluster is installed.
 func (o *Cluster) GetCloudProvider() (value *v1.CloudProvider, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
+	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
 	if ok {
 		value = o.cloudProvider
 	}
@@ -584,7 +610,7 @@ func (o *Cluster) GetCloudProvider() (value *v1.CloudProvider, ok bool) {
 //
 // Information about the console of the cluster.
 func (o *Cluster) Console() *ClusterConsole {
-	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
+	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
 		return o.console
 	}
 	return nil
@@ -595,7 +621,7 @@ func (o *Cluster) Console() *ClusterConsole {
 //
 // Information about the console of the cluster.
 func (o *Cluster) GetConsole() (value *ClusterConsole, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
+	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
 	if ok {
 		value = o.console
 	}
@@ -608,7 +634,7 @@ func (o *Cluster) GetConsole() (value *ClusterConsole, ok bool) {
 // Date and time when the cluster was initially created, using the
 // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
 func (o *Cluster) CreationTimestamp() time.Time {
-	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
+	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
 		return o.creationTimestamp
 	}
 	return time.Time{}
@@ -620,7 +646,7 @@ func (o *Cluster) CreationTimestamp() time.Time {
 // Date and time when the cluster was initially created, using the
 // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
 func (o *Cluster) GetCreationTimestamp() (value time.Time, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
+	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
 	if ok {
 		value = o.creationTimestamp
 	}
@@ -632,7 +658,7 @@ func (o *Cluster) GetCreationTimestamp() (value time.Time, ok bool) {
 //
 // Delete protection
 func (o *Cluster) DeleteProtection() *DeleteProtection {
-	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
+	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
 		return o.deleteProtection
 	}
 	return nil
@@ -643,7 +669,7 @@ func (o *Cluster) DeleteProtection() *DeleteProtection {
 //
 // Delete protection
 func (o *Cluster) GetDeleteProtection() (value *DeleteProtection, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
+	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
 	if ok {
 		value = o.deleteProtection
 	}
@@ -656,7 +682,7 @@ func (o *Cluster) GetDeleteProtection() (value *DeleteProtection, ok bool) {
 // Indicates whether the User workload monitoring is enabled or not
 // It is enabled by default
 func (o *Cluster) DisableUserWorkloadMonitoring() bool {
-	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
+	if o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23] {
 		return o.disableUserWorkloadMonitoring
 	}
 	return false
@@ -668,7 +694,7 @@ func (o *Cluster) DisableUserWorkloadMonitoring() bool {
 // Indicates whether the User workload monitoring is enabled or not
 // It is enabled by default
 func (o *Cluster) GetDisableUserWorkloadMonitoring() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
+	ok = o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23]
 	if ok {
 		value = o.disableUserWorkloadMonitoring
 	}
@@ -681,7 +707,7 @@ func (o *Cluster) GetDisableUserWorkloadMonitoring() (value bool, ok bool) {
 // DomainPrefix of the cluster. This prefix is optionally assigned by the user when the
 // cluster is created. It will appear in the Cluster's domain when the cluster is provisioned.
 func (o *Cluster) DomainPrefix() string {
-	if o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23] {
+	if o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24] {
 		return o.domainPrefix
 	}
 	return ""
@@ -693,7 +719,7 @@ func (o *Cluster) DomainPrefix() string {
 // DomainPrefix of the cluster. This prefix is optionally assigned by the user when the
 // cluster is created. It will appear in the Cluster's domain when the cluster is provisioned.
 func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23]
+	ok = o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24]
 	if ok {
 		value = o.domainPrefix
 	}
@@ -707,7 +733,7 @@ func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
 // This is set only during cluster creation.
 // For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) EtcdEncryption() bool {
-	if o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24] {
+	if o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25] {
 		return o.etcdEncryption
 	}
 	return false
@@ -720,7 +746,7 @@ func (o *Cluster) EtcdEncryption() bool {
 // This is set only during cluster creation.
 // For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24]
+	ok = o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25]
 	if ok {
 		value = o.etcdEncryption
 	}
@@ -736,7 +762,7 @@ func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
 //
 // This option is unsupported.
 func (o *Cluster) ExpirationTimestamp() time.Time {
-	if o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25] {
+	if o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26] {
 		return o.expirationTimestamp
 	}
 	return time.Time{}
@@ -751,7 +777,7 @@ func (o *Cluster) ExpirationTimestamp() time.Time {
 //
 // This option is unsupported.
 func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25]
+	ok = o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26]
 	if ok {
 		value = o.expirationTimestamp
 	}
@@ -763,7 +789,7 @@ func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
 //
 // External identifier of the cluster, generated by the installer.
 func (o *Cluster) ExternalID() string {
-	if o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26] {
+	if o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27] {
 		return o.externalID
 	}
 	return ""
@@ -774,7 +800,7 @@ func (o *Cluster) ExternalID() string {
 //
 // External identifier of the cluster, generated by the installer.
 func (o *Cluster) GetExternalID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26]
+	ok = o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27]
 	if ok {
 		value = o.externalID
 	}
@@ -789,7 +815,7 @@ func (o *Cluster) GetExternalID() (value string, ok bool) {
 // For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
 // For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
-	if o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27] {
+	if o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28] {
 		return o.externalAuthConfig
 	}
 	return nil
@@ -803,7 +829,7 @@ func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 // For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
 // For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27]
+	ok = o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28]
 	if ok {
 		value = o.externalAuthConfig
 	}
@@ -815,7 +841,7 @@ func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
 //
 // ExternalConfiguration shows external configuration on the cluster.
 func (o *Cluster) ExternalConfiguration() *ExternalConfiguration {
-	if o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28] {
+	if o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29] {
 		return o.externalConfiguration
 	}
 	return nil
@@ -826,7 +852,7 @@ func (o *Cluster) ExternalConfiguration() *ExternalConfiguration {
 //
 // ExternalConfiguration shows external configuration on the cluster.
 func (o *Cluster) GetExternalConfiguration() (value *ExternalConfiguration, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28]
+	ok = o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29]
 	if ok {
 		value = o.externalConfiguration
 	}
@@ -838,7 +864,7 @@ func (o *Cluster) GetExternalConfiguration() (value *ExternalConfiguration, ok b
 //
 // Link to the _flavour_ that was used to create the cluster.
 func (o *Cluster) Flavour() *v1.Flavour {
-	if o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29] {
+	if o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30] {
 		return o.flavour
 	}
 	return nil
@@ -849,7 +875,7 @@ func (o *Cluster) Flavour() *v1.Flavour {
 //
 // Link to the _flavour_ that was used to create the cluster.
 func (o *Cluster) GetFlavour() (value *v1.Flavour, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29]
+	ok = o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30]
 	if ok {
 		value = o.flavour
 	}
@@ -861,7 +887,7 @@ func (o *Cluster) GetFlavour() (value *v1.Flavour, ok bool) {
 //
 // Link to the collection of groups of user of the cluster.
 func (o *Cluster) Groups() *v1.GroupList {
-	if o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30] {
+	if o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31] {
 		return o.groups
 	}
 	return nil
@@ -872,7 +898,7 @@ func (o *Cluster) Groups() *v1.GroupList {
 //
 // Link to the collection of groups of user of the cluster.
 func (o *Cluster) GetGroups() (value *v1.GroupList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30]
+	ok = o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31]
 	if ok {
 		value = o.groups
 	}
@@ -884,7 +910,7 @@ func (o *Cluster) GetGroups() (value *v1.GroupList, ok bool) {
 //
 // HealthState indicates the overall health state of the cluster.
 func (o *Cluster) HealthState() ClusterHealthState {
-	if o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31] {
+	if o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32] {
 		return o.healthState
 	}
 	return ClusterHealthState("")
@@ -895,7 +921,7 @@ func (o *Cluster) HealthState() ClusterHealthState {
 //
 // HealthState indicates the overall health state of the cluster.
 func (o *Cluster) GetHealthState() (value ClusterHealthState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31]
+	ok = o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32]
 	if ok {
 		value = o.healthState
 	}
@@ -907,7 +933,7 @@ func (o *Cluster) GetHealthState() (value ClusterHealthState, ok bool) {
 //
 // Details for `htpasswd` identity provider.
 func (o *Cluster) Htpasswd() *HTPasswdIdentityProvider {
-	if o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32] {
+	if o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33] {
 		return o.htpasswd
 	}
 	return nil
@@ -918,7 +944,7 @@ func (o *Cluster) Htpasswd() *HTPasswdIdentityProvider {
 //
 // Details for `htpasswd` identity provider.
 func (o *Cluster) GetHtpasswd() (value *HTPasswdIdentityProvider, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32]
+	ok = o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33]
 	if ok {
 		value = o.htpasswd
 	}
@@ -930,7 +956,7 @@ func (o *Cluster) GetHtpasswd() (value *HTPasswdIdentityProvider, ok bool) {
 //
 // Hypershift configuration.
 func (o *Cluster) Hypershift() *Hypershift {
-	if o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33] {
+	if o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34] {
 		return o.hypershift
 	}
 	return nil
@@ -941,7 +967,7 @@ func (o *Cluster) Hypershift() *Hypershift {
 //
 // Hypershift configuration.
 func (o *Cluster) GetHypershift() (value *Hypershift, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33]
+	ok = o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34]
 	if ok {
 		value = o.hypershift
 	}
@@ -953,7 +979,7 @@ func (o *Cluster) GetHypershift() (value *Hypershift, ok bool) {
 //
 // Link to the collection of identity providers of the cluster.
 func (o *Cluster) IdentityProviders() *v1.IdentityProviderList {
-	if o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34] {
+	if o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35] {
 		return o.identityProviders
 	}
 	return nil
@@ -964,7 +990,7 @@ func (o *Cluster) IdentityProviders() *v1.IdentityProviderList {
 //
 // Link to the collection of identity providers of the cluster.
 func (o *Cluster) GetIdentityProviders() (value *v1.IdentityProviderList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34]
+	ok = o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35]
 	if ok {
 		value = o.identityProviders
 	}
@@ -978,7 +1004,7 @@ func (o *Cluster) GetIdentityProviders() (value *v1.IdentityProviderList, ok boo
 // It provides an internal, integrated container image registry to locally manage images.
 // For non ARO-HCP clusters, it is readonly and always enabled
 func (o *Cluster) ImageRegistry() *ClusterImageRegistry {
-	if o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35] {
+	if o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36] {
 		return o.imageRegistry
 	}
 	return nil
@@ -991,7 +1017,7 @@ func (o *Cluster) ImageRegistry() *ClusterImageRegistry {
 // It provides an internal, integrated container image registry to locally manage images.
 // For non ARO-HCP clusters, it is readonly and always enabled
 func (o *Cluster) GetImageRegistry() (value *ClusterImageRegistry, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35]
+	ok = o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36]
 	if ok {
 		value = o.imageRegistry
 	}
@@ -1003,7 +1029,7 @@ func (o *Cluster) GetImageRegistry() (value *ClusterImageRegistry, ok bool) {
 //
 // List of inflight checks on this cluster.
 func (o *Cluster) InflightChecks() *InflightCheckList {
-	if o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36] {
+	if o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37] {
 		return o.inflightChecks
 	}
 	return nil
@@ -1014,7 +1040,7 @@ func (o *Cluster) InflightChecks() *InflightCheckList {
 //
 // List of inflight checks on this cluster.
 func (o *Cluster) GetInflightChecks() (value *InflightCheckList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36]
+	ok = o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37]
 	if ok {
 		value = o.inflightChecks
 	}
@@ -1026,7 +1052,7 @@ func (o *Cluster) GetInflightChecks() (value *InflightCheckList, ok bool) {
 //
 // InfraID is used for example to name the VPCs.
 func (o *Cluster) InfraID() string {
-	if o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37] {
+	if o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38] {
 		return o.infraID
 	}
 	return ""
@@ -1037,7 +1063,7 @@ func (o *Cluster) InfraID() string {
 //
 // InfraID is used for example to name the VPCs.
 func (o *Cluster) GetInfraID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37]
+	ok = o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38]
 	if ok {
 		value = o.infraID
 	}
@@ -1049,7 +1075,7 @@ func (o *Cluster) GetInfraID() (value string, ok bool) {
 //
 // List of ingresses on this cluster.
 func (o *Cluster) Ingresses() *v1.IngressList {
-	if o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38] {
+	if o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39] {
 		return o.ingresses
 	}
 	return nil
@@ -1060,7 +1086,7 @@ func (o *Cluster) Ingresses() *v1.IngressList {
 //
 // List of ingresses on this cluster.
 func (o *Cluster) GetIngresses() (value *v1.IngressList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38]
+	ok = o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39]
 	if ok {
 		value = o.ingresses
 	}
@@ -1072,7 +1098,7 @@ func (o *Cluster) GetIngresses() (value *v1.IngressList, ok bool) {
 //
 // Details of cluster-wide KubeletConfig
 func (o *Cluster) KubeletConfig() *KubeletConfig {
-	if o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39] {
+	if o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40] {
 		return o.kubeletConfig
 	}
 	return nil
@@ -1083,7 +1109,7 @@ func (o *Cluster) KubeletConfig() *KubeletConfig {
 //
 // Details of cluster-wide KubeletConfig
 func (o *Cluster) GetKubeletConfig() (value *KubeletConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39]
+	ok = o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40]
 	if ok {
 		value = o.kubeletConfig
 	}
@@ -1095,7 +1121,7 @@ func (o *Cluster) GetKubeletConfig() (value *KubeletConfig, ok bool) {
 //
 // Load Balancer quota to be assigned to the cluster.
 func (o *Cluster) LoadBalancerQuota() int {
-	if o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40] {
+	if o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41] {
 		return o.loadBalancerQuota
 	}
 	return 0
@@ -1106,7 +1132,7 @@ func (o *Cluster) LoadBalancerQuota() int {
 //
 // Load Balancer quota to be assigned to the cluster.
 func (o *Cluster) GetLoadBalancerQuota() (value int, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40]
+	ok = o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41]
 	if ok {
 		value = o.loadBalancerQuota
 	}
@@ -1118,7 +1144,7 @@ func (o *Cluster) GetLoadBalancerQuota() (value int, ok bool) {
 //
 // List of machine pools on this cluster.
 func (o *Cluster) MachinePools() *v1.MachinePoolList {
-	if o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41] {
+	if o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42] {
 		return o.machinePools
 	}
 	return nil
@@ -1129,7 +1155,7 @@ func (o *Cluster) MachinePools() *v1.MachinePoolList {
 //
 // List of machine pools on this cluster.
 func (o *Cluster) GetMachinePools() (value *v1.MachinePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41]
+	ok = o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42]
 	if ok {
 		value = o.machinePools
 	}
@@ -1142,7 +1168,7 @@ func (o *Cluster) GetMachinePools() (value *v1.MachinePoolList, ok bool) {
 // Flag indicating if the cluster is managed (by Red Hat) or
 // self-managed by the user.
 func (o *Cluster) Managed() bool {
-	if o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42] {
+	if o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43] {
 		return o.managed
 	}
 	return false
@@ -1154,7 +1180,7 @@ func (o *Cluster) Managed() bool {
 // Flag indicating if the cluster is managed (by Red Hat) or
 // self-managed by the user.
 func (o *Cluster) GetManaged() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42]
+	ok = o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43]
 	if ok {
 		value = o.managed
 	}
@@ -1166,7 +1192,7 @@ func (o *Cluster) GetManaged() (value bool, ok bool) {
 //
 // Contains information about Managed Service
 func (o *Cluster) ManagedService() *ManagedService {
-	if o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43] {
+	if o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44] {
 		return o.managedService
 	}
 	return nil
@@ -1177,7 +1203,7 @@ func (o *Cluster) ManagedService() *ManagedService {
 //
 // Contains information about Managed Service
 func (o *Cluster) GetManagedService() (value *ManagedService, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43]
+	ok = o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44]
 	if ok {
 		value = o.managedService
 	}
@@ -1194,7 +1220,7 @@ func (o *Cluster) GetManagedService() (value *ManagedService, ok bool) {
 // is deployed in multiple availability zones when the Azure region where
 // it is deployed supports multiple availability zones.
 func (o *Cluster) MultiAZ() bool {
-	if o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44] {
+	if o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45] {
 		return o.multiAZ
 	}
 	return false
@@ -1210,7 +1236,7 @@ func (o *Cluster) MultiAZ() bool {
 // is deployed in multiple availability zones when the Azure region where
 // it is deployed supports multiple availability zones.
 func (o *Cluster) GetMultiAZ() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44]
+	ok = o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45]
 	if ok {
 		value = o.multiAZ
 	}
@@ -1222,7 +1248,7 @@ func (o *Cluster) GetMultiAZ() (value bool, ok bool) {
 //
 // Indicate whether the cluster is enabled for multi arch workers
 func (o *Cluster) MultiArchEnabled() bool {
-	if o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45] {
+	if o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46] {
 		return o.multiArchEnabled
 	}
 	return false
@@ -1233,7 +1259,7 @@ func (o *Cluster) MultiArchEnabled() bool {
 //
 // Indicate whether the cluster is enabled for multi arch workers
 func (o *Cluster) GetMultiArchEnabled() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45]
+	ok = o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46]
 	if ok {
 		value = o.multiArchEnabled
 	}
@@ -1246,7 +1272,7 @@ func (o *Cluster) GetMultiArchEnabled() (value bool, ok bool) {
 // Name of the cluster. This name is assigned by the user when the
 // cluster is created. This is used to uniquely identify the cluster
 func (o *Cluster) Name() string {
-	if o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46] {
+	if o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47] {
 		return o.name
 	}
 	return ""
@@ -1258,7 +1284,7 @@ func (o *Cluster) Name() string {
 // Name of the cluster. This name is assigned by the user when the
 // cluster is created. This is used to uniquely identify the cluster
 func (o *Cluster) GetName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46]
+	ok = o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47]
 	if ok {
 		value = o.name
 	}
@@ -1270,7 +1296,7 @@ func (o *Cluster) GetName() (value string, ok bool) {
 //
 // Network settings of the cluster.
 func (o *Cluster) Network() *Network {
-	if o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47] {
+	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
 		return o.network
 	}
 	return nil
@@ -1281,7 +1307,7 @@ func (o *Cluster) Network() *Network {
 //
 // Network settings of the cluster.
 func (o *Cluster) GetNetwork() (value *Network, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47]
+	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
 	if ok {
 		value = o.network
 	}
@@ -1293,7 +1319,7 @@ func (o *Cluster) GetNetwork() (value *Network, ok bool) {
 //
 // Node drain grace period.
 func (o *Cluster) NodeDrainGracePeriod() *Value {
-	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
+	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
 		return o.nodeDrainGracePeriod
 	}
 	return nil
@@ -1304,7 +1330,7 @@ func (o *Cluster) NodeDrainGracePeriod() *Value {
 //
 // Node drain grace period.
 func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
+	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
 	if ok {
 		value = o.nodeDrainGracePeriod
 	}
@@ -1317,7 +1343,7 @@ func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) NodePools() *NodePoolList {
-	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
+	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
 		return o.nodePools
 	}
 	return nil
@@ -1329,7 +1355,7 @@ func (o *Cluster) NodePools() *NodePoolList {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
+	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
 	if ok {
 		value = o.nodePools
 	}
@@ -1341,7 +1367,7 @@ func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) Nodes() *ClusterNodes {
-	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
+	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
 		return o.nodes
 	}
 	return nil
@@ -1352,7 +1378,7 @@ func (o *Cluster) Nodes() *ClusterNodes {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
+	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
 	if ok {
 		value = o.nodes
 	}
@@ -1369,7 +1395,7 @@ func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) OpenshiftVersion() string {
-	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
+	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
 		return o.openshiftVersion
 	}
 	return ""
@@ -1385,7 +1411,7 @@ func (o *Cluster) OpenshiftVersion() string {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
+	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
 	if ok {
 		value = o.openshiftVersion
 	}
@@ -1397,7 +1423,7 @@ func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) Product() *v1.Product {
-	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
+	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
 		return o.product
 	}
 	return nil
@@ -1408,7 +1434,7 @@ func (o *Cluster) Product() *v1.Product {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) GetProduct() (value *v1.Product, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
+	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
 	if ok {
 		value = o.product
 	}
@@ -1420,7 +1446,7 @@ func (o *Cluster) GetProduct() (value *v1.Product, ok bool) {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) Properties() map[string]string {
-	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
+	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
 		return o.properties
 	}
 	return nil
@@ -1431,7 +1457,7 @@ func (o *Cluster) Properties() map[string]string {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
+	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
 	if ok {
 		value = o.properties
 	}
@@ -1443,7 +1469,7 @@ func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) ProvisionShard() *ProvisionShard {
-	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
+	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
 		return o.provisionShard
 	}
 	return nil
@@ -1454,7 +1480,7 @@ func (o *Cluster) ProvisionShard() *ProvisionShard {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
+	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
 	if ok {
 		value = o.provisionShard
 	}
@@ -1466,7 +1492,7 @@ func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
 //
 // Proxy.
 func (o *Cluster) Proxy() *Proxy {
-	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
+	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
 		return o.proxy
 	}
 	return nil
@@ -1477,7 +1503,7 @@ func (o *Cluster) Proxy() *Proxy {
 //
 // Proxy.
 func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
+	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
 	if ok {
 		value = o.proxy
 	}
@@ -1489,7 +1515,7 @@ func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) Region() *v1.CloudRegion {
-	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
+	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
 		return o.region
 	}
 	return nil
@@ -1500,7 +1526,7 @@ func (o *Cluster) Region() *v1.CloudRegion {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) GetRegion() (value *v1.CloudRegion, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
+	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
 	if ok {
 		value = o.region
 	}
@@ -1512,7 +1538,7 @@ func (o *Cluster) GetRegion() (value *v1.CloudRegion, ok bool) {
 //
 // External registry configuration for the cluster
 func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
-	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
+	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
 		return o.registryConfig
 	}
 	return nil
@@ -1523,7 +1549,7 @@ func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
 //
 // External registry configuration for the cluster
 func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
+	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
 	if ok {
 		value = o.registryConfig
 	}
@@ -1535,7 +1561,7 @@ func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
 //
 // Overall state of the cluster.
 func (o *Cluster) State() ClusterState {
-	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
+	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
 		return o.state
 	}
 	return ClusterState("")
@@ -1546,7 +1572,7 @@ func (o *Cluster) State() ClusterState {
 //
 // Overall state of the cluster.
 func (o *Cluster) GetState() (value ClusterState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
+	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
 	if ok {
 		value = o.state
 	}
@@ -1558,7 +1584,7 @@ func (o *Cluster) GetState() (value ClusterState, ok bool) {
 //
 // Status of cluster
 func (o *Cluster) Status() *ClusterStatus {
-	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
+	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
 		return o.status
 	}
 	return nil
@@ -1569,7 +1595,7 @@ func (o *Cluster) Status() *ClusterStatus {
 //
 // Status of cluster
 func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
+	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
 	if ok {
 		value = o.status
 	}
@@ -1581,7 +1607,7 @@ func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) StorageQuota() *Value {
-	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
+	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
 		return o.storageQuota
 	}
 	return nil
@@ -1592,7 +1618,7 @@ func (o *Cluster) StorageQuota() *Value {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
+	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
 	if ok {
 		value = o.storageQuota
 	}
@@ -1605,7 +1631,7 @@ func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) Subscription() *v1.Subscription {
-	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
+	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
 		return o.subscription
 	}
 	return nil
@@ -1617,7 +1643,7 @@ func (o *Cluster) Subscription() *v1.Subscription {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) GetSubscription() (value *v1.Subscription, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
+	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
 	if ok {
 		value = o.subscription
 	}
@@ -1629,7 +1655,7 @@ func (o *Cluster) GetSubscription() (value *v1.Subscription, ok bool) {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) Version() *Version {
-	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
+	if o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63] {
 		return o.version
 	}
 	return nil
@@ -1640,7 +1666,7 @@ func (o *Cluster) Version() *Version {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) GetVersion() (value *Version, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
+	ok = o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63]
 	if ok {
 		value = o.version
 	}

--- a/clientapi/arohcp/v1alpha1/cluster_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type_json.go
@@ -173,7 +173,16 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14] && object.autoscaler != nil
+	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14] && object.autoNode != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("auto_node")
+		WriteClusterAutoNode(object.autoNode, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15] && object.autoscaler != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -182,7 +191,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		v1.WriteClusterAutoscaler(object.autoscaler, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15] && object.azure != nil
+	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16] && object.azure != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -191,7 +200,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteAzure(object.azure, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16]
+	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -200,7 +209,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.billingModel))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17] && object.byoOidc != nil
+	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18] && object.byoOidc != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -209,7 +218,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteByoOidc(object.byoOidc, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18] && object.cloudProvider != nil
+	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.cloudProvider != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -218,7 +227,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		v1.WriteCloudProvider(object.cloudProvider, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.console != nil
+	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.console != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -227,7 +236,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterConsole(object.console, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20]
+	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -236,7 +245,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString((object.creationTimestamp).Format(time.RFC3339))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21] && object.deleteProtection != nil
+	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22] && object.deleteProtection != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -245,7 +254,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteDeleteProtection(object.deleteProtection, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22]
+	present_ = len(object.fieldSet_) > 23 && object.fieldSet_[23]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -254,7 +263,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.disableUserWorkloadMonitoring)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 23 && object.fieldSet_[23]
+	present_ = len(object.fieldSet_) > 24 && object.fieldSet_[24]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -263,7 +272,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.domainPrefix)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 24 && object.fieldSet_[24]
+	present_ = len(object.fieldSet_) > 25 && object.fieldSet_[25]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -272,7 +281,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.etcdEncryption)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 25 && object.fieldSet_[25]
+	present_ = len(object.fieldSet_) > 26 && object.fieldSet_[26]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -281,7 +290,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString((object.expirationTimestamp).Format(time.RFC3339))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 26 && object.fieldSet_[26]
+	present_ = len(object.fieldSet_) > 27 && object.fieldSet_[27]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -290,7 +299,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.externalID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 27 && object.fieldSet_[27] && object.externalAuthConfig != nil
+	present_ = len(object.fieldSet_) > 28 && object.fieldSet_[28] && object.externalAuthConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -299,7 +308,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteExternalAuthConfig(object.externalAuthConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 28 && object.fieldSet_[28] && object.externalConfiguration != nil
+	present_ = len(object.fieldSet_) > 29 && object.fieldSet_[29] && object.externalConfiguration != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -308,7 +317,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteExternalConfiguration(object.externalConfiguration, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 29 && object.fieldSet_[29] && object.flavour != nil
+	present_ = len(object.fieldSet_) > 30 && object.fieldSet_[30] && object.flavour != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -317,7 +326,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		v1.WriteFlavour(object.flavour, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 30 && object.fieldSet_[30] && object.groups != nil
+	present_ = len(object.fieldSet_) > 31 && object.fieldSet_[31] && object.groups != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -329,7 +338,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 31 && object.fieldSet_[31]
+	present_ = len(object.fieldSet_) > 32 && object.fieldSet_[32]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -338,7 +347,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.healthState))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 32 && object.fieldSet_[32] && object.htpasswd != nil
+	present_ = len(object.fieldSet_) > 33 && object.fieldSet_[33] && object.htpasswd != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -347,7 +356,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteHTPasswdIdentityProvider(object.htpasswd, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 33 && object.fieldSet_[33] && object.hypershift != nil
+	present_ = len(object.fieldSet_) > 34 && object.fieldSet_[34] && object.hypershift != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -356,7 +365,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteHypershift(object.hypershift, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 34 && object.fieldSet_[34] && object.identityProviders != nil
+	present_ = len(object.fieldSet_) > 35 && object.fieldSet_[35] && object.identityProviders != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -368,7 +377,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 35 && object.fieldSet_[35] && object.imageRegistry != nil
+	present_ = len(object.fieldSet_) > 36 && object.fieldSet_[36] && object.imageRegistry != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -377,7 +386,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterImageRegistry(object.imageRegistry, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 36 && object.fieldSet_[36] && object.inflightChecks != nil
+	present_ = len(object.fieldSet_) > 37 && object.fieldSet_[37] && object.inflightChecks != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -389,7 +398,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 37 && object.fieldSet_[37]
+	present_ = len(object.fieldSet_) > 38 && object.fieldSet_[38]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -398,7 +407,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.infraID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 38 && object.fieldSet_[38] && object.ingresses != nil
+	present_ = len(object.fieldSet_) > 39 && object.fieldSet_[39] && object.ingresses != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -410,7 +419,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 39 && object.fieldSet_[39] && object.kubeletConfig != nil
+	present_ = len(object.fieldSet_) > 40 && object.fieldSet_[40] && object.kubeletConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -419,7 +428,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteKubeletConfig(object.kubeletConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 40 && object.fieldSet_[40]
+	present_ = len(object.fieldSet_) > 41 && object.fieldSet_[41]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -428,7 +437,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteInt(object.loadBalancerQuota)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 41 && object.fieldSet_[41] && object.machinePools != nil
+	present_ = len(object.fieldSet_) > 42 && object.fieldSet_[42] && object.machinePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -440,7 +449,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 42 && object.fieldSet_[42]
+	present_ = len(object.fieldSet_) > 43 && object.fieldSet_[43]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -449,7 +458,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.managed)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 43 && object.fieldSet_[43] && object.managedService != nil
+	present_ = len(object.fieldSet_) > 44 && object.fieldSet_[44] && object.managedService != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -458,7 +467,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteManagedService(object.managedService, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 44 && object.fieldSet_[44]
+	present_ = len(object.fieldSet_) > 45 && object.fieldSet_[45]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -467,7 +476,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.multiAZ)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 45 && object.fieldSet_[45]
+	present_ = len(object.fieldSet_) > 46 && object.fieldSet_[46]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -476,7 +485,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.multiArchEnabled)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 46 && object.fieldSet_[46]
+	present_ = len(object.fieldSet_) > 47 && object.fieldSet_[47]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -485,7 +494,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.name)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 47 && object.fieldSet_[47] && object.network != nil
+	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48] && object.network != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -494,7 +503,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteNetwork(object.network, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48] && object.nodeDrainGracePeriod != nil
+	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49] && object.nodeDrainGracePeriod != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -503,7 +512,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.nodeDrainGracePeriod, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49] && object.nodePools != nil
+	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.nodePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -515,7 +524,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.nodes != nil
+	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51] && object.nodes != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -524,7 +533,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterNodes(object.nodes, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51]
+	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -533,7 +542,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.openshiftVersion)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52] && object.product != nil
+	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.product != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -542,7 +551,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		v1.WriteProduct(object.product, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.properties != nil
+	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.properties != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -571,7 +580,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.provisionShard != nil
+	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.provisionShard != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -580,7 +589,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProvisionShard(object.provisionShard, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.proxy != nil
+	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.proxy != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -589,7 +598,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProxy(object.proxy, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.region != nil
+	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.region != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -598,7 +607,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		v1.WriteCloudRegion(object.region, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.registryConfig != nil
+	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58] && object.registryConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -607,7 +616,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterRegistryConfig(object.registryConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58]
+	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -616,7 +625,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.state))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59] && object.status != nil
+	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.status != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -625,7 +634,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterStatus(object.status, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.storageQuota != nil
+	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.storageQuota != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -634,7 +643,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.storageQuota, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.subscription != nil
+	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.subscription != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -643,7 +652,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		v1.WriteSubscription(object.subscription, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.version != nil
+	present_ = len(object.fieldSet_) > 63 && object.fieldSet_[63] && object.version != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -669,7 +678,7 @@ func UnmarshalCluster(source interface{}) (object *Cluster, err error) {
 // ReadCluster reads a value of the 'cluster' type from the given iterator.
 func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 	object := &Cluster{
-		fieldSet_: make([]bool, 63),
+		fieldSet_: make([]bool, 64),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -766,31 +775,35 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 			}
 			object.addons = value
 			object.fieldSet_[13] = true
+		case "auto_node":
+			value := ReadClusterAutoNode(iterator)
+			object.autoNode = value
+			object.fieldSet_[14] = true
 		case "autoscaler":
 			value := v1.ReadClusterAutoscaler(iterator)
 			object.autoscaler = value
-			object.fieldSet_[14] = true
+			object.fieldSet_[15] = true
 		case "azure":
 			value := ReadAzure(iterator)
 			object.azure = value
-			object.fieldSet_[15] = true
+			object.fieldSet_[16] = true
 		case "billing_model":
 			text := iterator.ReadString()
 			value := BillingModel(text)
 			object.billingModel = value
-			object.fieldSet_[16] = true
+			object.fieldSet_[17] = true
 		case "byo_oidc":
 			value := ReadByoOidc(iterator)
 			object.byoOidc = value
-			object.fieldSet_[17] = true
+			object.fieldSet_[18] = true
 		case "cloud_provider":
 			value := v1.ReadCloudProvider(iterator)
 			object.cloudProvider = value
-			object.fieldSet_[18] = true
+			object.fieldSet_[19] = true
 		case "console":
 			value := ReadClusterConsole(iterator)
 			object.console = value
-			object.fieldSet_[19] = true
+			object.fieldSet_[20] = true
 		case "creation_timestamp":
 			text := iterator.ReadString()
 			value, err := time.Parse(time.RFC3339, text)
@@ -798,23 +811,23 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				iterator.ReportError("", err.Error())
 			}
 			object.creationTimestamp = value
-			object.fieldSet_[20] = true
+			object.fieldSet_[21] = true
 		case "delete_protection":
 			value := ReadDeleteProtection(iterator)
 			object.deleteProtection = value
-			object.fieldSet_[21] = true
+			object.fieldSet_[22] = true
 		case "disable_user_workload_monitoring":
 			value := iterator.ReadBool()
 			object.disableUserWorkloadMonitoring = value
-			object.fieldSet_[22] = true
+			object.fieldSet_[23] = true
 		case "domain_prefix":
 			value := iterator.ReadString()
 			object.domainPrefix = value
-			object.fieldSet_[23] = true
+			object.fieldSet_[24] = true
 		case "etcd_encryption":
 			value := iterator.ReadBool()
 			object.etcdEncryption = value
-			object.fieldSet_[24] = true
+			object.fieldSet_[25] = true
 		case "expiration_timestamp":
 			text := iterator.ReadString()
 			value, err := time.Parse(time.RFC3339, text)
@@ -822,23 +835,23 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				iterator.ReportError("", err.Error())
 			}
 			object.expirationTimestamp = value
-			object.fieldSet_[25] = true
+			object.fieldSet_[26] = true
 		case "external_id":
 			value := iterator.ReadString()
 			object.externalID = value
-			object.fieldSet_[26] = true
+			object.fieldSet_[27] = true
 		case "external_auth_config":
 			value := ReadExternalAuthConfig(iterator)
 			object.externalAuthConfig = value
-			object.fieldSet_[27] = true
+			object.fieldSet_[28] = true
 		case "external_configuration":
 			value := ReadExternalConfiguration(iterator)
 			object.externalConfiguration = value
-			object.fieldSet_[28] = true
+			object.fieldSet_[29] = true
 		case "flavour":
 			value := v1.ReadFlavour(iterator)
 			object.flavour = value
-			object.fieldSet_[29] = true
+			object.fieldSet_[30] = true
 		case "groups":
 			value := &v1.GroupList{}
 			for {
@@ -859,20 +872,20 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.groups = value
-			object.fieldSet_[30] = true
+			object.fieldSet_[31] = true
 		case "health_state":
 			text := iterator.ReadString()
 			value := ClusterHealthState(text)
 			object.healthState = value
-			object.fieldSet_[31] = true
+			object.fieldSet_[32] = true
 		case "htpasswd":
 			value := ReadHTPasswdIdentityProvider(iterator)
 			object.htpasswd = value
-			object.fieldSet_[32] = true
+			object.fieldSet_[33] = true
 		case "hypershift":
 			value := ReadHypershift(iterator)
 			object.hypershift = value
-			object.fieldSet_[33] = true
+			object.fieldSet_[34] = true
 		case "identity_providers":
 			value := &v1.IdentityProviderList{}
 			for {
@@ -893,11 +906,11 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.identityProviders = value
-			object.fieldSet_[34] = true
+			object.fieldSet_[35] = true
 		case "image_registry":
 			value := ReadClusterImageRegistry(iterator)
 			object.imageRegistry = value
-			object.fieldSet_[35] = true
+			object.fieldSet_[36] = true
 		case "inflight_checks":
 			value := &InflightCheckList{}
 			for {
@@ -918,11 +931,11 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.inflightChecks = value
-			object.fieldSet_[36] = true
+			object.fieldSet_[37] = true
 		case "infra_id":
 			value := iterator.ReadString()
 			object.infraID = value
-			object.fieldSet_[37] = true
+			object.fieldSet_[38] = true
 		case "ingresses":
 			value := &v1.IngressList{}
 			for {
@@ -943,15 +956,15 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.ingresses = value
-			object.fieldSet_[38] = true
+			object.fieldSet_[39] = true
 		case "kubelet_config":
 			value := ReadKubeletConfig(iterator)
 			object.kubeletConfig = value
-			object.fieldSet_[39] = true
+			object.fieldSet_[40] = true
 		case "load_balancer_quota":
 			value := iterator.ReadInt()
 			object.loadBalancerQuota = value
-			object.fieldSet_[40] = true
+			object.fieldSet_[41] = true
 		case "machine_pools":
 			value := &v1.MachinePoolList{}
 			for {
@@ -972,35 +985,35 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.machinePools = value
-			object.fieldSet_[41] = true
+			object.fieldSet_[42] = true
 		case "managed":
 			value := iterator.ReadBool()
 			object.managed = value
-			object.fieldSet_[42] = true
+			object.fieldSet_[43] = true
 		case "managed_service":
 			value := ReadManagedService(iterator)
 			object.managedService = value
-			object.fieldSet_[43] = true
+			object.fieldSet_[44] = true
 		case "multi_az":
 			value := iterator.ReadBool()
 			object.multiAZ = value
-			object.fieldSet_[44] = true
+			object.fieldSet_[45] = true
 		case "multi_arch_enabled":
 			value := iterator.ReadBool()
 			object.multiArchEnabled = value
-			object.fieldSet_[45] = true
+			object.fieldSet_[46] = true
 		case "name":
 			value := iterator.ReadString()
 			object.name = value
-			object.fieldSet_[46] = true
+			object.fieldSet_[47] = true
 		case "network":
 			value := ReadNetwork(iterator)
 			object.network = value
-			object.fieldSet_[47] = true
+			object.fieldSet_[48] = true
 		case "node_drain_grace_period":
 			value := ReadValue(iterator)
 			object.nodeDrainGracePeriod = value
-			object.fieldSet_[48] = true
+			object.fieldSet_[49] = true
 		case "node_pools":
 			value := &NodePoolList{}
 			for {
@@ -1021,19 +1034,19 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.nodePools = value
-			object.fieldSet_[49] = true
+			object.fieldSet_[50] = true
 		case "nodes":
 			value := ReadClusterNodes(iterator)
 			object.nodes = value
-			object.fieldSet_[50] = true
+			object.fieldSet_[51] = true
 		case "openshift_version":
 			value := iterator.ReadString()
 			object.openshiftVersion = value
-			object.fieldSet_[51] = true
+			object.fieldSet_[52] = true
 		case "product":
 			value := v1.ReadProduct(iterator)
 			object.product = value
-			object.fieldSet_[52] = true
+			object.fieldSet_[53] = true
 		case "properties":
 			value := map[string]string{}
 			for {
@@ -1045,44 +1058,44 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				value[key] = item
 			}
 			object.properties = value
-			object.fieldSet_[53] = true
+			object.fieldSet_[54] = true
 		case "provision_shard":
 			value := ReadProvisionShard(iterator)
 			object.provisionShard = value
-			object.fieldSet_[54] = true
+			object.fieldSet_[55] = true
 		case "proxy":
 			value := ReadProxy(iterator)
 			object.proxy = value
-			object.fieldSet_[55] = true
+			object.fieldSet_[56] = true
 		case "region":
 			value := v1.ReadCloudRegion(iterator)
 			object.region = value
-			object.fieldSet_[56] = true
+			object.fieldSet_[57] = true
 		case "registry_config":
 			value := ReadClusterRegistryConfig(iterator)
 			object.registryConfig = value
-			object.fieldSet_[57] = true
+			object.fieldSet_[58] = true
 		case "state":
 			text := iterator.ReadString()
 			value := ClusterState(text)
 			object.state = value
-			object.fieldSet_[58] = true
+			object.fieldSet_[59] = true
 		case "status":
 			value := ReadClusterStatus(iterator)
 			object.status = value
-			object.fieldSet_[59] = true
+			object.fieldSet_[60] = true
 		case "storage_quota":
 			value := ReadValue(iterator)
 			object.storageQuota = value
-			object.fieldSet_[60] = true
+			object.fieldSet_[61] = true
 		case "subscription":
 			value := v1.ReadSubscription(iterator)
 			object.subscription = value
-			object.fieldSet_[61] = true
+			object.fieldSet_[62] = true
 		case "version":
 			value := ReadVersion(iterator)
 			object.version = value
-			object.fieldSet_[62] = true
+			object.fieldSet_[63] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/aws_auto_node_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_auto_node_builder.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+type AwsAutoNodeBuilder struct {
+	fieldSet_ []bool
+	roleArn   string
+}
+
+// NewAwsAutoNode creates a new builder of 'aws_auto_node' objects.
+func NewAwsAutoNode() *AwsAutoNodeBuilder {
+	return &AwsAutoNodeBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AwsAutoNodeBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// RoleArn sets the value of the 'role_arn' attribute to the given value.
+func (b *AwsAutoNodeBuilder) RoleArn(value string) *AwsAutoNodeBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.roleArn = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AwsAutoNodeBuilder) Copy(object *AwsAutoNode) *AwsAutoNodeBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.roleArn = object.roleArn
+	return b
+}
+
+// Build creates a 'aws_auto_node' object using the configuration stored in the builder.
+func (b *AwsAutoNodeBuilder) Build() (object *AwsAutoNode, err error) {
+	object = new(AwsAutoNode)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.roleArn = b.roleArn
+	return
+}

--- a/clientapi/clustersmgmt/v1/aws_auto_node_list_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_auto_node_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AwsAutoNodeListBuilder contains the data and logic needed to build
+// 'aws_auto_node' objects.
+type AwsAutoNodeListBuilder struct {
+	items []*AwsAutoNodeBuilder
+}
+
+// NewAwsAutoNodeList creates a new builder of 'aws_auto_node' objects.
+func NewAwsAutoNodeList() *AwsAutoNodeListBuilder {
+	return new(AwsAutoNodeListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AwsAutoNodeListBuilder) Items(values ...*AwsAutoNodeBuilder) *AwsAutoNodeListBuilder {
+	b.items = make([]*AwsAutoNodeBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AwsAutoNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AwsAutoNodeListBuilder) Copy(list *AwsAutoNodeList) *AwsAutoNodeListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AwsAutoNodeBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAwsAutoNode().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'aws_auto_node' objects using the
+// configuration stored in the builder.
+func (b *AwsAutoNodeListBuilder) Build() (list *AwsAutoNodeList, err error) {
+	items := make([]*AwsAutoNode, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AwsAutoNodeList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/aws_auto_node_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_auto_node_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAwsAutoNodeList writes a list of values of the 'aws_auto_node' type to
+// the given writer.
+func MarshalAwsAutoNodeList(list []*AwsAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAwsAutoNodeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAwsAutoNodeList writes a list of value of the 'aws_auto_node' type to
+// the given stream.
+func WriteAwsAutoNodeList(list []*AwsAutoNode, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAwsAutoNode(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAwsAutoNodeList reads a list of values of the 'aws_auto_node' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAwsAutoNodeList(source interface{}) (items []*AwsAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAwsAutoNodeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAwsAutoNodeList reads list of values of the ”aws_auto_node' type from
+// the given iterator.
+func ReadAwsAutoNodeList(iterator *jsoniter.Iterator) []*AwsAutoNode {
+	list := []*AwsAutoNode{}
+	for iterator.ReadArray() {
+		item := ReadAwsAutoNode(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/aws_auto_node_type.go
+++ b/clientapi/clustersmgmt/v1/aws_auto_node_type.go
@@ -1,0 +1,177 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AwsAutoNode represents the values of the 'aws_auto_node' type.
+//
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+type AwsAutoNode struct {
+	fieldSet_ []bool
+	roleArn   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AwsAutoNode) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// RoleArn returns the value of the 'role_arn' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+// controller.
+// The role must exist prior to enabling AutoNode on the cluster.
+func (o *AwsAutoNode) RoleArn() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.roleArn
+	}
+	return ""
+}
+
+// GetRoleArn returns the value of the 'role_arn' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+// controller.
+// The role must exist prior to enabling AutoNode on the cluster.
+func (o *AwsAutoNode) GetRoleArn() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.roleArn
+	}
+	return
+}
+
+// AwsAutoNodeListKind is the name of the type used to represent list of objects of
+// type 'aws_auto_node'.
+const AwsAutoNodeListKind = "AwsAutoNodeList"
+
+// AwsAutoNodeListLinkKind is the name of the type used to represent links to list
+// of objects of type 'aws_auto_node'.
+const AwsAutoNodeListLinkKind = "AwsAutoNodeListLink"
+
+// AwsAutoNodeNilKind is the name of the type used to nil lists of objects of
+// type 'aws_auto_node'.
+const AwsAutoNodeListNilKind = "AwsAutoNodeListNil"
+
+// AwsAutoNodeList is a list of values of the 'aws_auto_node' type.
+type AwsAutoNodeList struct {
+	href  string
+	link  bool
+	items []*AwsAutoNode
+}
+
+// Len returns the length of the list.
+func (l *AwsAutoNodeList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AwsAutoNodeList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AwsAutoNodeList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AwsAutoNodeList) SetItems(items []*AwsAutoNode) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AwsAutoNodeList) Items() []*AwsAutoNode {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AwsAutoNodeList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AwsAutoNodeList) Get(i int) *AwsAutoNode {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AwsAutoNodeList) Slice() []*AwsAutoNode {
+	var slice []*AwsAutoNode
+	if l == nil {
+		slice = make([]*AwsAutoNode, 0)
+	} else {
+		slice = make([]*AwsAutoNode, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AwsAutoNodeList) Each(f func(item *AwsAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AwsAutoNodeList) Range(f func(index int, item *AwsAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/aws_auto_node_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_auto_node_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAwsAutoNode writes a value of the 'aws_auto_node' type to the given writer.
+func MarshalAwsAutoNode(object *AwsAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAwsAutoNode(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAwsAutoNode writes a value of the 'aws_auto_node' type to the given stream.
+func WriteAwsAutoNode(object *AwsAutoNode, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("role_arn")
+		stream.WriteString(object.roleArn)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAwsAutoNode reads a value of the 'aws_auto_node' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAwsAutoNode(source interface{}) (object *AwsAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAwsAutoNode(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAwsAutoNode reads a value of the 'aws_auto_node' type from the given iterator.
+func ReadAwsAutoNode(iterator *jsoniter.Iterator) *AwsAutoNode {
+	object := &AwsAutoNode{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "role_arn":
+			value := iterator.ReadString()
+			object.roleArn = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/aws_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_builder.go
@@ -31,6 +31,7 @@ type AWSBuilder struct {
 	additionalControlPlaneSecurityGroupIds []string
 	additionalInfraSecurityGroupIds        []string
 	auditLog                               *AuditLogBuilder
+	autoNode                               *AwsAutoNodeBuilder
 	billingAccountID                       string
 	ec2MetadataHttpTokens                  Ec2MetadataHttpTokens
 	etcdEncryption                         *AwsEtcdEncryptionBuilder
@@ -48,7 +49,7 @@ type AWSBuilder struct {
 // NewAWS creates a new builder of 'AWS' objects.
 func NewAWS() *AWSBuilder {
 	return &AWSBuilder{
-		fieldSet_: make([]bool, 21),
+		fieldSet_: make([]bool, 22),
 	}
 }
 
@@ -68,7 +69,7 @@ func (b *AWSBuilder) Empty() bool {
 // KMSKeyArn sets the value of the 'KMS_key_arn' attribute to the given value.
 func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.kmsKeyArn = value
 	b.fieldSet_[0] = true
@@ -80,7 +81,7 @@ func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.sts = value
 	if value != nil {
@@ -94,7 +95,7 @@ func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 // AccessKeyID sets the value of the 'access_key_ID' attribute to the given value.
 func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.accessKeyID = value
 	b.fieldSet_[2] = true
@@ -104,7 +105,7 @@ func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 // AccountID sets the value of the 'account_ID' attribute to the given value.
 func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.accountID = value
 	b.fieldSet_[3] = true
@@ -114,7 +115,7 @@ func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 // AdditionalAllowedPrincipals sets the value of the 'additional_allowed_principals' attribute to the given values.
 func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalAllowedPrincipals = make([]string, len(values))
 	copy(b.additionalAllowedPrincipals, values)
@@ -125,7 +126,7 @@ func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 // AdditionalComputeSecurityGroupIds sets the value of the 'additional_compute_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalComputeSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalComputeSecurityGroupIds, values)
@@ -136,7 +137,7 @@ func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBui
 // AdditionalControlPlaneSecurityGroupIds sets the value of the 'additional_control_plane_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalControlPlaneSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalControlPlaneSecurityGroupIds, values)
@@ -147,7 +148,7 @@ func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *A
 // AdditionalInfraSecurityGroupIds sets the value of the 'additional_infra_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.additionalInfraSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalInfraSecurityGroupIds, values)
@@ -160,7 +161,7 @@ func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuild
 // Contains the necessary attributes to support audit log forwarding
 func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.auditLog = value
 	if value != nil {
@@ -171,13 +172,29 @@ func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 	return b
 }
 
+// AutoNode sets the value of the 'auto_node' attribute to the given value.
+//
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+func (b *AWSBuilder) AutoNode(value *AwsAutoNodeBuilder) *AWSBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 22)
+	}
+	b.autoNode = value
+	if value != nil {
+		b.fieldSet_[9] = true
+	} else {
+		b.fieldSet_[9] = false
+	}
+	return b
+}
+
 // BillingAccountID sets the value of the 'billing_account_ID' attribute to the given value.
 func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.billingAccountID = value
-	b.fieldSet_[9] = true
+	b.fieldSet_[10] = true
 	return b
 }
 
@@ -186,10 +203,10 @@ func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.ec2MetadataHttpTokens = value
-	b.fieldSet_[10] = true
+	b.fieldSet_[11] = true
 	return b
 }
 
@@ -198,13 +215,13 @@ func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuil
 // Contains the necessary attributes to support etcd encryption for AWS based clusters.
 func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.etcdEncryption = value
 	if value != nil {
-		b.fieldSet_[11] = true
+		b.fieldSet_[12] = true
 	} else {
-		b.fieldSet_[11] = false
+		b.fieldSet_[12] = false
 	}
 	return b
 }
@@ -212,40 +229,40 @@ func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder
 // HcpInternalCommunicationHostedZoneId sets the value of the 'hcp_internal_communication_hosted_zone_id' attribute to the given value.
 func (b *AWSBuilder) HcpInternalCommunicationHostedZoneId(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.hcpInternalCommunicationHostedZoneId = value
-	b.fieldSet_[12] = true
+	b.fieldSet_[13] = true
 	return b
 }
 
 // PrivateHostedZoneID sets the value of the 'private_hosted_zone_ID' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateHostedZoneID = value
-	b.fieldSet_[13] = true
+	b.fieldSet_[14] = true
 	return b
 }
 
 // PrivateHostedZoneRoleARN sets the value of the 'private_hosted_zone_role_ARN' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneRoleARN(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateHostedZoneRoleARN = value
-	b.fieldSet_[14] = true
+	b.fieldSet_[15] = true
 	return b
 }
 
 // PrivateLink sets the value of the 'private_link' attribute to the given value.
 func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateLink = value
-	b.fieldSet_[15] = true
+	b.fieldSet_[16] = true
 	return b
 }
 
@@ -254,13 +271,13 @@ func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 // Manages the configuration for the Private Links.
 func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigurationBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.privateLinkConfiguration = value
 	if value != nil {
-		b.fieldSet_[16] = true
+		b.fieldSet_[17] = true
 	} else {
-		b.fieldSet_[16] = false
+		b.fieldSet_[17] = false
 	}
 	return b
 }
@@ -268,34 +285,34 @@ func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigura
 // SecretAccessKey sets the value of the 'secret_access_key' attribute to the given value.
 func (b *AWSBuilder) SecretAccessKey(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.secretAccessKey = value
-	b.fieldSet_[17] = true
+	b.fieldSet_[18] = true
 	return b
 }
 
 // SubnetIDs sets the value of the 'subnet_IDs' attribute to the given values.
 func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.subnetIDs = make([]string, len(values))
 	copy(b.subnetIDs, values)
-	b.fieldSet_[18] = true
+	b.fieldSet_[19] = true
 	return b
 }
 
 // Tags sets the value of the 'tags' attribute to the given value.
 func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.tags = value
 	if value != nil {
-		b.fieldSet_[19] = true
+		b.fieldSet_[20] = true
 	} else {
-		b.fieldSet_[19] = false
+		b.fieldSet_[20] = false
 	}
 	return b
 }
@@ -303,10 +320,10 @@ func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 // VpcEndpointRoleArn sets the value of the 'vpc_endpoint_role_arn' attribute to the given value.
 func (b *AWSBuilder) VpcEndpointRoleArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 21)
+		b.fieldSet_ = make([]bool, 22)
 	}
 	b.vpcEndpointRoleArn = value
-	b.fieldSet_[20] = true
+	b.fieldSet_[21] = true
 	return b
 }
 
@@ -355,6 +372,11 @@ func (b *AWSBuilder) Copy(object *AWS) *AWSBuilder {
 		b.auditLog = NewAuditLog().Copy(object.auditLog)
 	} else {
 		b.auditLog = nil
+	}
+	if object.autoNode != nil {
+		b.autoNode = NewAwsAutoNode().Copy(object.autoNode)
+	} else {
+		b.autoNode = nil
 	}
 	b.billingAccountID = object.billingAccountID
 	b.ec2MetadataHttpTokens = object.ec2MetadataHttpTokens
@@ -425,6 +447,12 @@ func (b *AWSBuilder) Build() (object *AWS, err error) {
 	}
 	if b.auditLog != nil {
 		object.auditLog, err = b.auditLog.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.autoNode != nil {
+		object.autoNode, err = b.autoNode.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/clustersmgmt/v1/aws_type.go
+++ b/clientapi/clustersmgmt/v1/aws_type.go
@@ -33,6 +33,7 @@ type AWS struct {
 	additionalControlPlaneSecurityGroupIds []string
 	additionalInfraSecurityGroupIds        []string
 	auditLog                               *AuditLog
+	autoNode                               *AwsAutoNode
 	billingAccountID                       string
 	ec2MetadataHttpTokens                  Ec2MetadataHttpTokens
 	etcdEncryption                         *AwsEtcdEncryption
@@ -267,12 +268,35 @@ func (o *AWS) GetAuditLog() (value *AuditLog, ok bool) {
 	return
 }
 
+// AutoNode returns the value of the 'auto_node' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// AWS specific configuration for AutoNode
+func (o *AWS) AutoNode() *AwsAutoNode {
+	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+		return o.autoNode
+	}
+	return nil
+}
+
+// GetAutoNode returns the value of the 'auto_node' attribute and
+// a flag indicating if the attribute has a value.
+//
+// AWS specific configuration for AutoNode
+func (o *AWS) GetAutoNode() (value *AwsAutoNode, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	if ok {
+		value = o.autoNode
+	}
+	return
+}
+
 // BillingAccountID returns the value of the 'billing_account_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // BillingAccountID is the account used for billing subscriptions purchased via the marketplace
 func (o *AWS) BillingAccountID() string {
-	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
 		return o.billingAccountID
 	}
 	return ""
@@ -283,7 +307,7 @@ func (o *AWS) BillingAccountID() string {
 //
 // BillingAccountID is the account used for billing subscriptions purchased via the marketplace
 func (o *AWS) GetBillingAccountID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
 	if ok {
 		value = o.billingAccountID
 	}
@@ -295,7 +319,7 @@ func (o *AWS) GetBillingAccountID() (value string, ok bool) {
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWS) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.ec2MetadataHttpTokens
 	}
 	return Ec2MetadataHttpTokens("")
@@ -306,7 +330,7 @@ func (o *AWS) Ec2MetadataHttpTokens() Ec2MetadataHttpTokens {
 //
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (o *AWS) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.ec2MetadataHttpTokens
 	}
@@ -318,7 +342,7 @@ func (o *AWS) GetEc2MetadataHttpTokens() (value Ec2MetadataHttpTokens, ok bool) 
 //
 // Related etcd encryption configuration
 func (o *AWS) EtcdEncryption() *AwsEtcdEncryption {
-	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
+	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
 		return o.etcdEncryption
 	}
 	return nil
@@ -329,7 +353,7 @@ func (o *AWS) EtcdEncryption() *AwsEtcdEncryption {
 //
 // Related etcd encryption configuration
 func (o *AWS) GetEtcdEncryption() (value *AwsEtcdEncryption, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
+	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
 	if ok {
 		value = o.etcdEncryption
 	}
@@ -341,7 +365,7 @@ func (o *AWS) GetEtcdEncryption() (value *AwsEtcdEncryption, ok bool) {
 //
 // ID of local private hosted zone for hypershift internal communication.
 func (o *AWS) HcpInternalCommunicationHostedZoneId() string {
-	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
+	if o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13] {
 		return o.hcpInternalCommunicationHostedZoneId
 	}
 	return ""
@@ -352,7 +376,7 @@ func (o *AWS) HcpInternalCommunicationHostedZoneId() string {
 //
 // ID of local private hosted zone for hypershift internal communication.
 func (o *AWS) GetHcpInternalCommunicationHostedZoneId() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
+	ok = o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13]
 	if ok {
 		value = o.hcpInternalCommunicationHostedZoneId
 	}
@@ -364,7 +388,7 @@ func (o *AWS) GetHcpInternalCommunicationHostedZoneId() (value string, ok bool) 
 //
 // ID of private hosted zone.
 func (o *AWS) PrivateHostedZoneID() string {
-	if o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13] {
+	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
 		return o.privateHostedZoneID
 	}
 	return ""
@@ -375,7 +399,7 @@ func (o *AWS) PrivateHostedZoneID() string {
 //
 // ID of private hosted zone.
 func (o *AWS) GetPrivateHostedZoneID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 13 && o.fieldSet_[13]
+	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
 	if ok {
 		value = o.privateHostedZoneID
 	}
@@ -387,7 +411,7 @@ func (o *AWS) GetPrivateHostedZoneID() (value string, ok bool) {
 //
 // Role ARN for private hosted zone.
 func (o *AWS) PrivateHostedZoneRoleARN() string {
-	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
+	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
 		return o.privateHostedZoneRoleARN
 	}
 	return ""
@@ -398,7 +422,7 @@ func (o *AWS) PrivateHostedZoneRoleARN() string {
 //
 // Role ARN for private hosted zone.
 func (o *AWS) GetPrivateHostedZoneRoleARN() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
+	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
 	if ok {
 		value = o.privateHostedZoneRoleARN
 	}
@@ -410,7 +434,7 @@ func (o *AWS) GetPrivateHostedZoneRoleARN() (value string, ok bool) {
 //
 // Sets cluster to be inaccessible externally.
 func (o *AWS) PrivateLink() bool {
-	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
+	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
 		return o.privateLink
 	}
 	return false
@@ -421,7 +445,7 @@ func (o *AWS) PrivateLink() bool {
 //
 // Sets cluster to be inaccessible externally.
 func (o *AWS) GetPrivateLink() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
+	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
 	if ok {
 		value = o.privateLink
 	}
@@ -433,7 +457,7 @@ func (o *AWS) GetPrivateLink() (value bool, ok bool) {
 //
 // Manages additional configuration for Private Links.
 func (o *AWS) PrivateLinkConfiguration() *PrivateLinkClusterConfiguration {
-	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
+	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
 		return o.privateLinkConfiguration
 	}
 	return nil
@@ -444,7 +468,7 @@ func (o *AWS) PrivateLinkConfiguration() *PrivateLinkClusterConfiguration {
 //
 // Manages additional configuration for Private Links.
 func (o *AWS) GetPrivateLinkConfiguration() (value *PrivateLinkClusterConfiguration, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
+	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
 	if ok {
 		value = o.privateLinkConfiguration
 	}
@@ -456,7 +480,7 @@ func (o *AWS) GetPrivateLinkConfiguration() (value *PrivateLinkClusterConfigurat
 //
 // AWS secret access key.
 func (o *AWS) SecretAccessKey() string {
-	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
+	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
 		return o.secretAccessKey
 	}
 	return ""
@@ -467,7 +491,7 @@ func (o *AWS) SecretAccessKey() string {
 //
 // AWS secret access key.
 func (o *AWS) GetSecretAccessKey() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
+	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
 	if ok {
 		value = o.secretAccessKey
 	}
@@ -479,7 +503,7 @@ func (o *AWS) GetSecretAccessKey() (value string, ok bool) {
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) SubnetIDs() []string {
-	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
+	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
 		return o.subnetIDs
 	}
 	return nil
@@ -490,7 +514,7 @@ func (o *AWS) SubnetIDs() []string {
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
+	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
 	if ok {
 		value = o.subnetIDs
 	}
@@ -502,7 +526,7 @@ func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
+	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
 		return o.tags
 	}
 	return nil
@@ -513,7 +537,7 @@ func (o *AWS) Tags() map[string]string {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
+	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
 	if ok {
 		value = o.tags
 	}
@@ -525,7 +549,7 @@ func (o *AWS) GetTags() (value map[string]string, ok bool) {
 //
 // Role ARN for VPC Endpoint Service cross account role.
 func (o *AWS) VpcEndpointRoleArn() string {
-	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
+	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
 		return o.vpcEndpointRoleArn
 	}
 	return ""
@@ -536,7 +560,7 @@ func (o *AWS) VpcEndpointRoleArn() string {
 //
 // Role ARN for VPC Endpoint Service cross account role.
 func (o *AWS) GetVpcEndpointRoleArn() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
+	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
 	if ok {
 		value = o.vpcEndpointRoleArn
 	}

--- a/clientapi/clustersmgmt/v1/aws_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_type_json.go
@@ -124,7 +124,16 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteAuditLog(object.auditLog, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9]
+	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.autoNode != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("auto_node")
+		WriteAwsAutoNode(object.autoNode, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -133,7 +142,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.billingAccountID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10]
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -142,7 +151,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.ec2MetadataHttpTokens))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.etcdEncryption != nil
+	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12] && object.etcdEncryption != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -151,7 +160,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteAwsEtcdEncryption(object.etcdEncryption, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12]
+	present_ = len(object.fieldSet_) > 13 && object.fieldSet_[13]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -160,7 +169,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.hcpInternalCommunicationHostedZoneId)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 13 && object.fieldSet_[13]
+	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -169,7 +178,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.privateHostedZoneID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14]
+	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -178,7 +187,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.privateHostedZoneRoleARN)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15]
+	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -187,7 +196,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteBool(object.privateLink)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16] && object.privateLinkConfiguration != nil
+	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17] && object.privateLinkConfiguration != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -196,7 +205,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WritePrivateLinkClusterConfiguration(object.privateLinkConfiguration, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17]
+	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -205,7 +214,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.secretAccessKey)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18] && object.subnetIDs != nil
+	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.subnetIDs != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -214,7 +223,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteStringList(object.subnetIDs, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.tags != nil
+	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -243,7 +252,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20]
+	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -269,7 +278,7 @@ func UnmarshalAWS(source interface{}) (object *AWS, err error) {
 // ReadAWS reads a value of the 'AWS' type from the given iterator.
 func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 	object := &AWS{
-		fieldSet_: make([]bool, 21),
+		fieldSet_: make([]bool, 22),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -313,47 +322,51 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 			value := ReadAuditLog(iterator)
 			object.auditLog = value
 			object.fieldSet_[8] = true
+		case "auto_node":
+			value := ReadAwsAutoNode(iterator)
+			object.autoNode = value
+			object.fieldSet_[9] = true
 		case "billing_account_id":
 			value := iterator.ReadString()
 			object.billingAccountID = value
-			object.fieldSet_[9] = true
+			object.fieldSet_[10] = true
 		case "ec2_metadata_http_tokens":
 			text := iterator.ReadString()
 			value := Ec2MetadataHttpTokens(text)
 			object.ec2MetadataHttpTokens = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		case "etcd_encryption":
 			value := ReadAwsEtcdEncryption(iterator)
 			object.etcdEncryption = value
-			object.fieldSet_[11] = true
+			object.fieldSet_[12] = true
 		case "hcp_internal_communication_hosted_zone_id":
 			value := iterator.ReadString()
 			object.hcpInternalCommunicationHostedZoneId = value
-			object.fieldSet_[12] = true
+			object.fieldSet_[13] = true
 		case "private_hosted_zone_id":
 			value := iterator.ReadString()
 			object.privateHostedZoneID = value
-			object.fieldSet_[13] = true
+			object.fieldSet_[14] = true
 		case "private_hosted_zone_role_arn":
 			value := iterator.ReadString()
 			object.privateHostedZoneRoleARN = value
-			object.fieldSet_[14] = true
+			object.fieldSet_[15] = true
 		case "private_link":
 			value := iterator.ReadBool()
 			object.privateLink = value
-			object.fieldSet_[15] = true
+			object.fieldSet_[16] = true
 		case "private_link_configuration":
 			value := ReadPrivateLinkClusterConfiguration(iterator)
 			object.privateLinkConfiguration = value
-			object.fieldSet_[16] = true
+			object.fieldSet_[17] = true
 		case "secret_access_key":
 			value := iterator.ReadString()
 			object.secretAccessKey = value
-			object.fieldSet_[17] = true
+			object.fieldSet_[18] = true
 		case "subnet_ids":
 			value := ReadStringList(iterator)
 			object.subnetIDs = value
-			object.fieldSet_[18] = true
+			object.fieldSet_[19] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -365,11 +378,11 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 				value[key] = item
 			}
 			object.tags = value
-			object.fieldSet_[19] = true
+			object.fieldSet_[20] = true
 		case "vpc_endpoint_role_arn":
 			value := iterator.ReadString()
 			object.vpcEndpointRoleArn = value
-			object.fieldSet_[20] = true
+			object.fieldSet_[21] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_builder.go
@@ -1,0 +1,108 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// The AutoNode configuration for the Cluster.
+type ClusterAutoNodeBuilder struct {
+	fieldSet_ []bool
+	mode      string
+	status    *ClusterAutoNodeStatusBuilder
+}
+
+// NewClusterAutoNode creates a new builder of 'cluster_auto_node' objects.
+func NewClusterAutoNode() *ClusterAutoNodeBuilder {
+	return &ClusterAutoNodeBuilder{
+		fieldSet_: make([]bool, 2),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAutoNodeBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Mode sets the value of the 'mode' attribute to the given value.
+func (b *ClusterAutoNodeBuilder) Mode(value string) *ClusterAutoNodeBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.mode = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Status sets the value of the 'status' attribute to the given value.
+//
+// Additional status information on the AutoNode configuration on this Cluster
+func (b *ClusterAutoNodeBuilder) Status(value *ClusterAutoNodeStatusBuilder) *ClusterAutoNodeBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.status = value
+	if value != nil {
+		b.fieldSet_[1] = true
+	} else {
+		b.fieldSet_[1] = false
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ClusterAutoNodeBuilder) Copy(object *ClusterAutoNode) *ClusterAutoNodeBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.mode = object.mode
+	if object.status != nil {
+		b.status = NewClusterAutoNodeStatus().Copy(object.status)
+	} else {
+		b.status = nil
+	}
+	return b
+}
+
+// Build creates a 'cluster_auto_node' object using the configuration stored in the builder.
+func (b *ClusterAutoNodeBuilder) Build() (object *ClusterAutoNode, err error) {
+	object = new(ClusterAutoNode)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.mode = b.mode
+	if b.status != nil {
+		object.status, err = b.status.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_list_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ClusterAutoNodeListBuilder contains the data and logic needed to build
+// 'cluster_auto_node' objects.
+type ClusterAutoNodeListBuilder struct {
+	items []*ClusterAutoNodeBuilder
+}
+
+// NewClusterAutoNodeList creates a new builder of 'cluster_auto_node' objects.
+func NewClusterAutoNodeList() *ClusterAutoNodeListBuilder {
+	return new(ClusterAutoNodeListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ClusterAutoNodeListBuilder) Items(values ...*ClusterAutoNodeBuilder) *ClusterAutoNodeListBuilder {
+	b.items = make([]*ClusterAutoNodeBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ClusterAutoNodeListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ClusterAutoNodeListBuilder) Copy(list *ClusterAutoNodeList) *ClusterAutoNodeListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ClusterAutoNodeBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewClusterAutoNode().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'cluster_auto_node' objects using the
+// configuration stored in the builder.
+func (b *ClusterAutoNodeListBuilder) Build() (list *ClusterAutoNodeList, err error) {
+	items := make([]*ClusterAutoNode, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterAutoNodeList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNodeList writes a list of values of the 'cluster_auto_node' type to
+// the given writer.
+func MarshalClusterAutoNodeList(list []*ClusterAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNodeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNodeList writes a list of value of the 'cluster_auto_node' type to
+// the given stream.
+func WriteClusterAutoNodeList(list []*ClusterAutoNode, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteClusterAutoNode(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalClusterAutoNodeList reads a list of values of the 'cluster_auto_node' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNodeList(source interface{}) (items []*ClusterAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadClusterAutoNodeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNodeList reads list of values of the ”cluster_auto_node' type from
+// the given iterator.
+func ReadClusterAutoNodeList(iterator *jsoniter.Iterator) []*ClusterAutoNode {
+	list := []*ClusterAutoNode{}
+	for iterator.ReadArray() {
+		item := ReadClusterAutoNode(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_builder.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Additional status information on the AutoNode configuration on this Cluster
+type ClusterAutoNodeStatusBuilder struct {
+	fieldSet_ []bool
+	message   string
+}
+
+// NewClusterAutoNodeStatus creates a new builder of 'cluster_auto_node_status' objects.
+func NewClusterAutoNodeStatus() *ClusterAutoNodeStatusBuilder {
+	return &ClusterAutoNodeStatusBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ClusterAutoNodeStatusBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Message sets the value of the 'message' attribute to the given value.
+func (b *ClusterAutoNodeStatusBuilder) Message(value string) *ClusterAutoNodeStatusBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.message = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ClusterAutoNodeStatusBuilder) Copy(object *ClusterAutoNodeStatus) *ClusterAutoNodeStatusBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.message = object.message
+	return b
+}
+
+// Build creates a 'cluster_auto_node_status' object using the configuration stored in the builder.
+func (b *ClusterAutoNodeStatusBuilder) Build() (object *ClusterAutoNodeStatus, err error) {
+	object = new(ClusterAutoNodeStatus)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.message = b.message
+	return
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_list_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ClusterAutoNodeStatusListBuilder contains the data and logic needed to build
+// 'cluster_auto_node_status' objects.
+type ClusterAutoNodeStatusListBuilder struct {
+	items []*ClusterAutoNodeStatusBuilder
+}
+
+// NewClusterAutoNodeStatusList creates a new builder of 'cluster_auto_node_status' objects.
+func NewClusterAutoNodeStatusList() *ClusterAutoNodeStatusListBuilder {
+	return new(ClusterAutoNodeStatusListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ClusterAutoNodeStatusListBuilder) Items(values ...*ClusterAutoNodeStatusBuilder) *ClusterAutoNodeStatusListBuilder {
+	b.items = make([]*ClusterAutoNodeStatusBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ClusterAutoNodeStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ClusterAutoNodeStatusListBuilder) Copy(list *ClusterAutoNodeStatusList) *ClusterAutoNodeStatusListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ClusterAutoNodeStatusBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewClusterAutoNodeStatus().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'cluster_auto_node_status' objects using the
+// configuration stored in the builder.
+func (b *ClusterAutoNodeStatusListBuilder) Build() (list *ClusterAutoNodeStatusList, err error) {
+	items := make([]*ClusterAutoNodeStatus, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ClusterAutoNodeStatusList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNodeStatusList writes a list of values of the 'cluster_auto_node_status' type to
+// the given writer.
+func MarshalClusterAutoNodeStatusList(list []*ClusterAutoNodeStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNodeStatusList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNodeStatusList writes a list of value of the 'cluster_auto_node_status' type to
+// the given stream.
+func WriteClusterAutoNodeStatusList(list []*ClusterAutoNodeStatus, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteClusterAutoNodeStatus(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalClusterAutoNodeStatusList reads a list of values of the 'cluster_auto_node_status' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNodeStatusList(source interface{}) (items []*ClusterAutoNodeStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadClusterAutoNodeStatusList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNodeStatusList reads list of values of the ”cluster_auto_node_status' type from
+// the given iterator.
+func ReadClusterAutoNodeStatusList(iterator *jsoniter.Iterator) []*ClusterAutoNodeStatus {
+	list := []*ClusterAutoNodeStatus{}
+	for iterator.ReadArray() {
+		item := ReadClusterAutoNodeStatus(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_type.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ClusterAutoNodeStatus represents the values of the 'cluster_auto_node_status' type.
+//
+// Additional status information on the AutoNode configuration on this Cluster
+type ClusterAutoNodeStatus struct {
+	fieldSet_ []bool
+	message   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAutoNodeStatus) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Message returns the value of the 'message' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Messages relating to the status of the AutoNode installation on this Cluster
+func (o *ClusterAutoNodeStatus) Message() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.message
+	}
+	return ""
+}
+
+// GetMessage returns the value of the 'message' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Messages relating to the status of the AutoNode installation on this Cluster
+func (o *ClusterAutoNodeStatus) GetMessage() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.message
+	}
+	return
+}
+
+// ClusterAutoNodeStatusListKind is the name of the type used to represent list of objects of
+// type 'cluster_auto_node_status'.
+const ClusterAutoNodeStatusListKind = "ClusterAutoNodeStatusList"
+
+// ClusterAutoNodeStatusListLinkKind is the name of the type used to represent links to list
+// of objects of type 'cluster_auto_node_status'.
+const ClusterAutoNodeStatusListLinkKind = "ClusterAutoNodeStatusListLink"
+
+// ClusterAutoNodeStatusNilKind is the name of the type used to nil lists of objects of
+// type 'cluster_auto_node_status'.
+const ClusterAutoNodeStatusListNilKind = "ClusterAutoNodeStatusListNil"
+
+// ClusterAutoNodeStatusList is a list of values of the 'cluster_auto_node_status' type.
+type ClusterAutoNodeStatusList struct {
+	href  string
+	link  bool
+	items []*ClusterAutoNodeStatus
+}
+
+// Len returns the length of the list.
+func (l *ClusterAutoNodeStatusList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeStatusList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeStatusList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeStatusList) SetItems(items []*ClusterAutoNodeStatus) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ClusterAutoNodeStatusList) Items() []*ClusterAutoNodeStatus {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAutoNodeStatusList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAutoNodeStatusList) Get(i int) *ClusterAutoNodeStatus {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ClusterAutoNodeStatusList) Slice() []*ClusterAutoNodeStatus {
+	var slice []*ClusterAutoNodeStatus
+	if l == nil {
+		slice = make([]*ClusterAutoNodeStatus, 0)
+	} else {
+		slice = make([]*ClusterAutoNodeStatus, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ClusterAutoNodeStatusList) Each(f func(item *ClusterAutoNodeStatus) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ClusterAutoNodeStatusList) Range(f func(index int, item *ClusterAutoNodeStatus) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNodeStatus writes a value of the 'cluster_auto_node_status' type to the given writer.
+func MarshalClusterAutoNodeStatus(object *ClusterAutoNodeStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNodeStatus(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNodeStatus writes a value of the 'cluster_auto_node_status' type to the given stream.
+func WriteClusterAutoNodeStatus(object *ClusterAutoNodeStatus, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("message")
+		stream.WriteString(object.message)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalClusterAutoNodeStatus reads a value of the 'cluster_auto_node_status' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNodeStatus(source interface{}) (object *ClusterAutoNodeStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadClusterAutoNodeStatus(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNodeStatus reads a value of the 'cluster_auto_node_status' type from the given iterator.
+func ReadClusterAutoNodeStatus(iterator *jsoniter.Iterator) *ClusterAutoNodeStatus {
+	object := &ClusterAutoNodeStatus{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "message":
+			value := iterator.ReadString()
+			object.message = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_type.go
@@ -1,0 +1,195 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ClusterAutoNode represents the values of the 'cluster_auto_node' type.
+//
+// The AutoNode configuration for the Cluster.
+type ClusterAutoNode struct {
+	fieldSet_ []bool
+	mode      string
+	status    *ClusterAutoNodeStatus
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ClusterAutoNode) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Mode returns the value of the 'mode' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Mode indicates the current state of AutoNode on this cluster.
+// Valid values: "enabled", "disabled".
+func (o *ClusterAutoNode) Mode() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.mode
+	}
+	return ""
+}
+
+// GetMode returns the value of the 'mode' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Mode indicates the current state of AutoNode on this cluster.
+// Valid values: "enabled", "disabled".
+func (o *ClusterAutoNode) GetMode() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.mode
+	}
+	return
+}
+
+// Status returns the value of the 'status' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+func (o *ClusterAutoNode) Status() *ClusterAutoNodeStatus {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.status
+	}
+	return nil
+}
+
+// GetStatus returns the value of the 'status' attribute and
+// a flag indicating if the attribute has a value.
+func (o *ClusterAutoNode) GetStatus() (value *ClusterAutoNodeStatus, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.status
+	}
+	return
+}
+
+// ClusterAutoNodeListKind is the name of the type used to represent list of objects of
+// type 'cluster_auto_node'.
+const ClusterAutoNodeListKind = "ClusterAutoNodeList"
+
+// ClusterAutoNodeListLinkKind is the name of the type used to represent links to list
+// of objects of type 'cluster_auto_node'.
+const ClusterAutoNodeListLinkKind = "ClusterAutoNodeListLink"
+
+// ClusterAutoNodeNilKind is the name of the type used to nil lists of objects of
+// type 'cluster_auto_node'.
+const ClusterAutoNodeListNilKind = "ClusterAutoNodeListNil"
+
+// ClusterAutoNodeList is a list of values of the 'cluster_auto_node' type.
+type ClusterAutoNodeList struct {
+	href  string
+	link  bool
+	items []*ClusterAutoNode
+}
+
+// Len returns the length of the list.
+func (l *ClusterAutoNodeList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ClusterAutoNodeList) SetItems(items []*ClusterAutoNode) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ClusterAutoNodeList) Items() []*ClusterAutoNode {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ClusterAutoNodeList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ClusterAutoNodeList) Get(i int) *ClusterAutoNode {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ClusterAutoNodeList) Slice() []*ClusterAutoNode {
+	var slice []*ClusterAutoNode
+	if l == nil {
+		slice = make([]*ClusterAutoNode, 0)
+	} else {
+		slice = make([]*ClusterAutoNode, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ClusterAutoNodeList) Each(f func(item *ClusterAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ClusterAutoNodeList) Range(f func(index int, item *ClusterAutoNode) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_type_json.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalClusterAutoNode writes a value of the 'cluster_auto_node' type to the given writer.
+func MarshalClusterAutoNode(object *ClusterAutoNode, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteClusterAutoNode(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteClusterAutoNode writes a value of the 'cluster_auto_node' type to the given stream.
+func WriteClusterAutoNode(object *ClusterAutoNode, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("mode")
+		stream.WriteString(object.mode)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.status != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("status")
+		WriteClusterAutoNodeStatus(object.status, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalClusterAutoNode reads a value of the 'cluster_auto_node' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalClusterAutoNode(source interface{}) (object *ClusterAutoNode, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadClusterAutoNode(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadClusterAutoNode reads a value of the 'cluster_auto_node' type from the given iterator.
+func ReadClusterAutoNode(iterator *jsoniter.Iterator) *ClusterAutoNode {
+	object := &ClusterAutoNode{
+		fieldSet_: make([]bool, 2),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "mode":
+			value := iterator.ReadString()
+			object.mode = value
+			object.fieldSet_[0] = true
+		case "status":
+			value := ReadClusterAutoNodeStatus(iterator)
+			object.status = value
+			object.fieldSet_[1] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/cluster_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_builder.go
@@ -76,6 +76,7 @@ type ClusterBuilder struct {
 	gcpNetwork                        *GCPNetworkBuilder
 	additionalTrustBundle             string
 	addons                            *AddOnInstallationListBuilder
+	autoNode                          *ClusterAutoNodeBuilder
 	autoscaler                        *ClusterAutoscalerBuilder
 	azure                             *AzureBuilder
 	billingModel                      BillingModel
@@ -131,14 +132,14 @@ type ClusterBuilder struct {
 // NewCluster creates a new builder of 'cluster' objects.
 func NewCluster() *ClusterBuilder {
 	return &ClusterBuilder{
-		fieldSet_: make([]bool, 63),
+		fieldSet_: make([]bool, 64),
 	}
 }
 
 // Link sets the flag that indicates if this is a link.
 func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.fieldSet_[0] = true
 	return b
@@ -147,7 +148,7 @@ func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 // ID sets the identifier of the object.
 func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.id = value
 	b.fieldSet_[1] = true
@@ -157,7 +158,7 @@ func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 // HREF sets the link to the object.
 func (b *ClusterBuilder) HREF(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.href = value
 	b.fieldSet_[2] = true
@@ -184,7 +185,7 @@ func (b *ClusterBuilder) Empty() bool {
 // Information about the API of a cluster.
 func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.api = value
 	if value != nil {
@@ -200,7 +201,7 @@ func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 // _Amazon Web Services_ specific settings of a cluster.
 func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.aws = value
 	if value != nil {
@@ -214,7 +215,7 @@ func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 // AWSInfrastructureAccessRoleGrants sets the value of the 'AWS_infrastructure_access_role_grants' attribute to the given values.
 func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *AWSInfrastructureAccessRoleGrantListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.awsInfrastructureAccessRoleGrants = value
 	b.fieldSet_[5] = true
@@ -224,7 +225,7 @@ func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *AWSInfrastruct
 // CCS sets the value of the 'CCS' attribute to the given value.
 func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.ccs = value
 	if value != nil {
@@ -240,7 +241,7 @@ func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 // DNS settings of the cluster.
 func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.dns = value
 	if value != nil {
@@ -254,7 +255,7 @@ func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 // FIPS sets the value of the 'FIPS' attribute to the given value.
 func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.fips = value
 	b.fieldSet_[8] = true
@@ -266,7 +267,7 @@ func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 // Google cloud platform settings of a cluster.
 func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcp = value
 	if value != nil {
@@ -282,7 +283,7 @@ func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 // GCP Encryption Key for CCS clusters.
 func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcpEncryptionKey = value
 	if value != nil {
@@ -298,7 +299,7 @@ func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *Clust
 // GCP Network configuration of a cluster.
 func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcpNetwork = value
 	if value != nil {
@@ -312,7 +313,7 @@ func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 // AdditionalTrustBundle sets the value of the 'additional_trust_bundle' attribute to the given value.
 func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.additionalTrustBundle = value
 	b.fieldSet_[12] = true
@@ -322,10 +323,26 @@ func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 // Addons sets the value of the 'addons' attribute to the given values.
 func (b *ClusterBuilder) Addons(value *AddOnInstallationListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.addons = value
 	b.fieldSet_[13] = true
+	return b
+}
+
+// AutoNode sets the value of the 'auto_node' attribute to the given value.
+//
+// The AutoNode configuration for the Cluster.
+func (b *ClusterBuilder) AutoNode(value *ClusterAutoNodeBuilder) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 64)
+	}
+	b.autoNode = value
+	if value != nil {
+		b.fieldSet_[14] = true
+	} else {
+		b.fieldSet_[14] = false
+	}
 	return b
 }
 
@@ -334,13 +351,13 @@ func (b *ClusterBuilder) Addons(value *AddOnInstallationListBuilder) *ClusterBui
 // Cluster-wide autoscaling configuration.
 func (b *ClusterBuilder) Autoscaler(value *ClusterAutoscalerBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.autoscaler = value
 	if value != nil {
-		b.fieldSet_[14] = true
+		b.fieldSet_[15] = true
 	} else {
-		b.fieldSet_[14] = false
+		b.fieldSet_[15] = false
 	}
 	return b
 }
@@ -350,13 +367,13 @@ func (b *ClusterBuilder) Autoscaler(value *ClusterAutoscalerBuilder) *ClusterBui
 // Microsoft Azure settings of a cluster.
 func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.azure = value
 	if value != nil {
-		b.fieldSet_[15] = true
+		b.fieldSet_[16] = true
 	} else {
-		b.fieldSet_[15] = false
+		b.fieldSet_[16] = false
 	}
 	return b
 }
@@ -366,10 +383,10 @@ func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 // Billing model for cluster resources.
 func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.billingModel = value
-	b.fieldSet_[16] = true
+	b.fieldSet_[17] = true
 	return b
 }
 
@@ -378,13 +395,13 @@ func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 // ByoOidc configuration.
 func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.byoOidc = value
 	if value != nil {
-		b.fieldSet_[17] = true
+		b.fieldSet_[18] = true
 	} else {
-		b.fieldSet_[17] = false
+		b.fieldSet_[18] = false
 	}
 	return b
 }
@@ -394,13 +411,13 @@ func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 // Cloud provider.
 func (b *ClusterBuilder) CloudProvider(value *CloudProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.cloudProvider = value
 	if value != nil {
-		b.fieldSet_[18] = true
+		b.fieldSet_[19] = true
 	} else {
-		b.fieldSet_[18] = false
+		b.fieldSet_[19] = false
 	}
 	return b
 }
@@ -410,13 +427,13 @@ func (b *ClusterBuilder) CloudProvider(value *CloudProviderBuilder) *ClusterBuil
 // Information about the console of a cluster.
 func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.console = value
 	if value != nil {
-		b.fieldSet_[19] = true
+		b.fieldSet_[20] = true
 	} else {
-		b.fieldSet_[19] = false
+		b.fieldSet_[20] = false
 	}
 	return b
 }
@@ -424,10 +441,10 @@ func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 // CreationTimestamp sets the value of the 'creation_timestamp' attribute to the given value.
 func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.creationTimestamp = value
-	b.fieldSet_[20] = true
+	b.fieldSet_[21] = true
 	return b
 }
 
@@ -436,13 +453,13 @@ func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 // DeleteProtection configuration.
 func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.deleteProtection = value
 	if value != nil {
-		b.fieldSet_[21] = true
+		b.fieldSet_[22] = true
 	} else {
-		b.fieldSet_[21] = false
+		b.fieldSet_[22] = false
 	}
 	return b
 }
@@ -450,50 +467,50 @@ func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *Clust
 // DisableUserWorkloadMonitoring sets the value of the 'disable_user_workload_monitoring' attribute to the given value.
 func (b *ClusterBuilder) DisableUserWorkloadMonitoring(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.disableUserWorkloadMonitoring = value
-	b.fieldSet_[22] = true
+	b.fieldSet_[23] = true
 	return b
 }
 
 // DomainPrefix sets the value of the 'domain_prefix' attribute to the given value.
 func (b *ClusterBuilder) DomainPrefix(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.domainPrefix = value
-	b.fieldSet_[23] = true
+	b.fieldSet_[24] = true
 	return b
 }
 
 // EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
 func (b *ClusterBuilder) EtcdEncryption(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.etcdEncryption = value
-	b.fieldSet_[24] = true
+	b.fieldSet_[25] = true
 	return b
 }
 
 // ExpirationTimestamp sets the value of the 'expiration_timestamp' attribute to the given value.
 func (b *ClusterBuilder) ExpirationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.expirationTimestamp = value
-	b.fieldSet_[25] = true
+	b.fieldSet_[26] = true
 	return b
 }
 
 // ExternalID sets the value of the 'external_ID' attribute to the given value.
 func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalID = value
-	b.fieldSet_[26] = true
+	b.fieldSet_[27] = true
 	return b
 }
 
@@ -502,13 +519,13 @@ func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 // Represents an external authentication configuration
 func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalAuthConfig = value
 	if value != nil {
-		b.fieldSet_[27] = true
+		b.fieldSet_[28] = true
 	} else {
-		b.fieldSet_[27] = false
+		b.fieldSet_[28] = false
 	}
 	return b
 }
@@ -518,13 +535,13 @@ func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *C
 // Representation of cluster external configuration.
 func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalConfiguration = value
 	if value != nil {
-		b.fieldSet_[28] = true
+		b.fieldSet_[29] = true
 	} else {
-		b.fieldSet_[28] = false
+		b.fieldSet_[29] = false
 	}
 	return b
 }
@@ -535,13 +552,13 @@ func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuild
 // with 10 infra nodes and 1000 compute nodes.
 func (b *ClusterBuilder) Flavour(value *FlavourBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.flavour = value
 	if value != nil {
-		b.fieldSet_[29] = true
+		b.fieldSet_[30] = true
 	} else {
-		b.fieldSet_[29] = false
+		b.fieldSet_[30] = false
 	}
 	return b
 }
@@ -549,10 +566,10 @@ func (b *ClusterBuilder) Flavour(value *FlavourBuilder) *ClusterBuilder {
 // Groups sets the value of the 'groups' attribute to the given values.
 func (b *ClusterBuilder) Groups(value *GroupListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.groups = value
-	b.fieldSet_[30] = true
+	b.fieldSet_[31] = true
 	return b
 }
 
@@ -561,10 +578,10 @@ func (b *ClusterBuilder) Groups(value *GroupListBuilder) *ClusterBuilder {
 // ClusterHealthState indicates the health of a cluster.
 func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.healthState = value
-	b.fieldSet_[31] = true
+	b.fieldSet_[32] = true
 	return b
 }
 
@@ -573,13 +590,13 @@ func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 // Details for `htpasswd` identity providers.
 func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.htpasswd = value
 	if value != nil {
-		b.fieldSet_[32] = true
+		b.fieldSet_[33] = true
 	} else {
-		b.fieldSet_[32] = false
+		b.fieldSet_[33] = false
 	}
 	return b
 }
@@ -589,13 +606,13 @@ func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *Clust
 // Hypershift configuration.
 func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.hypershift = value
 	if value != nil {
-		b.fieldSet_[33] = true
+		b.fieldSet_[34] = true
 	} else {
-		b.fieldSet_[33] = false
+		b.fieldSet_[34] = false
 	}
 	return b
 }
@@ -603,10 +620,10 @@ func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 // IdentityProviders sets the value of the 'identity_providers' attribute to the given values.
 func (b *ClusterBuilder) IdentityProviders(value *IdentityProviderListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.identityProviders = value
-	b.fieldSet_[34] = true
+	b.fieldSet_[35] = true
 	return b
 }
 
@@ -615,13 +632,13 @@ func (b *ClusterBuilder) IdentityProviders(value *IdentityProviderListBuilder) *
 // ClusterImageRegistry represents the configuration for the cluster's internal image registry.
 func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.imageRegistry = value
 	if value != nil {
-		b.fieldSet_[35] = true
+		b.fieldSet_[36] = true
 	} else {
-		b.fieldSet_[35] = false
+		b.fieldSet_[36] = false
 	}
 	return b
 }
@@ -629,30 +646,30 @@ func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *Clus
 // InflightChecks sets the value of the 'inflight_checks' attribute to the given values.
 func (b *ClusterBuilder) InflightChecks(value *InflightCheckListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.inflightChecks = value
-	b.fieldSet_[36] = true
+	b.fieldSet_[37] = true
 	return b
 }
 
 // InfraID sets the value of the 'infra_ID' attribute to the given value.
 func (b *ClusterBuilder) InfraID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.infraID = value
-	b.fieldSet_[37] = true
+	b.fieldSet_[38] = true
 	return b
 }
 
 // Ingresses sets the value of the 'ingresses' attribute to the given values.
 func (b *ClusterBuilder) Ingresses(value *IngressListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.ingresses = value
-	b.fieldSet_[38] = true
+	b.fieldSet_[39] = true
 	return b
 }
 
@@ -662,13 +679,13 @@ func (b *ClusterBuilder) Ingresses(value *IngressListBuilder) *ClusterBuilder {
 // KubeletConfig that can be managed by users
 func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.kubeletConfig = value
 	if value != nil {
-		b.fieldSet_[39] = true
+		b.fieldSet_[40] = true
 	} else {
-		b.fieldSet_[39] = false
+		b.fieldSet_[40] = false
 	}
 	return b
 }
@@ -676,30 +693,30 @@ func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuil
 // LoadBalancerQuota sets the value of the 'load_balancer_quota' attribute to the given value.
 func (b *ClusterBuilder) LoadBalancerQuota(value int) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.loadBalancerQuota = value
-	b.fieldSet_[40] = true
+	b.fieldSet_[41] = true
 	return b
 }
 
 // MachinePools sets the value of the 'machine_pools' attribute to the given values.
 func (b *ClusterBuilder) MachinePools(value *MachinePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.machinePools = value
-	b.fieldSet_[41] = true
+	b.fieldSet_[42] = true
 	return b
 }
 
 // Managed sets the value of the 'managed' attribute to the given value.
 func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.managed = value
-	b.fieldSet_[42] = true
+	b.fieldSet_[43] = true
 	return b
 }
 
@@ -708,13 +725,13 @@ func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.managedService = value
 	if value != nil {
-		b.fieldSet_[43] = true
+		b.fieldSet_[44] = true
 	} else {
-		b.fieldSet_[43] = false
+		b.fieldSet_[44] = false
 	}
 	return b
 }
@@ -722,30 +739,30 @@ func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBu
 // MultiAZ sets the value of the 'multi_AZ' attribute to the given value.
 func (b *ClusterBuilder) MultiAZ(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.multiAZ = value
-	b.fieldSet_[44] = true
+	b.fieldSet_[45] = true
 	return b
 }
 
 // MultiArchEnabled sets the value of the 'multi_arch_enabled' attribute to the given value.
 func (b *ClusterBuilder) MultiArchEnabled(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.multiArchEnabled = value
-	b.fieldSet_[45] = true
+	b.fieldSet_[46] = true
 	return b
 }
 
 // Name sets the value of the 'name' attribute to the given value.
 func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.name = value
-	b.fieldSet_[46] = true
+	b.fieldSet_[47] = true
 	return b
 }
 
@@ -754,13 +771,13 @@ func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 // Network configuration of a cluster.
 func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.network = value
 	if value != nil {
-		b.fieldSet_[47] = true
+		b.fieldSet_[48] = true
 	} else {
-		b.fieldSet_[47] = false
+		b.fieldSet_[48] = false
 	}
 	return b
 }
@@ -787,13 +804,13 @@ func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodeDrainGracePeriod = value
 	if value != nil {
-		b.fieldSet_[48] = true
+		b.fieldSet_[49] = true
 	} else {
-		b.fieldSet_[48] = false
+		b.fieldSet_[49] = false
 	}
 	return b
 }
@@ -801,10 +818,10 @@ func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuild
 // NodePools sets the value of the 'node_pools' attribute to the given values.
 func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodePools = value
-	b.fieldSet_[49] = true
+	b.fieldSet_[50] = true
 	return b
 }
 
@@ -813,13 +830,13 @@ func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 // Counts of different classes of nodes inside a cluster.
 func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodes = value
 	if value != nil {
-		b.fieldSet_[50] = true
+		b.fieldSet_[51] = true
 	} else {
-		b.fieldSet_[50] = false
+		b.fieldSet_[51] = false
 	}
 	return b
 }
@@ -827,10 +844,10 @@ func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 // OpenshiftVersion sets the value of the 'openshift_version' attribute to the given value.
 func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.openshiftVersion = value
-	b.fieldSet_[51] = true
+	b.fieldSet_[52] = true
 	return b
 }
 
@@ -839,13 +856,13 @@ func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
 // Representation of an product that can be selected as a cluster type.
 func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.product = value
 	if value != nil {
-		b.fieldSet_[52] = true
+		b.fieldSet_[53] = true
 	} else {
-		b.fieldSet_[52] = false
+		b.fieldSet_[53] = false
 	}
 	return b
 }
@@ -853,13 +870,13 @@ func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
 // Properties sets the value of the 'properties' attribute to the given value.
 func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.properties = value
 	if value != nil {
-		b.fieldSet_[53] = true
+		b.fieldSet_[54] = true
 	} else {
-		b.fieldSet_[53] = false
+		b.fieldSet_[54] = false
 	}
 	return b
 }
@@ -869,13 +886,13 @@ func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 // Contains the properties of the provision shard, including AWS and GCP related configurations
 func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.provisionShard = value
 	if value != nil {
-		b.fieldSet_[54] = true
+		b.fieldSet_[55] = true
 	} else {
-		b.fieldSet_[54] = false
+		b.fieldSet_[55] = false
 	}
 	return b
 }
@@ -885,13 +902,13 @@ func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBu
 // Proxy configuration of a cluster.
 func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.proxy = value
 	if value != nil {
-		b.fieldSet_[55] = true
+		b.fieldSet_[56] = true
 	} else {
-		b.fieldSet_[55] = false
+		b.fieldSet_[56] = false
 	}
 	return b
 }
@@ -901,13 +918,13 @@ func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 // Description of a region of a cloud provider.
 func (b *ClusterBuilder) Region(value *CloudRegionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.region = value
 	if value != nil {
-		b.fieldSet_[56] = true
+		b.fieldSet_[57] = true
 	} else {
-		b.fieldSet_[56] = false
+		b.fieldSet_[57] = false
 	}
 	return b
 }
@@ -933,13 +950,13 @@ func (b *ClusterBuilder) Region(value *CloudRegionBuilder) *ClusterBuilder {
 // ```
 func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.registryConfig = value
 	if value != nil {
-		b.fieldSet_[57] = true
+		b.fieldSet_[58] = true
 	} else {
-		b.fieldSet_[57] = false
+		b.fieldSet_[58] = false
 	}
 	return b
 }
@@ -949,10 +966,10 @@ func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *Cl
 // Overall state of a cluster.
 func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.state = value
-	b.fieldSet_[58] = true
+	b.fieldSet_[59] = true
 	return b
 }
 
@@ -961,13 +978,13 @@ func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 // Detailed status of a cluster.
 func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.status = value
 	if value != nil {
-		b.fieldSet_[59] = true
+		b.fieldSet_[60] = true
 	} else {
-		b.fieldSet_[59] = false
+		b.fieldSet_[60] = false
 	}
 	return b
 }
@@ -994,13 +1011,13 @@ func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.storageQuota = value
 	if value != nil {
-		b.fieldSet_[60] = true
+		b.fieldSet_[61] = true
 	} else {
-		b.fieldSet_[60] = false
+		b.fieldSet_[61] = false
 	}
 	return b
 }
@@ -1010,13 +1027,13 @@ func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 // Definition of a subscription.
 func (b *ClusterBuilder) Subscription(value *SubscriptionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.subscription = value
 	if value != nil {
-		b.fieldSet_[61] = true
+		b.fieldSet_[62] = true
 	} else {
-		b.fieldSet_[61] = false
+		b.fieldSet_[62] = false
 	}
 	return b
 }
@@ -1026,13 +1043,13 @@ func (b *ClusterBuilder) Subscription(value *SubscriptionBuilder) *ClusterBuilde
 // Representation of an _OpenShift_ version.
 func (b *ClusterBuilder) Version(value *VersionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.version = value
 	if value != nil {
-		b.fieldSet_[62] = true
+		b.fieldSet_[63] = true
 	} else {
-		b.fieldSet_[62] = false
+		b.fieldSet_[63] = false
 	}
 	return b
 }
@@ -1094,6 +1111,11 @@ func (b *ClusterBuilder) Copy(object *Cluster) *ClusterBuilder {
 		b.addons = NewAddOnInstallationList().Copy(object.addons)
 	} else {
 		b.addons = nil
+	}
+	if object.autoNode != nil {
+		b.autoNode = NewClusterAutoNode().Copy(object.autoNode)
+	} else {
+		b.autoNode = nil
 	}
 	if object.autoscaler != nil {
 		b.autoscaler = NewClusterAutoscaler().Copy(object.autoscaler)
@@ -1343,6 +1365,12 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 	object.additionalTrustBundle = b.additionalTrustBundle
 	if b.addons != nil {
 		object.addons, err = b.addons.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.autoNode != nil {
+		object.autoNode, err = b.autoNode.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/clustersmgmt/v1/cluster_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_type.go
@@ -90,6 +90,7 @@ type Cluster struct {
 	gcpNetwork                        *GCPNetwork
 	additionalTrustBundle             string
 	addons                            *AddOnInstallationList
+	autoNode                          *ClusterAutoNode
 	autoscaler                        *ClusterAutoscaler
 	azure                             *Azure
 	billingModel                      BillingModel
@@ -462,12 +463,37 @@ func (o *Cluster) GetAddons() (value *AddOnInstallationList, ok bool) {
 	return
 }
 
+// AutoNode returns the value of the 'auto_node' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The AutoNode settings for this cluster.
+// This is currently only supported for ROSA HCP
+func (o *Cluster) AutoNode() *ClusterAutoNode {
+	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
+		return o.autoNode
+	}
+	return nil
+}
+
+// GetAutoNode returns the value of the 'auto_node' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The AutoNode settings for this cluster.
+// This is currently only supported for ROSA HCP
+func (o *Cluster) GetAutoNode() (value *ClusterAutoNode, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
+	if ok {
+		value = o.autoNode
+	}
+	return
+}
+
 // Autoscaler returns the value of the 'autoscaler' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Link to an optional _ClusterAutoscaler_ that is coupled with the cluster.
 func (o *Cluster) Autoscaler() *ClusterAutoscaler {
-	if o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14] {
+	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
 		return o.autoscaler
 	}
 	return nil
@@ -478,7 +504,7 @@ func (o *Cluster) Autoscaler() *ClusterAutoscaler {
 //
 // Link to an optional _ClusterAutoscaler_ that is coupled with the cluster.
 func (o *Cluster) GetAutoscaler() (value *ClusterAutoscaler, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 14 && o.fieldSet_[14]
+	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
 	if ok {
 		value = o.autoscaler
 	}
@@ -490,7 +516,7 @@ func (o *Cluster) GetAutoscaler() (value *ClusterAutoscaler, ok bool) {
 //
 // Microsoft Azure settings of the cluster.
 func (o *Cluster) Azure() *Azure {
-	if o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15] {
+	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
 		return o.azure
 	}
 	return nil
@@ -501,7 +527,7 @@ func (o *Cluster) Azure() *Azure {
 //
 // Microsoft Azure settings of the cluster.
 func (o *Cluster) GetAzure() (value *Azure, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 15 && o.fieldSet_[15]
+	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
 	if ok {
 		value = o.azure
 	}
@@ -513,7 +539,7 @@ func (o *Cluster) GetAzure() (value *Azure, ok bool) {
 //
 // Billing model for cluster resources.
 func (o *Cluster) BillingModel() BillingModel {
-	if o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16] {
+	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
 		return o.billingModel
 	}
 	return BillingModel("")
@@ -524,7 +550,7 @@ func (o *Cluster) BillingModel() BillingModel {
 //
 // Billing model for cluster resources.
 func (o *Cluster) GetBillingModel() (value BillingModel, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 16 && o.fieldSet_[16]
+	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
 	if ok {
 		value = o.billingModel
 	}
@@ -536,7 +562,7 @@ func (o *Cluster) GetBillingModel() (value BillingModel, ok bool) {
 //
 // Contains information about BYO OIDC.
 func (o *Cluster) ByoOidc() *ByoOidc {
-	if o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17] {
+	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
 		return o.byoOidc
 	}
 	return nil
@@ -547,7 +573,7 @@ func (o *Cluster) ByoOidc() *ByoOidc {
 //
 // Contains information about BYO OIDC.
 func (o *Cluster) GetByoOidc() (value *ByoOidc, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 17 && o.fieldSet_[17]
+	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
 	if ok {
 		value = o.byoOidc
 	}
@@ -559,7 +585,7 @@ func (o *Cluster) GetByoOidc() (value *ByoOidc, ok bool) {
 //
 // Link to the cloud provider where the cluster is installed.
 func (o *Cluster) CloudProvider() *CloudProvider {
-	if o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18] {
+	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
 		return o.cloudProvider
 	}
 	return nil
@@ -570,7 +596,7 @@ func (o *Cluster) CloudProvider() *CloudProvider {
 //
 // Link to the cloud provider where the cluster is installed.
 func (o *Cluster) GetCloudProvider() (value *CloudProvider, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 18 && o.fieldSet_[18]
+	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
 	if ok {
 		value = o.cloudProvider
 	}
@@ -582,7 +608,7 @@ func (o *Cluster) GetCloudProvider() (value *CloudProvider, ok bool) {
 //
 // Information about the console of the cluster.
 func (o *Cluster) Console() *ClusterConsole {
-	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
+	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
 		return o.console
 	}
 	return nil
@@ -593,7 +619,7 @@ func (o *Cluster) Console() *ClusterConsole {
 //
 // Information about the console of the cluster.
 func (o *Cluster) GetConsole() (value *ClusterConsole, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
+	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
 	if ok {
 		value = o.console
 	}
@@ -606,7 +632,7 @@ func (o *Cluster) GetConsole() (value *ClusterConsole, ok bool) {
 // Date and time when the cluster was initially created, using the
 // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
 func (o *Cluster) CreationTimestamp() time.Time {
-	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
+	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
 		return o.creationTimestamp
 	}
 	return time.Time{}
@@ -618,7 +644,7 @@ func (o *Cluster) CreationTimestamp() time.Time {
 // Date and time when the cluster was initially created, using the
 // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
 func (o *Cluster) GetCreationTimestamp() (value time.Time, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
+	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
 	if ok {
 		value = o.creationTimestamp
 	}
@@ -630,7 +656,7 @@ func (o *Cluster) GetCreationTimestamp() (value time.Time, ok bool) {
 //
 // Delete protection
 func (o *Cluster) DeleteProtection() *DeleteProtection {
-	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
+	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
 		return o.deleteProtection
 	}
 	return nil
@@ -641,7 +667,7 @@ func (o *Cluster) DeleteProtection() *DeleteProtection {
 //
 // Delete protection
 func (o *Cluster) GetDeleteProtection() (value *DeleteProtection, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
+	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
 	if ok {
 		value = o.deleteProtection
 	}
@@ -654,7 +680,7 @@ func (o *Cluster) GetDeleteProtection() (value *DeleteProtection, ok bool) {
 // Indicates whether the User workload monitoring is enabled or not
 // It is enabled by default
 func (o *Cluster) DisableUserWorkloadMonitoring() bool {
-	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
+	if o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23] {
 		return o.disableUserWorkloadMonitoring
 	}
 	return false
@@ -666,7 +692,7 @@ func (o *Cluster) DisableUserWorkloadMonitoring() bool {
 // Indicates whether the User workload monitoring is enabled or not
 // It is enabled by default
 func (o *Cluster) GetDisableUserWorkloadMonitoring() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
+	ok = o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23]
 	if ok {
 		value = o.disableUserWorkloadMonitoring
 	}
@@ -679,7 +705,7 @@ func (o *Cluster) GetDisableUserWorkloadMonitoring() (value bool, ok bool) {
 // DomainPrefix of the cluster. This prefix is optionally assigned by the user when the
 // cluster is created. It will appear in the Cluster's domain when the cluster is provisioned.
 func (o *Cluster) DomainPrefix() string {
-	if o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23] {
+	if o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24] {
 		return o.domainPrefix
 	}
 	return ""
@@ -691,7 +717,7 @@ func (o *Cluster) DomainPrefix() string {
 // DomainPrefix of the cluster. This prefix is optionally assigned by the user when the
 // cluster is created. It will appear in the Cluster's domain when the cluster is provisioned.
 func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23]
+	ok = o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24]
 	if ok {
 		value = o.domainPrefix
 	}
@@ -705,7 +731,7 @@ func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
 // This is set only during cluster creation.
 // For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) EtcdEncryption() bool {
-	if o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24] {
+	if o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25] {
 		return o.etcdEncryption
 	}
 	return false
@@ -718,7 +744,7 @@ func (o *Cluster) EtcdEncryption() bool {
 // This is set only during cluster creation.
 // For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24]
+	ok = o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25]
 	if ok {
 		value = o.etcdEncryption
 	}
@@ -734,7 +760,7 @@ func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
 //
 // This option is unsupported.
 func (o *Cluster) ExpirationTimestamp() time.Time {
-	if o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25] {
+	if o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26] {
 		return o.expirationTimestamp
 	}
 	return time.Time{}
@@ -749,7 +775,7 @@ func (o *Cluster) ExpirationTimestamp() time.Time {
 //
 // This option is unsupported.
 func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25]
+	ok = o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26]
 	if ok {
 		value = o.expirationTimestamp
 	}
@@ -761,7 +787,7 @@ func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
 //
 // External identifier of the cluster, generated by the installer.
 func (o *Cluster) ExternalID() string {
-	if o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26] {
+	if o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27] {
 		return o.externalID
 	}
 	return ""
@@ -772,7 +798,7 @@ func (o *Cluster) ExternalID() string {
 //
 // External identifier of the cluster, generated by the installer.
 func (o *Cluster) GetExternalID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26]
+	ok = o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27]
 	if ok {
 		value = o.externalID
 	}
@@ -787,7 +813,7 @@ func (o *Cluster) GetExternalID() (value string, ok bool) {
 // For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
 // For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
-	if o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27] {
+	if o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28] {
 		return o.externalAuthConfig
 	}
 	return nil
@@ -801,7 +827,7 @@ func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 // For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
 // For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27]
+	ok = o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28]
 	if ok {
 		value = o.externalAuthConfig
 	}
@@ -813,7 +839,7 @@ func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
 //
 // ExternalConfiguration shows external configuration on the cluster.
 func (o *Cluster) ExternalConfiguration() *ExternalConfiguration {
-	if o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28] {
+	if o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29] {
 		return o.externalConfiguration
 	}
 	return nil
@@ -824,7 +850,7 @@ func (o *Cluster) ExternalConfiguration() *ExternalConfiguration {
 //
 // ExternalConfiguration shows external configuration on the cluster.
 func (o *Cluster) GetExternalConfiguration() (value *ExternalConfiguration, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28]
+	ok = o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29]
 	if ok {
 		value = o.externalConfiguration
 	}
@@ -836,7 +862,7 @@ func (o *Cluster) GetExternalConfiguration() (value *ExternalConfiguration, ok b
 //
 // Link to the _flavour_ that was used to create the cluster.
 func (o *Cluster) Flavour() *Flavour {
-	if o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29] {
+	if o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30] {
 		return o.flavour
 	}
 	return nil
@@ -847,7 +873,7 @@ func (o *Cluster) Flavour() *Flavour {
 //
 // Link to the _flavour_ that was used to create the cluster.
 func (o *Cluster) GetFlavour() (value *Flavour, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29]
+	ok = o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30]
 	if ok {
 		value = o.flavour
 	}
@@ -859,7 +885,7 @@ func (o *Cluster) GetFlavour() (value *Flavour, ok bool) {
 //
 // Link to the collection of groups of user of the cluster.
 func (o *Cluster) Groups() *GroupList {
-	if o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30] {
+	if o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31] {
 		return o.groups
 	}
 	return nil
@@ -870,7 +896,7 @@ func (o *Cluster) Groups() *GroupList {
 //
 // Link to the collection of groups of user of the cluster.
 func (o *Cluster) GetGroups() (value *GroupList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30]
+	ok = o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31]
 	if ok {
 		value = o.groups
 	}
@@ -882,7 +908,7 @@ func (o *Cluster) GetGroups() (value *GroupList, ok bool) {
 //
 // HealthState indicates the overall health state of the cluster.
 func (o *Cluster) HealthState() ClusterHealthState {
-	if o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31] {
+	if o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32] {
 		return o.healthState
 	}
 	return ClusterHealthState("")
@@ -893,7 +919,7 @@ func (o *Cluster) HealthState() ClusterHealthState {
 //
 // HealthState indicates the overall health state of the cluster.
 func (o *Cluster) GetHealthState() (value ClusterHealthState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31]
+	ok = o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32]
 	if ok {
 		value = o.healthState
 	}
@@ -905,7 +931,7 @@ func (o *Cluster) GetHealthState() (value ClusterHealthState, ok bool) {
 //
 // Details for `htpasswd` identity provider.
 func (o *Cluster) Htpasswd() *HTPasswdIdentityProvider {
-	if o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32] {
+	if o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33] {
 		return o.htpasswd
 	}
 	return nil
@@ -916,7 +942,7 @@ func (o *Cluster) Htpasswd() *HTPasswdIdentityProvider {
 //
 // Details for `htpasswd` identity provider.
 func (o *Cluster) GetHtpasswd() (value *HTPasswdIdentityProvider, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32]
+	ok = o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33]
 	if ok {
 		value = o.htpasswd
 	}
@@ -928,7 +954,7 @@ func (o *Cluster) GetHtpasswd() (value *HTPasswdIdentityProvider, ok bool) {
 //
 // Hypershift configuration.
 func (o *Cluster) Hypershift() *Hypershift {
-	if o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33] {
+	if o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34] {
 		return o.hypershift
 	}
 	return nil
@@ -939,7 +965,7 @@ func (o *Cluster) Hypershift() *Hypershift {
 //
 // Hypershift configuration.
 func (o *Cluster) GetHypershift() (value *Hypershift, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33]
+	ok = o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34]
 	if ok {
 		value = o.hypershift
 	}
@@ -951,7 +977,7 @@ func (o *Cluster) GetHypershift() (value *Hypershift, ok bool) {
 //
 // Link to the collection of identity providers of the cluster.
 func (o *Cluster) IdentityProviders() *IdentityProviderList {
-	if o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34] {
+	if o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35] {
 		return o.identityProviders
 	}
 	return nil
@@ -962,7 +988,7 @@ func (o *Cluster) IdentityProviders() *IdentityProviderList {
 //
 // Link to the collection of identity providers of the cluster.
 func (o *Cluster) GetIdentityProviders() (value *IdentityProviderList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34]
+	ok = o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35]
 	if ok {
 		value = o.identityProviders
 	}
@@ -976,7 +1002,7 @@ func (o *Cluster) GetIdentityProviders() (value *IdentityProviderList, ok bool) 
 // It provides an internal, integrated container image registry to locally manage images.
 // For non ARO-HCP clusters, it is readonly and always enabled
 func (o *Cluster) ImageRegistry() *ClusterImageRegistry {
-	if o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35] {
+	if o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36] {
 		return o.imageRegistry
 	}
 	return nil
@@ -989,7 +1015,7 @@ func (o *Cluster) ImageRegistry() *ClusterImageRegistry {
 // It provides an internal, integrated container image registry to locally manage images.
 // For non ARO-HCP clusters, it is readonly and always enabled
 func (o *Cluster) GetImageRegistry() (value *ClusterImageRegistry, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35]
+	ok = o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36]
 	if ok {
 		value = o.imageRegistry
 	}
@@ -1001,7 +1027,7 @@ func (o *Cluster) GetImageRegistry() (value *ClusterImageRegistry, ok bool) {
 //
 // List of inflight checks on this cluster.
 func (o *Cluster) InflightChecks() *InflightCheckList {
-	if o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36] {
+	if o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37] {
 		return o.inflightChecks
 	}
 	return nil
@@ -1012,7 +1038,7 @@ func (o *Cluster) InflightChecks() *InflightCheckList {
 //
 // List of inflight checks on this cluster.
 func (o *Cluster) GetInflightChecks() (value *InflightCheckList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36]
+	ok = o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37]
 	if ok {
 		value = o.inflightChecks
 	}
@@ -1024,7 +1050,7 @@ func (o *Cluster) GetInflightChecks() (value *InflightCheckList, ok bool) {
 //
 // InfraID is used for example to name the VPCs.
 func (o *Cluster) InfraID() string {
-	if o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37] {
+	if o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38] {
 		return o.infraID
 	}
 	return ""
@@ -1035,7 +1061,7 @@ func (o *Cluster) InfraID() string {
 //
 // InfraID is used for example to name the VPCs.
 func (o *Cluster) GetInfraID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37]
+	ok = o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38]
 	if ok {
 		value = o.infraID
 	}
@@ -1047,7 +1073,7 @@ func (o *Cluster) GetInfraID() (value string, ok bool) {
 //
 // List of ingresses on this cluster.
 func (o *Cluster) Ingresses() *IngressList {
-	if o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38] {
+	if o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39] {
 		return o.ingresses
 	}
 	return nil
@@ -1058,7 +1084,7 @@ func (o *Cluster) Ingresses() *IngressList {
 //
 // List of ingresses on this cluster.
 func (o *Cluster) GetIngresses() (value *IngressList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38]
+	ok = o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39]
 	if ok {
 		value = o.ingresses
 	}
@@ -1070,7 +1096,7 @@ func (o *Cluster) GetIngresses() (value *IngressList, ok bool) {
 //
 // Details of cluster-wide KubeletConfig
 func (o *Cluster) KubeletConfig() *KubeletConfig {
-	if o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39] {
+	if o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40] {
 		return o.kubeletConfig
 	}
 	return nil
@@ -1081,7 +1107,7 @@ func (o *Cluster) KubeletConfig() *KubeletConfig {
 //
 // Details of cluster-wide KubeletConfig
 func (o *Cluster) GetKubeletConfig() (value *KubeletConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39]
+	ok = o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40]
 	if ok {
 		value = o.kubeletConfig
 	}
@@ -1093,7 +1119,7 @@ func (o *Cluster) GetKubeletConfig() (value *KubeletConfig, ok bool) {
 //
 // Load Balancer quota to be assigned to the cluster.
 func (o *Cluster) LoadBalancerQuota() int {
-	if o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40] {
+	if o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41] {
 		return o.loadBalancerQuota
 	}
 	return 0
@@ -1104,7 +1130,7 @@ func (o *Cluster) LoadBalancerQuota() int {
 //
 // Load Balancer quota to be assigned to the cluster.
 func (o *Cluster) GetLoadBalancerQuota() (value int, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40]
+	ok = o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41]
 	if ok {
 		value = o.loadBalancerQuota
 	}
@@ -1116,7 +1142,7 @@ func (o *Cluster) GetLoadBalancerQuota() (value int, ok bool) {
 //
 // List of machine pools on this cluster.
 func (o *Cluster) MachinePools() *MachinePoolList {
-	if o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41] {
+	if o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42] {
 		return o.machinePools
 	}
 	return nil
@@ -1127,7 +1153,7 @@ func (o *Cluster) MachinePools() *MachinePoolList {
 //
 // List of machine pools on this cluster.
 func (o *Cluster) GetMachinePools() (value *MachinePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41]
+	ok = o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42]
 	if ok {
 		value = o.machinePools
 	}
@@ -1140,7 +1166,7 @@ func (o *Cluster) GetMachinePools() (value *MachinePoolList, ok bool) {
 // Flag indicating if the cluster is managed (by Red Hat) or
 // self-managed by the user.
 func (o *Cluster) Managed() bool {
-	if o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42] {
+	if o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43] {
 		return o.managed
 	}
 	return false
@@ -1152,7 +1178,7 @@ func (o *Cluster) Managed() bool {
 // Flag indicating if the cluster is managed (by Red Hat) or
 // self-managed by the user.
 func (o *Cluster) GetManaged() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42]
+	ok = o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43]
 	if ok {
 		value = o.managed
 	}
@@ -1164,7 +1190,7 @@ func (o *Cluster) GetManaged() (value bool, ok bool) {
 //
 // Contains information about Managed Service
 func (o *Cluster) ManagedService() *ManagedService {
-	if o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43] {
+	if o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44] {
 		return o.managedService
 	}
 	return nil
@@ -1175,7 +1201,7 @@ func (o *Cluster) ManagedService() *ManagedService {
 //
 // Contains information about Managed Service
 func (o *Cluster) GetManagedService() (value *ManagedService, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43]
+	ok = o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44]
 	if ok {
 		value = o.managedService
 	}
@@ -1192,7 +1218,7 @@ func (o *Cluster) GetManagedService() (value *ManagedService, ok bool) {
 // is deployed in multiple availability zones when the Azure region where
 // it is deployed supports multiple availability zones.
 func (o *Cluster) MultiAZ() bool {
-	if o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44] {
+	if o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45] {
 		return o.multiAZ
 	}
 	return false
@@ -1208,7 +1234,7 @@ func (o *Cluster) MultiAZ() bool {
 // is deployed in multiple availability zones when the Azure region where
 // it is deployed supports multiple availability zones.
 func (o *Cluster) GetMultiAZ() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44]
+	ok = o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45]
 	if ok {
 		value = o.multiAZ
 	}
@@ -1220,7 +1246,7 @@ func (o *Cluster) GetMultiAZ() (value bool, ok bool) {
 //
 // Indicate whether the cluster is enabled for multi arch workers
 func (o *Cluster) MultiArchEnabled() bool {
-	if o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45] {
+	if o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46] {
 		return o.multiArchEnabled
 	}
 	return false
@@ -1231,7 +1257,7 @@ func (o *Cluster) MultiArchEnabled() bool {
 //
 // Indicate whether the cluster is enabled for multi arch workers
 func (o *Cluster) GetMultiArchEnabled() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45]
+	ok = o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46]
 	if ok {
 		value = o.multiArchEnabled
 	}
@@ -1244,7 +1270,7 @@ func (o *Cluster) GetMultiArchEnabled() (value bool, ok bool) {
 // Name of the cluster. This name is assigned by the user when the
 // cluster is created. This is used to uniquely identify the cluster
 func (o *Cluster) Name() string {
-	if o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46] {
+	if o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47] {
 		return o.name
 	}
 	return ""
@@ -1256,7 +1282,7 @@ func (o *Cluster) Name() string {
 // Name of the cluster. This name is assigned by the user when the
 // cluster is created. This is used to uniquely identify the cluster
 func (o *Cluster) GetName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46]
+	ok = o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47]
 	if ok {
 		value = o.name
 	}
@@ -1268,7 +1294,7 @@ func (o *Cluster) GetName() (value string, ok bool) {
 //
 // Network settings of the cluster.
 func (o *Cluster) Network() *Network {
-	if o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47] {
+	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
 		return o.network
 	}
 	return nil
@@ -1279,7 +1305,7 @@ func (o *Cluster) Network() *Network {
 //
 // Network settings of the cluster.
 func (o *Cluster) GetNetwork() (value *Network, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47]
+	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
 	if ok {
 		value = o.network
 	}
@@ -1291,7 +1317,7 @@ func (o *Cluster) GetNetwork() (value *Network, ok bool) {
 //
 // Node drain grace period.
 func (o *Cluster) NodeDrainGracePeriod() *Value {
-	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
+	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
 		return o.nodeDrainGracePeriod
 	}
 	return nil
@@ -1302,7 +1328,7 @@ func (o *Cluster) NodeDrainGracePeriod() *Value {
 //
 // Node drain grace period.
 func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
+	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
 	if ok {
 		value = o.nodeDrainGracePeriod
 	}
@@ -1315,7 +1341,7 @@ func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) NodePools() *NodePoolList {
-	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
+	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
 		return o.nodePools
 	}
 	return nil
@@ -1327,7 +1353,7 @@ func (o *Cluster) NodePools() *NodePoolList {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
+	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
 	if ok {
 		value = o.nodePools
 	}
@@ -1339,7 +1365,7 @@ func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) Nodes() *ClusterNodes {
-	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
+	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
 		return o.nodes
 	}
 	return nil
@@ -1350,7 +1376,7 @@ func (o *Cluster) Nodes() *ClusterNodes {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
+	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
 	if ok {
 		value = o.nodes
 	}
@@ -1367,7 +1393,7 @@ func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) OpenshiftVersion() string {
-	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
+	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
 		return o.openshiftVersion
 	}
 	return ""
@@ -1383,7 +1409,7 @@ func (o *Cluster) OpenshiftVersion() string {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
+	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
 	if ok {
 		value = o.openshiftVersion
 	}
@@ -1395,7 +1421,7 @@ func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) Product() *Product {
-	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
+	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
 		return o.product
 	}
 	return nil
@@ -1406,7 +1432,7 @@ func (o *Cluster) Product() *Product {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) GetProduct() (value *Product, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
+	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
 	if ok {
 		value = o.product
 	}
@@ -1418,7 +1444,7 @@ func (o *Cluster) GetProduct() (value *Product, ok bool) {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) Properties() map[string]string {
-	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
+	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
 		return o.properties
 	}
 	return nil
@@ -1429,7 +1455,7 @@ func (o *Cluster) Properties() map[string]string {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
+	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
 	if ok {
 		value = o.properties
 	}
@@ -1441,7 +1467,7 @@ func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) ProvisionShard() *ProvisionShard {
-	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
+	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
 		return o.provisionShard
 	}
 	return nil
@@ -1452,7 +1478,7 @@ func (o *Cluster) ProvisionShard() *ProvisionShard {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
+	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
 	if ok {
 		value = o.provisionShard
 	}
@@ -1464,7 +1490,7 @@ func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
 //
 // Proxy.
 func (o *Cluster) Proxy() *Proxy {
-	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
+	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
 		return o.proxy
 	}
 	return nil
@@ -1475,7 +1501,7 @@ func (o *Cluster) Proxy() *Proxy {
 //
 // Proxy.
 func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
+	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
 	if ok {
 		value = o.proxy
 	}
@@ -1487,7 +1513,7 @@ func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) Region() *CloudRegion {
-	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
+	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
 		return o.region
 	}
 	return nil
@@ -1498,7 +1524,7 @@ func (o *Cluster) Region() *CloudRegion {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) GetRegion() (value *CloudRegion, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
+	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
 	if ok {
 		value = o.region
 	}
@@ -1510,7 +1536,7 @@ func (o *Cluster) GetRegion() (value *CloudRegion, ok bool) {
 //
 // External registry configuration for the cluster
 func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
-	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
+	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
 		return o.registryConfig
 	}
 	return nil
@@ -1521,7 +1547,7 @@ func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
 //
 // External registry configuration for the cluster
 func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
+	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
 	if ok {
 		value = o.registryConfig
 	}
@@ -1533,7 +1559,7 @@ func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
 //
 // Overall state of the cluster.
 func (o *Cluster) State() ClusterState {
-	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
+	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
 		return o.state
 	}
 	return ClusterState("")
@@ -1544,7 +1570,7 @@ func (o *Cluster) State() ClusterState {
 //
 // Overall state of the cluster.
 func (o *Cluster) GetState() (value ClusterState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
+	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
 	if ok {
 		value = o.state
 	}
@@ -1556,7 +1582,7 @@ func (o *Cluster) GetState() (value ClusterState, ok bool) {
 //
 // Status of cluster
 func (o *Cluster) Status() *ClusterStatus {
-	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
+	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
 		return o.status
 	}
 	return nil
@@ -1567,7 +1593,7 @@ func (o *Cluster) Status() *ClusterStatus {
 //
 // Status of cluster
 func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
+	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
 	if ok {
 		value = o.status
 	}
@@ -1579,7 +1605,7 @@ func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) StorageQuota() *Value {
-	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
+	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
 		return o.storageQuota
 	}
 	return nil
@@ -1590,7 +1616,7 @@ func (o *Cluster) StorageQuota() *Value {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
+	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
 	if ok {
 		value = o.storageQuota
 	}
@@ -1603,7 +1629,7 @@ func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) Subscription() *Subscription {
-	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
+	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
 		return o.subscription
 	}
 	return nil
@@ -1615,7 +1641,7 @@ func (o *Cluster) Subscription() *Subscription {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) GetSubscription() (value *Subscription, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
+	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
 	if ok {
 		value = o.subscription
 	}
@@ -1627,7 +1653,7 @@ func (o *Cluster) GetSubscription() (value *Subscription, ok bool) {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) Version() *Version {
-	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
+	if o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63] {
 		return o.version
 	}
 	return nil
@@ -1638,7 +1664,7 @@ func (o *Cluster) Version() *Version {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) GetVersion() (value *Version, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
+	ok = o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63]
 	if ok {
 		value = o.version
 	}

--- a/clientapi/clustersmgmt/v1/cluster_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_type_json.go
@@ -172,7 +172,16 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14] && object.autoscaler != nil
+	present_ = len(object.fieldSet_) > 14 && object.fieldSet_[14] && object.autoNode != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("auto_node")
+		WriteClusterAutoNode(object.autoNode, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15] && object.autoscaler != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -181,7 +190,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterAutoscaler(object.autoscaler, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 15 && object.fieldSet_[15] && object.azure != nil
+	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16] && object.azure != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -190,7 +199,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteAzure(object.azure, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 16 && object.fieldSet_[16]
+	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -199,7 +208,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.billingModel))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 17 && object.fieldSet_[17] && object.byoOidc != nil
+	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18] && object.byoOidc != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -208,7 +217,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteByoOidc(object.byoOidc, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 18 && object.fieldSet_[18] && object.cloudProvider != nil
+	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.cloudProvider != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -217,7 +226,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteCloudProvider(object.cloudProvider, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.console != nil
+	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.console != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -226,7 +235,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterConsole(object.console, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20]
+	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -235,7 +244,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString((object.creationTimestamp).Format(time.RFC3339))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21] && object.deleteProtection != nil
+	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22] && object.deleteProtection != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -244,7 +253,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteDeleteProtection(object.deleteProtection, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22]
+	present_ = len(object.fieldSet_) > 23 && object.fieldSet_[23]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -253,7 +262,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.disableUserWorkloadMonitoring)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 23 && object.fieldSet_[23]
+	present_ = len(object.fieldSet_) > 24 && object.fieldSet_[24]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -262,7 +271,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.domainPrefix)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 24 && object.fieldSet_[24]
+	present_ = len(object.fieldSet_) > 25 && object.fieldSet_[25]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -271,7 +280,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.etcdEncryption)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 25 && object.fieldSet_[25]
+	present_ = len(object.fieldSet_) > 26 && object.fieldSet_[26]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -280,7 +289,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString((object.expirationTimestamp).Format(time.RFC3339))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 26 && object.fieldSet_[26]
+	present_ = len(object.fieldSet_) > 27 && object.fieldSet_[27]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -289,7 +298,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.externalID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 27 && object.fieldSet_[27] && object.externalAuthConfig != nil
+	present_ = len(object.fieldSet_) > 28 && object.fieldSet_[28] && object.externalAuthConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -298,7 +307,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteExternalAuthConfig(object.externalAuthConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 28 && object.fieldSet_[28] && object.externalConfiguration != nil
+	present_ = len(object.fieldSet_) > 29 && object.fieldSet_[29] && object.externalConfiguration != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -307,7 +316,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteExternalConfiguration(object.externalConfiguration, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 29 && object.fieldSet_[29] && object.flavour != nil
+	present_ = len(object.fieldSet_) > 30 && object.fieldSet_[30] && object.flavour != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -316,7 +325,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteFlavour(object.flavour, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 30 && object.fieldSet_[30] && object.groups != nil
+	present_ = len(object.fieldSet_) > 31 && object.fieldSet_[31] && object.groups != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -328,7 +337,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 31 && object.fieldSet_[31]
+	present_ = len(object.fieldSet_) > 32 && object.fieldSet_[32]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -337,7 +346,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.healthState))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 32 && object.fieldSet_[32] && object.htpasswd != nil
+	present_ = len(object.fieldSet_) > 33 && object.fieldSet_[33] && object.htpasswd != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -346,7 +355,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteHTPasswdIdentityProvider(object.htpasswd, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 33 && object.fieldSet_[33] && object.hypershift != nil
+	present_ = len(object.fieldSet_) > 34 && object.fieldSet_[34] && object.hypershift != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -355,7 +364,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteHypershift(object.hypershift, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 34 && object.fieldSet_[34] && object.identityProviders != nil
+	present_ = len(object.fieldSet_) > 35 && object.fieldSet_[35] && object.identityProviders != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -367,7 +376,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 35 && object.fieldSet_[35] && object.imageRegistry != nil
+	present_ = len(object.fieldSet_) > 36 && object.fieldSet_[36] && object.imageRegistry != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -376,7 +385,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterImageRegistry(object.imageRegistry, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 36 && object.fieldSet_[36] && object.inflightChecks != nil
+	present_ = len(object.fieldSet_) > 37 && object.fieldSet_[37] && object.inflightChecks != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -388,7 +397,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 37 && object.fieldSet_[37]
+	present_ = len(object.fieldSet_) > 38 && object.fieldSet_[38]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -397,7 +406,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.infraID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 38 && object.fieldSet_[38] && object.ingresses != nil
+	present_ = len(object.fieldSet_) > 39 && object.fieldSet_[39] && object.ingresses != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -409,7 +418,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 39 && object.fieldSet_[39] && object.kubeletConfig != nil
+	present_ = len(object.fieldSet_) > 40 && object.fieldSet_[40] && object.kubeletConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -418,7 +427,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteKubeletConfig(object.kubeletConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 40 && object.fieldSet_[40]
+	present_ = len(object.fieldSet_) > 41 && object.fieldSet_[41]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -427,7 +436,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteInt(object.loadBalancerQuota)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 41 && object.fieldSet_[41] && object.machinePools != nil
+	present_ = len(object.fieldSet_) > 42 && object.fieldSet_[42] && object.machinePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -439,7 +448,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 42 && object.fieldSet_[42]
+	present_ = len(object.fieldSet_) > 43 && object.fieldSet_[43]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -448,7 +457,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.managed)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 43 && object.fieldSet_[43] && object.managedService != nil
+	present_ = len(object.fieldSet_) > 44 && object.fieldSet_[44] && object.managedService != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -457,7 +466,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteManagedService(object.managedService, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 44 && object.fieldSet_[44]
+	present_ = len(object.fieldSet_) > 45 && object.fieldSet_[45]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -466,7 +475,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.multiAZ)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 45 && object.fieldSet_[45]
+	present_ = len(object.fieldSet_) > 46 && object.fieldSet_[46]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -475,7 +484,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.multiArchEnabled)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 46 && object.fieldSet_[46]
+	present_ = len(object.fieldSet_) > 47 && object.fieldSet_[47]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -484,7 +493,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.name)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 47 && object.fieldSet_[47] && object.network != nil
+	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48] && object.network != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -493,7 +502,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteNetwork(object.network, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48] && object.nodeDrainGracePeriod != nil
+	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49] && object.nodeDrainGracePeriod != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -502,7 +511,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.nodeDrainGracePeriod, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49] && object.nodePools != nil
+	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.nodePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -514,7 +523,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.nodes != nil
+	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51] && object.nodes != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -523,7 +532,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterNodes(object.nodes, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51]
+	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -532,7 +541,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.openshiftVersion)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52] && object.product != nil
+	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.product != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -541,7 +550,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProduct(object.product, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.properties != nil
+	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.properties != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -570,7 +579,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.provisionShard != nil
+	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.provisionShard != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -579,7 +588,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProvisionShard(object.provisionShard, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.proxy != nil
+	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.proxy != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -588,7 +597,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProxy(object.proxy, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.region != nil
+	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.region != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -597,7 +606,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteCloudRegion(object.region, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.registryConfig != nil
+	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58] && object.registryConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -606,7 +615,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterRegistryConfig(object.registryConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58]
+	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -615,7 +624,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.state))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59] && object.status != nil
+	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.status != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -624,7 +633,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterStatus(object.status, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.storageQuota != nil
+	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.storageQuota != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -633,7 +642,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.storageQuota, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.subscription != nil
+	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.subscription != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -642,7 +651,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteSubscription(object.subscription, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.version != nil
+	present_ = len(object.fieldSet_) > 63 && object.fieldSet_[63] && object.version != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -668,7 +677,7 @@ func UnmarshalCluster(source interface{}) (object *Cluster, err error) {
 // ReadCluster reads a value of the 'cluster' type from the given iterator.
 func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 	object := &Cluster{
-		fieldSet_: make([]bool, 63),
+		fieldSet_: make([]bool, 64),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -765,31 +774,35 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 			}
 			object.addons = value
 			object.fieldSet_[13] = true
+		case "auto_node":
+			value := ReadClusterAutoNode(iterator)
+			object.autoNode = value
+			object.fieldSet_[14] = true
 		case "autoscaler":
 			value := ReadClusterAutoscaler(iterator)
 			object.autoscaler = value
-			object.fieldSet_[14] = true
+			object.fieldSet_[15] = true
 		case "azure":
 			value := ReadAzure(iterator)
 			object.azure = value
-			object.fieldSet_[15] = true
+			object.fieldSet_[16] = true
 		case "billing_model":
 			text := iterator.ReadString()
 			value := BillingModel(text)
 			object.billingModel = value
-			object.fieldSet_[16] = true
+			object.fieldSet_[17] = true
 		case "byo_oidc":
 			value := ReadByoOidc(iterator)
 			object.byoOidc = value
-			object.fieldSet_[17] = true
+			object.fieldSet_[18] = true
 		case "cloud_provider":
 			value := ReadCloudProvider(iterator)
 			object.cloudProvider = value
-			object.fieldSet_[18] = true
+			object.fieldSet_[19] = true
 		case "console":
 			value := ReadClusterConsole(iterator)
 			object.console = value
-			object.fieldSet_[19] = true
+			object.fieldSet_[20] = true
 		case "creation_timestamp":
 			text := iterator.ReadString()
 			value, err := time.Parse(time.RFC3339, text)
@@ -797,23 +810,23 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				iterator.ReportError("", err.Error())
 			}
 			object.creationTimestamp = value
-			object.fieldSet_[20] = true
+			object.fieldSet_[21] = true
 		case "delete_protection":
 			value := ReadDeleteProtection(iterator)
 			object.deleteProtection = value
-			object.fieldSet_[21] = true
+			object.fieldSet_[22] = true
 		case "disable_user_workload_monitoring":
 			value := iterator.ReadBool()
 			object.disableUserWorkloadMonitoring = value
-			object.fieldSet_[22] = true
+			object.fieldSet_[23] = true
 		case "domain_prefix":
 			value := iterator.ReadString()
 			object.domainPrefix = value
-			object.fieldSet_[23] = true
+			object.fieldSet_[24] = true
 		case "etcd_encryption":
 			value := iterator.ReadBool()
 			object.etcdEncryption = value
-			object.fieldSet_[24] = true
+			object.fieldSet_[25] = true
 		case "expiration_timestamp":
 			text := iterator.ReadString()
 			value, err := time.Parse(time.RFC3339, text)
@@ -821,23 +834,23 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				iterator.ReportError("", err.Error())
 			}
 			object.expirationTimestamp = value
-			object.fieldSet_[25] = true
+			object.fieldSet_[26] = true
 		case "external_id":
 			value := iterator.ReadString()
 			object.externalID = value
-			object.fieldSet_[26] = true
+			object.fieldSet_[27] = true
 		case "external_auth_config":
 			value := ReadExternalAuthConfig(iterator)
 			object.externalAuthConfig = value
-			object.fieldSet_[27] = true
+			object.fieldSet_[28] = true
 		case "external_configuration":
 			value := ReadExternalConfiguration(iterator)
 			object.externalConfiguration = value
-			object.fieldSet_[28] = true
+			object.fieldSet_[29] = true
 		case "flavour":
 			value := ReadFlavour(iterator)
 			object.flavour = value
-			object.fieldSet_[29] = true
+			object.fieldSet_[30] = true
 		case "groups":
 			value := &GroupList{}
 			for {
@@ -858,20 +871,20 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.groups = value
-			object.fieldSet_[30] = true
+			object.fieldSet_[31] = true
 		case "health_state":
 			text := iterator.ReadString()
 			value := ClusterHealthState(text)
 			object.healthState = value
-			object.fieldSet_[31] = true
+			object.fieldSet_[32] = true
 		case "htpasswd":
 			value := ReadHTPasswdIdentityProvider(iterator)
 			object.htpasswd = value
-			object.fieldSet_[32] = true
+			object.fieldSet_[33] = true
 		case "hypershift":
 			value := ReadHypershift(iterator)
 			object.hypershift = value
-			object.fieldSet_[33] = true
+			object.fieldSet_[34] = true
 		case "identity_providers":
 			value := &IdentityProviderList{}
 			for {
@@ -892,11 +905,11 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.identityProviders = value
-			object.fieldSet_[34] = true
+			object.fieldSet_[35] = true
 		case "image_registry":
 			value := ReadClusterImageRegistry(iterator)
 			object.imageRegistry = value
-			object.fieldSet_[35] = true
+			object.fieldSet_[36] = true
 		case "inflight_checks":
 			value := &InflightCheckList{}
 			for {
@@ -917,11 +930,11 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.inflightChecks = value
-			object.fieldSet_[36] = true
+			object.fieldSet_[37] = true
 		case "infra_id":
 			value := iterator.ReadString()
 			object.infraID = value
-			object.fieldSet_[37] = true
+			object.fieldSet_[38] = true
 		case "ingresses":
 			value := &IngressList{}
 			for {
@@ -942,15 +955,15 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.ingresses = value
-			object.fieldSet_[38] = true
+			object.fieldSet_[39] = true
 		case "kubelet_config":
 			value := ReadKubeletConfig(iterator)
 			object.kubeletConfig = value
-			object.fieldSet_[39] = true
+			object.fieldSet_[40] = true
 		case "load_balancer_quota":
 			value := iterator.ReadInt()
 			object.loadBalancerQuota = value
-			object.fieldSet_[40] = true
+			object.fieldSet_[41] = true
 		case "machine_pools":
 			value := &MachinePoolList{}
 			for {
@@ -971,35 +984,35 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.machinePools = value
-			object.fieldSet_[41] = true
+			object.fieldSet_[42] = true
 		case "managed":
 			value := iterator.ReadBool()
 			object.managed = value
-			object.fieldSet_[42] = true
+			object.fieldSet_[43] = true
 		case "managed_service":
 			value := ReadManagedService(iterator)
 			object.managedService = value
-			object.fieldSet_[43] = true
+			object.fieldSet_[44] = true
 		case "multi_az":
 			value := iterator.ReadBool()
 			object.multiAZ = value
-			object.fieldSet_[44] = true
+			object.fieldSet_[45] = true
 		case "multi_arch_enabled":
 			value := iterator.ReadBool()
 			object.multiArchEnabled = value
-			object.fieldSet_[45] = true
+			object.fieldSet_[46] = true
 		case "name":
 			value := iterator.ReadString()
 			object.name = value
-			object.fieldSet_[46] = true
+			object.fieldSet_[47] = true
 		case "network":
 			value := ReadNetwork(iterator)
 			object.network = value
-			object.fieldSet_[47] = true
+			object.fieldSet_[48] = true
 		case "node_drain_grace_period":
 			value := ReadValue(iterator)
 			object.nodeDrainGracePeriod = value
-			object.fieldSet_[48] = true
+			object.fieldSet_[49] = true
 		case "node_pools":
 			value := &NodePoolList{}
 			for {
@@ -1020,19 +1033,19 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.nodePools = value
-			object.fieldSet_[49] = true
+			object.fieldSet_[50] = true
 		case "nodes":
 			value := ReadClusterNodes(iterator)
 			object.nodes = value
-			object.fieldSet_[50] = true
+			object.fieldSet_[51] = true
 		case "openshift_version":
 			value := iterator.ReadString()
 			object.openshiftVersion = value
-			object.fieldSet_[51] = true
+			object.fieldSet_[52] = true
 		case "product":
 			value := ReadProduct(iterator)
 			object.product = value
-			object.fieldSet_[52] = true
+			object.fieldSet_[53] = true
 		case "properties":
 			value := map[string]string{}
 			for {
@@ -1044,44 +1057,44 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				value[key] = item
 			}
 			object.properties = value
-			object.fieldSet_[53] = true
+			object.fieldSet_[54] = true
 		case "provision_shard":
 			value := ReadProvisionShard(iterator)
 			object.provisionShard = value
-			object.fieldSet_[54] = true
+			object.fieldSet_[55] = true
 		case "proxy":
 			value := ReadProxy(iterator)
 			object.proxy = value
-			object.fieldSet_[55] = true
+			object.fieldSet_[56] = true
 		case "region":
 			value := ReadCloudRegion(iterator)
 			object.region = value
-			object.fieldSet_[56] = true
+			object.fieldSet_[57] = true
 		case "registry_config":
 			value := ReadClusterRegistryConfig(iterator)
 			object.registryConfig = value
-			object.fieldSet_[57] = true
+			object.fieldSet_[58] = true
 		case "state":
 			text := iterator.ReadString()
 			value := ClusterState(text)
 			object.state = value
-			object.fieldSet_[58] = true
+			object.fieldSet_[59] = true
 		case "status":
 			value := ReadClusterStatus(iterator)
 			object.status = value
-			object.fieldSet_[59] = true
+			object.fieldSet_[60] = true
 		case "storage_quota":
 			value := ReadValue(iterator)
 			object.storageQuota = value
-			object.fieldSet_[60] = true
+			object.fieldSet_[61] = true
 		case "subscription":
 			value := ReadSubscription(iterator)
 			object.subscription = value
-			object.fieldSet_[61] = true
+			object.fieldSet_[62] = true
 		case "version":
 			value := ReadVersion(iterator)
 			object.version = value
-			object.fieldSet_[62] = true
+			object.fieldSet_[63] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/aws_autonode_type.model
+++ b/model/clusters_mgmt/v1/aws_autonode_type.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
+struct AwsAutoNode {
+    // The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+    // controller.
+    // The role must exist prior to enabling AutoNode on the cluster.
+    RoleArn String
+}

--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -79,4 +79,7 @@ struct AWS {
 
 	// Additional allowed principal ARNs to be added to the hosted control plane's VPC Endpoint Service.
 	AdditionalAllowedPrincipals []String
+
+    // AWS specific configuration for AutoNode
+	AutoNode AwsAutoNode
 }

--- a/model/clusters_mgmt/v1/cluster_autonode_type.model
+++ b/model/clusters_mgmt/v1/cluster_autonode_type.model
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The AutoNode configuration for the Cluster.
+struct ClusterAutoNode {
+    // Mode indicates the current state of AutoNode on this cluster.
+    // Valid values: "enabled", "disabled".
+    Mode String
+    Status ClusterAutoNodeStatus
+}
+
+// Additional status information on the AutoNode configuration on this Cluster
+struct ClusterAutoNodeStatus {
+    // Messages relating to the status of the AutoNode installation on this Cluster
+    Message String
+}

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -257,4 +257,8 @@ class Cluster {
 	// It provides an internal, integrated container image registry to locally manage images.
 	// For non ARO-HCP clusters, it is readonly and always enabled
 	ImageRegistry ClusterImageRegistry
+
+	// The AutoNode settings for this cluster.
+	// This is currently only supported for ROSA HCP
+	AutoNode ClusterAutoNode
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -1324,6 +1324,10 @@
             "description": "Audit log forwarding configuration",
             "$ref": "#/components/schemas/AuditLog"
           },
+          "auto_node": {
+            "description": "AWS specific configuration for AutoNode",
+            "$ref": "#/components/schemas/AwsAutoNode"
+          },
           "billing_account_id": {
             "description": "BillingAccountID is the account used for billing subscriptions purchased via the marketplace",
             "type": "string"
@@ -1789,6 +1793,15 @@
           }
         }
       },
+      "AwsAutoNode": {
+        "description": "AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster",
+        "properties": {
+          "role_arn": {
+            "description": "The AWS ARN of the IAM Role that has the permissions required for the AutoNode\ncontroller.\nThe role must exist prior to enabling AutoNode on the cluster.",
+            "type": "string"
+          }
+        }
+      },
       "AwsEtcdEncryption": {
         "description": "Contains the necessary attributes to support etcd encryption for AWS based clusters.",
         "properties": {
@@ -2245,6 +2258,10 @@
               "$ref": "#/components/schemas/AddOnInstallation"
             }
           },
+          "auto_node": {
+            "description": "The AutoNode settings for this cluster.\nThis is currently only supported for ROSA HCP",
+            "$ref": "#/components/schemas/ClusterAutoNode"
+          },
           "autoscaler": {
             "description": "Link to an optional _ClusterAutoscaler_ that is coupled with the cluster.",
             "$ref": "#/components/schemas/ClusterAutoscaler"
@@ -2477,6 +2494,27 @@
           "listening": {
             "description": "The listening method of the API server.",
             "$ref": "#/components/schemas/ListeningMethod"
+          }
+        }
+      },
+      "ClusterAutoNode": {
+        "description": "The AutoNode configuration for the Cluster.",
+        "properties": {
+          "mode": {
+            "description": "Mode indicates the current state of AutoNode on this cluster.\nValid values: \"enabled\", \"disabled\".",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ClusterAutoNodeStatus"
+          }
+        }
+      },
+      "ClusterAutoNodeStatus": {
+        "description": "Additional status information on the AutoNode configuration on this Cluster",
+        "properties": {
+          "message": {
+            "description": "Messages relating to the status of the AutoNode installation on this Cluster",
+            "type": "string"
           }
         }
       },

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -13269,6 +13269,10 @@
             "description": "Audit log forwarding configuration",
             "$ref": "#/components/schemas/AuditLog"
           },
+          "auto_node": {
+            "description": "AWS specific configuration for AutoNode",
+            "$ref": "#/components/schemas/AwsAutoNode"
+          },
           "billing_account_id": {
             "description": "BillingAccountID is the account used for billing subscriptions purchased via the marketplace",
             "type": "string"
@@ -15012,6 +15016,15 @@
           }
         }
       },
+      "AwsAutoNode": {
+        "description": "AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster",
+        "properties": {
+          "role_arn": {
+            "description": "The AWS ARN of the IAM Role that has the permissions required for the AutoNode\ncontroller.\nThe role must exist prior to enabling AutoNode on the cluster.",
+            "type": "string"
+          }
+        }
+      },
       "AwsEtcdEncryption": {
         "description": "Contains the necessary attributes to support etcd encryption for AWS based clusters.",
         "properties": {
@@ -15653,6 +15666,10 @@
               "$ref": "#/components/schemas/AddOnInstallation"
             }
           },
+          "auto_node": {
+            "description": "The AutoNode settings for this cluster.\nThis is currently only supported for ROSA HCP",
+            "$ref": "#/components/schemas/ClusterAutoNode"
+          },
           "autoscaler": {
             "description": "Link to an optional _ClusterAutoscaler_ that is coupled with the cluster.",
             "$ref": "#/components/schemas/ClusterAutoscaler"
@@ -15895,6 +15912,27 @@
           "classic",
           "hcp"
         ]
+      },
+      "ClusterAutoNode": {
+        "description": "The AutoNode configuration for the Cluster.",
+        "properties": {
+          "mode": {
+            "description": "Mode indicates the current state of AutoNode on this cluster.\nValid values: \"enabled\", \"disabled\".",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ClusterAutoNodeStatus"
+          }
+        }
+      },
+      "ClusterAutoNodeStatus": {
+        "description": "Additional status information on the AutoNode configuration on this Cluster",
+        "properties": {
+          "message": {
+            "description": "Messages relating to the status of the AutoNode installation on this Cluster",
+            "type": "string"
+          }
+        }
       },
       "ClusterAutoscaler": {
         "description": "Cluster-wide autoscaling configuration.",


### PR DESCRIPTION
This MR presents the API for AutoNode support on Cluster Service for private preview. 

AutoNode is the product name for Karpenter. Karpenter is a cluster autoscaler that supports heterogenous node types for compute resources on a cluster.

This MR proposes the following changes to the Cluster spec:

```
# AWS provider specific configuration for AutoNode
"aws": {
 "auto_node": {
   "role_arn": "The Role ARN
 }
},
# Cluster-wide configuration and status for AutoNode
auto_node : {
 # The state of AutoNode on the cluster, either enabled or disabled initially
 "state": "enabled|disabled",
 "status": {
   "message": "Additional message about the status of the AutoNode configuration on this cluster. Bubbled up from Hypershift",
  },
}
```

This is the minimal API for private preview and will be supported as a PATCH operation on the cluster, facilitating day 2 operations.

Please see the DDR for full context on the Private Preview: https://docs.google.com/document/d/19Bis24gVh9HnkihBGVZug2UjULEZF7Wzt219BMU3lMw/edit?tab=t.0