### PR TITLE
Remove old field osDiskSseEncryptionSetResourceId in AzureNodePool model

### DIFF
--- a/clientapi/arohcp/v1alpha1/azure_node_pool_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_builder.go
@@ -21,21 +21,20 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 
 // Representation of azure node pool specific parameters.
 type AzureNodePoolBuilder struct {
-	fieldSet_                        []bool
-	osDiskSizeGibibytes              int
-	osDiskStorageAccountType         string
-	vmSize                           string
-	encryptionAtHost                 *AzureNodePoolEncryptionAtHostBuilder
-	osDisk                           *AzureNodePoolOsDiskBuilder
-	osDiskSseEncryptionSetResourceId string
-	resourceName                     string
-	ephemeralOSDiskEnabled           bool
+	fieldSet_                []bool
+	osDiskSizeGibibytes      int
+	osDiskStorageAccountType string
+	vmSize                   string
+	encryptionAtHost         *AzureNodePoolEncryptionAtHostBuilder
+	osDisk                   *AzureNodePoolOsDiskBuilder
+	resourceName             string
+	ephemeralOSDiskEnabled   bool
 }
 
 // NewAzureNodePool creates a new builder of 'azure_node_pool' objects.
 func NewAzureNodePool() *AzureNodePoolBuilder {
 	return &AzureNodePoolBuilder{
-		fieldSet_: make([]bool, 8),
+		fieldSet_: make([]bool, 7),
 	}
 }
 
@@ -55,7 +54,7 @@ func (b *AzureNodePoolBuilder) Empty() bool {
 // OSDiskSizeGibibytes sets the value of the 'OS_disk_size_gibibytes' attribute to the given value.
 func (b *AzureNodePoolBuilder) OSDiskSizeGibibytes(value int) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.osDiskSizeGibibytes = value
 	b.fieldSet_[0] = true
@@ -65,7 +64,7 @@ func (b *AzureNodePoolBuilder) OSDiskSizeGibibytes(value int) *AzureNodePoolBuil
 // OSDiskStorageAccountType sets the value of the 'OS_disk_storage_account_type' attribute to the given value.
 func (b *AzureNodePoolBuilder) OSDiskStorageAccountType(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.osDiskStorageAccountType = value
 	b.fieldSet_[1] = true
@@ -75,7 +74,7 @@ func (b *AzureNodePoolBuilder) OSDiskStorageAccountType(value string) *AzureNode
 // VMSize sets the value of the 'VM_size' attribute to the given value.
 func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.vmSize = value
 	b.fieldSet_[2] = true
@@ -88,7 +87,7 @@ func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 // If not specified, Encryption at Host is not enabled.
 func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAtHostBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.encryptionAtHost = value
 	if value != nil {
@@ -102,7 +101,7 @@ func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAt
 // EphemeralOSDiskEnabled sets the value of the 'ephemeral_OS_disk_enabled' attribute to the given value.
 func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.ephemeralOSDiskEnabled = value
 	b.fieldSet_[4] = true
@@ -114,7 +113,7 @@ func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePool
 // Defines the configuration of a Node Pool's OS disk.
 func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.osDisk = value
 	if value != nil {
@@ -125,23 +124,13 @@ func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureN
 	return b
 }
 
-// OsDiskSseEncryptionSetResourceId sets the value of the 'os_disk_sse_encryption_set_resource_id' attribute to the given value.
-func (b *AzureNodePoolBuilder) OsDiskSseEncryptionSetResourceId(value string) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
-	}
-	b.osDiskSseEncryptionSetResourceId = value
-	b.fieldSet_[6] = true
-	return b
-}
-
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureNodePoolBuilder) ResourceName(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.resourceName = value
-	b.fieldSet_[7] = true
+	b.fieldSet_[6] = true
 	return b
 }
 
@@ -168,7 +157,6 @@ func (b *AzureNodePoolBuilder) Copy(object *AzureNodePool) *AzureNodePoolBuilder
 	} else {
 		b.osDisk = nil
 	}
-	b.osDiskSseEncryptionSetResourceId = object.osDiskSseEncryptionSetResourceId
 	b.resourceName = object.resourceName
 	return b
 }
@@ -196,7 +184,6 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 			return
 		}
 	}
-	object.osDiskSseEncryptionSetResourceId = b.osDiskSseEncryptionSetResourceId
 	object.resourceName = b.resourceName
 	return
 }

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_type.go
@@ -23,15 +23,14 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 //
 // Representation of azure node pool specific parameters.
 type AzureNodePool struct {
-	fieldSet_                        []bool
-	osDiskSizeGibibytes              int
-	osDiskStorageAccountType         string
-	vmSize                           string
-	encryptionAtHost                 *AzureNodePoolEncryptionAtHost
-	osDisk                           *AzureNodePoolOsDisk
-	osDiskSseEncryptionSetResourceId string
-	resourceName                     string
-	ephemeralOSDiskEnabled           bool
+	fieldSet_                []bool
+	osDiskSizeGibibytes      int
+	osDiskStorageAccountType string
+	vmSize                   string
+	encryptionAtHost         *AzureNodePoolEncryptionAtHost
+	osDisk                   *AzureNodePoolOsDisk
+	resourceName             string
+	ephemeralOSDiskEnabled   bool
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -223,49 +222,6 @@ func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
 	return
 }
 
-// OsDiskSseEncryptionSetResourceId returns the value of the 'os_disk_sse_encryption_set_resource_id' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-// When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed using the provided Disk Encryption Set.
-// It must be located in the same Azure location as the parent Cluster.
-// It must be located in the same Azure Subscription as the parent Cluster.
-// The Azure Resource Group Name specified as part of it must be a different resource group name
-// than the one specified in the parent Cluster's `managed_resource_group_name`.
-// The Azure Resource Group Name specified as part of it can be the same, or a different one
-// than the one specified in the parent Cluster's `resource_group_name`.
-// If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed with platform managed keys.
-func (o *AzureNodePool) OsDiskSseEncryptionSetResourceId() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
-		return o.osDiskSseEncryptionSetResourceId
-	}
-	return ""
-}
-
-// GetOsDiskSseEncryptionSetResourceId returns the value of the 'os_disk_sse_encryption_set_resource_id' attribute and
-// a flag indicating if the attribute has a value.
-//
-// The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-// When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed using the provided Disk Encryption Set.
-// It must be located in the same Azure location as the parent Cluster.
-// It must be located in the same Azure Subscription as the parent Cluster.
-// The Azure Resource Group Name specified as part of it must be a different resource group name
-// than the one specified in the parent Cluster's `managed_resource_group_name`.
-// The Azure Resource Group Name specified as part of it can be the same, or a different one
-// than the one specified in the parent Cluster's `resource_group_name`.
-// If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed with platform managed keys.
-func (o *AzureNodePool) GetOsDiskSseEncryptionSetResourceId() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
-	if ok {
-		value = o.osDiskSseEncryptionSetResourceId
-	}
-	return
-}
-
 // ResourceName returns the value of the 'resource_name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -281,7 +237,7 @@ func (o *AzureNodePool) GetOsDiskSseEncryptionSetResourceId() (value string, ok 
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
 		return o.resourceName
 	}
 	return ""
@@ -302,7 +258,7 @@ func (o *AzureNodePool) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
 	if ok {
 		value = o.resourceName
 	}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_type_json.go
@@ -101,15 +101,6 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("os_disk_sse_encryption_set_resource_id")
-		stream.WriteString(object.osDiskSseEncryptionSetResourceId)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
 		stream.WriteObjectField("resource_name")
 		stream.WriteString(object.resourceName)
 	}
@@ -131,7 +122,7 @@ func UnmarshalAzureNodePool(source interface{}) (object *AzureNodePool, err erro
 // ReadAzureNodePool reads a value of the 'azure_node_pool' type from the given iterator.
 func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 	object := &AzureNodePool{
-		fieldSet_: make([]bool, 8),
+		fieldSet_: make([]bool, 7),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -163,14 +154,10 @@ func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 			value := ReadAzureNodePoolOsDisk(iterator)
 			object.osDisk = value
 			object.fieldSet_[5] = true
-		case "os_disk_sse_encryption_set_resource_id":
-			value := iterator.ReadString()
-			object.osDiskSseEncryptionSetResourceId = value
-			object.fieldSet_[6] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[7] = true
+			object.fieldSet_[6] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_builder.go
@@ -21,21 +21,20 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 
 // Representation of azure node pool specific parameters.
 type AzureNodePoolBuilder struct {
-	fieldSet_                        []bool
-	osDiskSizeGibibytes              int
-	osDiskStorageAccountType         string
-	vmSize                           string
-	encryptionAtHost                 *AzureNodePoolEncryptionAtHostBuilder
-	osDisk                           *AzureNodePoolOsDiskBuilder
-	osDiskSseEncryptionSetResourceId string
-	resourceName                     string
-	ephemeralOSDiskEnabled           bool
+	fieldSet_                []bool
+	osDiskSizeGibibytes      int
+	osDiskStorageAccountType string
+	vmSize                   string
+	encryptionAtHost         *AzureNodePoolEncryptionAtHostBuilder
+	osDisk                   *AzureNodePoolOsDiskBuilder
+	resourceName             string
+	ephemeralOSDiskEnabled   bool
 }
 
 // NewAzureNodePool creates a new builder of 'azure_node_pool' objects.
 func NewAzureNodePool() *AzureNodePoolBuilder {
 	return &AzureNodePoolBuilder{
-		fieldSet_: make([]bool, 8),
+		fieldSet_: make([]bool, 7),
 	}
 }
 
@@ -55,7 +54,7 @@ func (b *AzureNodePoolBuilder) Empty() bool {
 // OSDiskSizeGibibytes sets the value of the 'OS_disk_size_gibibytes' attribute to the given value.
 func (b *AzureNodePoolBuilder) OSDiskSizeGibibytes(value int) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.osDiskSizeGibibytes = value
 	b.fieldSet_[0] = true
@@ -65,7 +64,7 @@ func (b *AzureNodePoolBuilder) OSDiskSizeGibibytes(value int) *AzureNodePoolBuil
 // OSDiskStorageAccountType sets the value of the 'OS_disk_storage_account_type' attribute to the given value.
 func (b *AzureNodePoolBuilder) OSDiskStorageAccountType(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.osDiskStorageAccountType = value
 	b.fieldSet_[1] = true
@@ -75,7 +74,7 @@ func (b *AzureNodePoolBuilder) OSDiskStorageAccountType(value string) *AzureNode
 // VMSize sets the value of the 'VM_size' attribute to the given value.
 func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.vmSize = value
 	b.fieldSet_[2] = true
@@ -88,7 +87,7 @@ func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 // If not specified, Encryption at Host is not enabled.
 func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAtHostBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.encryptionAtHost = value
 	if value != nil {
@@ -102,7 +101,7 @@ func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAt
 // EphemeralOSDiskEnabled sets the value of the 'ephemeral_OS_disk_enabled' attribute to the given value.
 func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.ephemeralOSDiskEnabled = value
 	b.fieldSet_[4] = true
@@ -114,7 +113,7 @@ func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePool
 // Defines the configuration of a Node Pool's OS disk.
 func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.osDisk = value
 	if value != nil {
@@ -125,23 +124,13 @@ func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureN
 	return b
 }
 
-// OsDiskSseEncryptionSetResourceId sets the value of the 'os_disk_sse_encryption_set_resource_id' attribute to the given value.
-func (b *AzureNodePoolBuilder) OsDiskSseEncryptionSetResourceId(value string) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
-	}
-	b.osDiskSseEncryptionSetResourceId = value
-	b.fieldSet_[6] = true
-	return b
-}
-
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureNodePoolBuilder) ResourceName(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 8)
+		b.fieldSet_ = make([]bool, 7)
 	}
 	b.resourceName = value
-	b.fieldSet_[7] = true
+	b.fieldSet_[6] = true
 	return b
 }
 
@@ -168,7 +157,6 @@ func (b *AzureNodePoolBuilder) Copy(object *AzureNodePool) *AzureNodePoolBuilder
 	} else {
 		b.osDisk = nil
 	}
-	b.osDiskSseEncryptionSetResourceId = object.osDiskSseEncryptionSetResourceId
 	b.resourceName = object.resourceName
 	return b
 }
@@ -196,7 +184,6 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 			return
 		}
 	}
-	object.osDiskSseEncryptionSetResourceId = b.osDiskSseEncryptionSetResourceId
 	object.resourceName = b.resourceName
 	return
 }

--- a/clientapi/clustersmgmt/v1/azure_node_pool_type.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_type.go
@@ -23,15 +23,14 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 //
 // Representation of azure node pool specific parameters.
 type AzureNodePool struct {
-	fieldSet_                        []bool
-	osDiskSizeGibibytes              int
-	osDiskStorageAccountType         string
-	vmSize                           string
-	encryptionAtHost                 *AzureNodePoolEncryptionAtHost
-	osDisk                           *AzureNodePoolOsDisk
-	osDiskSseEncryptionSetResourceId string
-	resourceName                     string
-	ephemeralOSDiskEnabled           bool
+	fieldSet_                []bool
+	osDiskSizeGibibytes      int
+	osDiskStorageAccountType string
+	vmSize                   string
+	encryptionAtHost         *AzureNodePoolEncryptionAtHost
+	osDisk                   *AzureNodePoolOsDisk
+	resourceName             string
+	ephemeralOSDiskEnabled   bool
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -223,49 +222,6 @@ func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
 	return
 }
 
-// OsDiskSseEncryptionSetResourceId returns the value of the 'os_disk_sse_encryption_set_resource_id' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-// When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed using the provided Disk Encryption Set.
-// It must be located in the same Azure location as the parent Cluster.
-// It must be located in the same Azure Subscription as the parent Cluster.
-// The Azure Resource Group Name specified as part of it must be a different resource group name
-// than the one specified in the parent Cluster's `managed_resource_group_name`.
-// The Azure Resource Group Name specified as part of it can be the same, or a different one
-// than the one specified in the parent Cluster's `resource_group_name`.
-// If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed with platform managed keys.
-func (o *AzureNodePool) OsDiskSseEncryptionSetResourceId() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
-		return o.osDiskSseEncryptionSetResourceId
-	}
-	return ""
-}
-
-// GetOsDiskSseEncryptionSetResourceId returns the value of the 'os_disk_sse_encryption_set_resource_id' attribute and
-// a flag indicating if the attribute has a value.
-//
-// The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-// When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed using the provided Disk Encryption Set.
-// It must be located in the same Azure location as the parent Cluster.
-// It must be located in the same Azure Subscription as the parent Cluster.
-// The Azure Resource Group Name specified as part of it must be a different resource group name
-// than the one specified in the parent Cluster's `managed_resource_group_name`.
-// The Azure Resource Group Name specified as part of it can be the same, or a different one
-// than the one specified in the parent Cluster's `resource_group_name`.
-// If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-// is performed with platform managed keys.
-func (o *AzureNodePool) GetOsDiskSseEncryptionSetResourceId() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
-	if ok {
-		value = o.osDiskSseEncryptionSetResourceId
-	}
-	return
-}
-
 // ResourceName returns the value of the 'resource_name' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -281,7 +237,7 @@ func (o *AzureNodePool) GetOsDiskSseEncryptionSetResourceId() (value string, ok 
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
 		return o.resourceName
 	}
 	return ""
@@ -302,7 +258,7 @@ func (o *AzureNodePool) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
 	if ok {
 		value = o.resourceName
 	}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_type_json.go
@@ -101,15 +101,6 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("os_disk_sse_encryption_set_resource_id")
-		stream.WriteString(object.osDiskSseEncryptionSetResourceId)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
 		stream.WriteObjectField("resource_name")
 		stream.WriteString(object.resourceName)
 	}
@@ -131,7 +122,7 @@ func UnmarshalAzureNodePool(source interface{}) (object *AzureNodePool, err erro
 // ReadAzureNodePool reads a value of the 'azure_node_pool' type from the given iterator.
 func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 	object := &AzureNodePool{
-		fieldSet_: make([]bool, 8),
+		fieldSet_: make([]bool, 7),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -163,14 +154,10 @@ func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 			value := ReadAzureNodePoolOsDisk(iterator)
 			object.osDisk = value
 			object.fieldSet_[5] = true
-		case "os_disk_sse_encryption_set_resource_id":
-			value := iterator.ReadString()
-			object.osDiskSseEncryptionSetResourceId = value
-			object.fieldSet_[6] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[7] = true
+			object.fieldSet_[6] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/azure_node_pool_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_type.model
@@ -62,19 +62,6 @@ struct AzureNodePool {
     // If not specified, Encryption at Host is not enabled.
     // Immutable.
     EncryptionAtHost AzureNodePoolEncryptionAtHost
-    
-    // The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-    // When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-    // is performed using the provided Disk Encryption Set.
-    // It must be located in the same Azure location as the parent Cluster.  
-    // It must be located in the same Azure Subscription as the parent Cluster.
-    // The Azure Resource Group Name specified as part of it must be a different resource group name
-    // than the one specified in the parent Cluster's `managed_resource_group_name`.
-    // The Azure Resource Group Name specified as part of it can be the same, or a different one
-    // than the one specified in the parent Cluster's `resource_group_name`.
-    // If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool 
-    // is performed with platform managed keys.
-    OsDiskSseEncryptionSetResourceId String
 
     // The configuration for the OS disk used by the nodes in the Node Pool.
     OsDisk AzureNodePoolOsDisk

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -1958,10 +1958,6 @@
             "description": "The configuration for the OS disk used by the nodes in the Node Pool.",
             "$ref": "#/components/schemas/AzureNodePoolOsDisk"
           },
-          "os_disk_sse_encryption_set_resource_id": {
-            "description": "The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).\nWhen provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool\nis performed using the provided Disk Encryption Set.\nIt must be located in the same Azure location as the parent Cluster.  \nIt must be located in the same Azure Subscription as the parent Cluster.\nThe Azure Resource Group Name specified as part of it must be a different resource group name\nthan the one specified in the parent Cluster's `managed_resource_group_name`.\nThe Azure Resource Group Name specified as part of it can be the same, or a different one\nthan the one specified in the parent Cluster's `resource_group_name`.\nIf not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool \nis performed with platform managed keys.",
-            "type": "string"
-          },
           "resource_name": {
             "description": "ResourceName is the Azure Resource Name of the NodePool.\nResourceName must be within the Azure Resource Group Name of the parent\nCluster it belongs to.\nResourceName must be located in the same Azure Location as the parent\nCluster it belongs to.\nResourceName must be located in the same Azure Subscription as the parent\nCluster it belongs to.\nResourceName must belong to the same Microsoft Entra Tenant ID as the parent\nCluster it belongs to.\nRequired during creation.\nImmutable.",
             "type": "string"

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -15181,10 +15181,6 @@
             "description": "The configuration for the OS disk used by the nodes in the Node Pool.",
             "$ref": "#/components/schemas/AzureNodePoolOsDisk"
           },
-          "os_disk_sse_encryption_set_resource_id": {
-            "description": "The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).\nWhen provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool\nis performed using the provided Disk Encryption Set.\nIt must be located in the same Azure location as the parent Cluster.  \nIt must be located in the same Azure Subscription as the parent Cluster.\nThe Azure Resource Group Name specified as part of it must be a different resource group name\nthan the one specified in the parent Cluster's `managed_resource_group_name`.\nThe Azure Resource Group Name specified as part of it can be the same, or a different one\nthan the one specified in the parent Cluster's `resource_group_name`.\nIf not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool \nis performed with platform managed keys.",
-            "type": "string"
-          },
           "resource_name": {
             "description": "ResourceName is the Azure Resource Name of the NodePool.\nResourceName must be within the Azure Resource Group Name of the parent\nCluster it belongs to.\nResourceName must be located in the same Azure Location as the parent\nCluster it belongs to.\nResourceName must be located in the same Azure Subscription as the parent\nCluster it belongs to.\nResourceName must belong to the same Microsoft Entra Tenant ID as the parent\nCluster it belongs to.\nRequired during creation.\nImmutable.",
             "type": "string"


### PR DESCRIPTION
The field `osDiskSseEncryptionSetResourceId ` has been shifted to a nested struct `AzureNodePoolOsDisk`. This is to remove the old remaining field in the AzureNodePool struct.
It can be removed as it is an attribute specific to ARO-HCP and the attribute was not used anywhere yet.