### PR TITLE
OCM-16333 | feat: add ControlPlaneCVE to UpgradeType

### DIFF
--- a/clientapi/clustersmgmt/v1/upgrade_type_type.go
+++ b/clientapi/clustersmgmt/v1/upgrade_type_type.go
@@ -29,6 +29,8 @@ const (
 	UpgradeTypeAddOn UpgradeType = "ADDON"
 	// Control plane upgrade, relevant only for hosted control plane clusters.
 	UpgradeTypeControlPlane UpgradeType = "ControlPlane"
+	// An upgrade required for security reasons.
+	UpgradeTypeControlPlaneCVE UpgradeType = "ControlPlaneCVE"
 	// Node pool upgrade, relevant only for hosted control plane clusters.
 	UpgradeTypeNodePool UpgradeType = "NodePool"
 )

--- a/model/clusters_mgmt/v1/upgrade_policy_upgrade_type.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_upgrade_type.model
@@ -31,4 +31,8 @@ enum UpgradeType {
 	// Upgrade of an AddOn
 	@json(name = "ADDON")
 	AddOn
+
+	// An upgrade required for security reasons.
+	@json(name = "ControlPlaneCVE")
+	ControlPlaneCVE
 }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -19151,6 +19151,7 @@
           "OSD",
           "ADDON",
           "ControlPlane",
+          "ControlPlaneCVE",
           "NodePool"
         ]
       },


### PR DESCRIPTION
This MR addes a new type `ControlPlaneCVE` to UpgradeType enum.

```
enum UpgradeType {
        ....
        ...
	@json(name = "ControlPlaneCVE")
	ControlPlaneCVE
}
```
related DDR: https://docs.google.com/document/d/1DWNR9bvDb41Cdt2TX6E8TNmz-KSy9nRariujKSBHznU/edit?tab=t.0