### PR TITLE
deprecate os disk configuration old design

### DIFF
--- a/clientapi/arohcp/v1alpha1/azure_node_pool_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_builder.go
@@ -21,20 +21,17 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 
 // Representation of azure node pool specific parameters.
 type AzureNodePoolBuilder struct {
-	fieldSet_                []bool
-	osDiskSizeGibibytes      int
-	osDiskStorageAccountType string
-	vmSize                   string
-	encryptionAtHost         *AzureNodePoolEncryptionAtHostBuilder
-	osDisk                   *AzureNodePoolOsDiskBuilder
-	resourceName             string
-	ephemeralOSDiskEnabled   bool
+	fieldSet_        []bool
+	vmSize           string
+	encryptionAtHost *AzureNodePoolEncryptionAtHostBuilder
+	osDisk           *AzureNodePoolOsDiskBuilder
+	resourceName     string
 }
 
 // NewAzureNodePool creates a new builder of 'azure_node_pool' objects.
 func NewAzureNodePool() *AzureNodePoolBuilder {
 	return &AzureNodePoolBuilder{
-		fieldSet_: make([]bool, 7),
+		fieldSet_: make([]bool, 4),
 	}
 }
 
@@ -51,33 +48,13 @@ func (b *AzureNodePoolBuilder) Empty() bool {
 	return true
 }
 
-// OSDiskSizeGibibytes sets the value of the 'OS_disk_size_gibibytes' attribute to the given value.
-func (b *AzureNodePoolBuilder) OSDiskSizeGibibytes(value int) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
-	}
-	b.osDiskSizeGibibytes = value
-	b.fieldSet_[0] = true
-	return b
-}
-
-// OSDiskStorageAccountType sets the value of the 'OS_disk_storage_account_type' attribute to the given value.
-func (b *AzureNodePoolBuilder) OSDiskStorageAccountType(value string) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
-	}
-	b.osDiskStorageAccountType = value
-	b.fieldSet_[1] = true
-	return b
-}
-
 // VMSize sets the value of the 'VM_size' attribute to the given value.
 func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.vmSize = value
-	b.fieldSet_[2] = true
+	b.fieldSet_[0] = true
 	return b
 }
 
@@ -87,24 +64,14 @@ func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 // If not specified, Encryption at Host is not enabled.
 func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAtHostBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.encryptionAtHost = value
 	if value != nil {
-		b.fieldSet_[3] = true
+		b.fieldSet_[1] = true
 	} else {
-		b.fieldSet_[3] = false
+		b.fieldSet_[1] = false
 	}
-	return b
-}
-
-// EphemeralOSDiskEnabled sets the value of the 'ephemeral_OS_disk_enabled' attribute to the given value.
-func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
-	}
-	b.ephemeralOSDiskEnabled = value
-	b.fieldSet_[4] = true
 	return b
 }
 
@@ -113,13 +80,13 @@ func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePool
 // Defines the configuration of a Node Pool's OS disk.
 func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.osDisk = value
 	if value != nil {
-		b.fieldSet_[5] = true
+		b.fieldSet_[2] = true
 	} else {
-		b.fieldSet_[5] = false
+		b.fieldSet_[2] = false
 	}
 	return b
 }
@@ -127,10 +94,10 @@ func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureN
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureNodePoolBuilder) ResourceName(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.resourceName = value
-	b.fieldSet_[6] = true
+	b.fieldSet_[3] = true
 	return b
 }
 
@@ -143,15 +110,12 @@ func (b *AzureNodePoolBuilder) Copy(object *AzureNodePool) *AzureNodePoolBuilder
 		b.fieldSet_ = make([]bool, len(object.fieldSet_))
 		copy(b.fieldSet_, object.fieldSet_)
 	}
-	b.osDiskSizeGibibytes = object.osDiskSizeGibibytes
-	b.osDiskStorageAccountType = object.osDiskStorageAccountType
 	b.vmSize = object.vmSize
 	if object.encryptionAtHost != nil {
 		b.encryptionAtHost = NewAzureNodePoolEncryptionAtHost().Copy(object.encryptionAtHost)
 	} else {
 		b.encryptionAtHost = nil
 	}
-	b.ephemeralOSDiskEnabled = object.ephemeralOSDiskEnabled
 	if object.osDisk != nil {
 		b.osDisk = NewAzureNodePoolOsDisk().Copy(object.osDisk)
 	} else {
@@ -168,8 +132,6 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 		object.fieldSet_ = make([]bool, len(b.fieldSet_))
 		copy(object.fieldSet_, b.fieldSet_)
 	}
-	object.osDiskSizeGibibytes = b.osDiskSizeGibibytes
-	object.osDiskStorageAccountType = b.osDiskStorageAccountType
 	object.vmSize = b.vmSize
 	if b.encryptionAtHost != nil {
 		object.encryptionAtHost, err = b.encryptionAtHost.Build()
@@ -177,7 +139,6 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 			return
 		}
 	}
-	object.ephemeralOSDiskEnabled = b.ephemeralOSDiskEnabled
 	if b.osDisk != nil {
 		object.osDisk, err = b.osDisk.Build()
 		if err != nil {

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_type.go
@@ -23,14 +23,11 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 //
 // Representation of azure node pool specific parameters.
 type AzureNodePool struct {
-	fieldSet_                []bool
-	osDiskSizeGibibytes      int
-	osDiskStorageAccountType string
-	vmSize                   string
-	encryptionAtHost         *AzureNodePoolEncryptionAtHost
-	osDisk                   *AzureNodePoolOsDisk
-	resourceName             string
-	ephemeralOSDiskEnabled   bool
+	fieldSet_        []bool
+	vmSize           string
+	encryptionAtHost *AzureNodePoolEncryptionAtHost
+	osDisk           *AzureNodePoolOsDisk
+	resourceName     string
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -46,72 +43,6 @@ func (o *AzureNodePool) Empty() bool {
 	return true
 }
 
-// OSDiskSizeGibibytes returns the value of the 'OS_disk_size_gibibytes' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// The size in GiB to assign to the OS disks of the
-// Nodes in the Node Pool. The property
-// is the number of bytes x 1024^3.
-// If not specified, OS disk size is 30 GiB.
-func (o *AzureNodePool) OSDiskSizeGibibytes() int {
-	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
-		return o.osDiskSizeGibibytes
-	}
-	return 0
-}
-
-// GetOSDiskSizeGibibytes returns the value of the 'OS_disk_size_gibibytes' attribute and
-// a flag indicating if the attribute has a value.
-//
-// The size in GiB to assign to the OS disks of the
-// Nodes in the Node Pool. The property
-// is the number of bytes x 1024^3.
-// If not specified, OS disk size is 30 GiB.
-func (o *AzureNodePool) GetOSDiskSizeGibibytes() (value int, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
-	if ok {
-		value = o.osDiskSizeGibibytes
-	}
-	return
-}
-
-// OSDiskStorageAccountType returns the value of the 'OS_disk_storage_account_type' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// The disk storage account type to use for the OS disks of the Nodes in the
-// Node Pool. Valid values are:
-// * Standard_LRS: HDD
-// * StandardSSD_LRS: Standard SSD
-// * Premium_LRS: Premium SDD
-// * UltraSSD_LRS: Ultra SDD
-//
-// If not specified, `Premium_LRS` is used.
-func (o *AzureNodePool) OSDiskStorageAccountType() string {
-	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
-		return o.osDiskStorageAccountType
-	}
-	return ""
-}
-
-// GetOSDiskStorageAccountType returns the value of the 'OS_disk_storage_account_type' attribute and
-// a flag indicating if the attribute has a value.
-//
-// The disk storage account type to use for the OS disks of the Nodes in the
-// Node Pool. Valid values are:
-// * Standard_LRS: HDD
-// * StandardSSD_LRS: Standard SSD
-// * Premium_LRS: Premium SDD
-// * UltraSSD_LRS: Ultra SDD
-//
-// If not specified, `Premium_LRS` is used.
-func (o *AzureNodePool) GetOSDiskStorageAccountType() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
-	if ok {
-		value = o.osDiskStorageAccountType
-	}
-	return
-}
-
 // VMSize returns the value of the 'VM_size' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -121,7 +52,7 @@ func (o *AzureNodePool) GetOSDiskStorageAccountType() (value string, ok bool) {
 // of the parent Cluster.
 // Required during creation.
 func (o *AzureNodePool) VMSize() string {
-	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
 		return o.vmSize
 	}
 	return ""
@@ -136,7 +67,7 @@ func (o *AzureNodePool) VMSize() string {
 // of the parent Cluster.
 // Required during creation.
 func (o *AzureNodePool) GetVMSize() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
 	if ok {
 		value = o.vmSize
 	}
@@ -152,7 +83,7 @@ func (o *AzureNodePool) GetVMSize() (value string, ok bool) {
 // If not specified, Encryption at Host is not enabled.
 // Immutable.
 func (o *AzureNodePool) EncryptionAtHost() *AzureNodePoolEncryptionAtHost {
-	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
 		return o.encryptionAtHost
 	}
 	return nil
@@ -167,34 +98,9 @@ func (o *AzureNodePool) EncryptionAtHost() *AzureNodePoolEncryptionAtHost {
 // If not specified, Encryption at Host is not enabled.
 // Immutable.
 func (o *AzureNodePool) GetEncryptionAtHost() (value *AzureNodePoolEncryptionAtHost, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
 	if ok {
 		value = o.encryptionAtHost
-	}
-	return
-}
-
-// EphemeralOSDiskEnabled returns the value of the 'ephemeral_OS_disk_enabled' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Enables Ephemeral OS Disks for the Nodes in the Node Pool.
-// If not specified, no Ephemeral OS Disks are used.
-func (o *AzureNodePool) EphemeralOSDiskEnabled() bool {
-	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
-		return o.ephemeralOSDiskEnabled
-	}
-	return false
-}
-
-// GetEphemeralOSDiskEnabled returns the value of the 'ephemeral_OS_disk_enabled' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Enables Ephemeral OS Disks for the Nodes in the Node Pool.
-// If not specified, no Ephemeral OS Disks are used.
-func (o *AzureNodePool) GetEphemeralOSDiskEnabled() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
-	if ok {
-		value = o.ephemeralOSDiskEnabled
 	}
 	return
 }
@@ -204,7 +110,7 @@ func (o *AzureNodePool) GetEphemeralOSDiskEnabled() (value bool, ok bool) {
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
-	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
 		return o.osDisk
 	}
 	return nil
@@ -215,7 +121,7 @@ func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
 	if ok {
 		value = o.osDisk
 	}
@@ -237,7 +143,7 @@ func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
 		return o.resourceName
 	}
 	return ""
@@ -258,7 +164,7 @@ func (o *AzureNodePool) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
 	if ok {
 		value = o.resourceName
 	}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_type_json.go
@@ -47,29 +47,11 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("os_disk_size_gibibytes")
-		stream.WriteInt(object.osDiskSizeGibibytes)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("os_disk_storage_account_type")
-		stream.WriteString(object.osDiskStorageAccountType)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
 		stream.WriteObjectField("vm_size")
 		stream.WriteString(object.vmSize)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3] && object.encryptionAtHost != nil
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.encryptionAtHost != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -78,16 +60,7 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolEncryptionAtHost(object.encryptionAtHost, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("ephemeral_os_disk_enabled")
-		stream.WriteBool(object.ephemeralOSDiskEnabled)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.osDisk != nil
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2] && object.osDisk != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -96,7 +69,7 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolOsDisk(object.osDisk, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -122,7 +95,7 @@ func UnmarshalAzureNodePool(source interface{}) (object *AzureNodePool, err erro
 // ReadAzureNodePool reads a value of the 'azure_node_pool' type from the given iterator.
 func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 	object := &AzureNodePool{
-		fieldSet_: make([]bool, 7),
+		fieldSet_: make([]bool, 4),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -130,34 +103,22 @@ func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 			break
 		}
 		switch field {
-		case "os_disk_size_gibibytes":
-			value := iterator.ReadInt()
-			object.osDiskSizeGibibytes = value
-			object.fieldSet_[0] = true
-		case "os_disk_storage_account_type":
-			value := iterator.ReadString()
-			object.osDiskStorageAccountType = value
-			object.fieldSet_[1] = true
 		case "vm_size":
 			value := iterator.ReadString()
 			object.vmSize = value
-			object.fieldSet_[2] = true
+			object.fieldSet_[0] = true
 		case "encryption_at_host":
 			value := ReadAzureNodePoolEncryptionAtHost(iterator)
 			object.encryptionAtHost = value
-			object.fieldSet_[3] = true
-		case "ephemeral_os_disk_enabled":
-			value := iterator.ReadBool()
-			object.ephemeralOSDiskEnabled = value
-			object.fieldSet_[4] = true
+			object.fieldSet_[1] = true
 		case "os_disk":
 			value := ReadAzureNodePoolOsDisk(iterator)
 			object.osDisk = value
-			object.fieldSet_[5] = true
+			object.fieldSet_[2] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[6] = true
+			object.fieldSet_[3] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_builder.go
@@ -21,20 +21,17 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 
 // Representation of azure node pool specific parameters.
 type AzureNodePoolBuilder struct {
-	fieldSet_                []bool
-	osDiskSizeGibibytes      int
-	osDiskStorageAccountType string
-	vmSize                   string
-	encryptionAtHost         *AzureNodePoolEncryptionAtHostBuilder
-	osDisk                   *AzureNodePoolOsDiskBuilder
-	resourceName             string
-	ephemeralOSDiskEnabled   bool
+	fieldSet_        []bool
+	vmSize           string
+	encryptionAtHost *AzureNodePoolEncryptionAtHostBuilder
+	osDisk           *AzureNodePoolOsDiskBuilder
+	resourceName     string
 }
 
 // NewAzureNodePool creates a new builder of 'azure_node_pool' objects.
 func NewAzureNodePool() *AzureNodePoolBuilder {
 	return &AzureNodePoolBuilder{
-		fieldSet_: make([]bool, 7),
+		fieldSet_: make([]bool, 4),
 	}
 }
 
@@ -51,33 +48,13 @@ func (b *AzureNodePoolBuilder) Empty() bool {
 	return true
 }
 
-// OSDiskSizeGibibytes sets the value of the 'OS_disk_size_gibibytes' attribute to the given value.
-func (b *AzureNodePoolBuilder) OSDiskSizeGibibytes(value int) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
-	}
-	b.osDiskSizeGibibytes = value
-	b.fieldSet_[0] = true
-	return b
-}
-
-// OSDiskStorageAccountType sets the value of the 'OS_disk_storage_account_type' attribute to the given value.
-func (b *AzureNodePoolBuilder) OSDiskStorageAccountType(value string) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
-	}
-	b.osDiskStorageAccountType = value
-	b.fieldSet_[1] = true
-	return b
-}
-
 // VMSize sets the value of the 'VM_size' attribute to the given value.
 func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.vmSize = value
-	b.fieldSet_[2] = true
+	b.fieldSet_[0] = true
 	return b
 }
 
@@ -87,24 +64,14 @@ func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 // If not specified, Encryption at Host is not enabled.
 func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAtHostBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.encryptionAtHost = value
 	if value != nil {
-		b.fieldSet_[3] = true
+		b.fieldSet_[1] = true
 	} else {
-		b.fieldSet_[3] = false
+		b.fieldSet_[1] = false
 	}
-	return b
-}
-
-// EphemeralOSDiskEnabled sets the value of the 'ephemeral_OS_disk_enabled' attribute to the given value.
-func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePoolBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
-	}
-	b.ephemeralOSDiskEnabled = value
-	b.fieldSet_[4] = true
 	return b
 }
 
@@ -113,13 +80,13 @@ func (b *AzureNodePoolBuilder) EphemeralOSDiskEnabled(value bool) *AzureNodePool
 // Defines the configuration of a Node Pool's OS disk.
 func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.osDisk = value
 	if value != nil {
-		b.fieldSet_[5] = true
+		b.fieldSet_[2] = true
 	} else {
-		b.fieldSet_[5] = false
+		b.fieldSet_[2] = false
 	}
 	return b
 }
@@ -127,10 +94,10 @@ func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureN
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureNodePoolBuilder) ResourceName(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 7)
+		b.fieldSet_ = make([]bool, 4)
 	}
 	b.resourceName = value
-	b.fieldSet_[6] = true
+	b.fieldSet_[3] = true
 	return b
 }
 
@@ -143,15 +110,12 @@ func (b *AzureNodePoolBuilder) Copy(object *AzureNodePool) *AzureNodePoolBuilder
 		b.fieldSet_ = make([]bool, len(object.fieldSet_))
 		copy(b.fieldSet_, object.fieldSet_)
 	}
-	b.osDiskSizeGibibytes = object.osDiskSizeGibibytes
-	b.osDiskStorageAccountType = object.osDiskStorageAccountType
 	b.vmSize = object.vmSize
 	if object.encryptionAtHost != nil {
 		b.encryptionAtHost = NewAzureNodePoolEncryptionAtHost().Copy(object.encryptionAtHost)
 	} else {
 		b.encryptionAtHost = nil
 	}
-	b.ephemeralOSDiskEnabled = object.ephemeralOSDiskEnabled
 	if object.osDisk != nil {
 		b.osDisk = NewAzureNodePoolOsDisk().Copy(object.osDisk)
 	} else {
@@ -168,8 +132,6 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 		object.fieldSet_ = make([]bool, len(b.fieldSet_))
 		copy(object.fieldSet_, b.fieldSet_)
 	}
-	object.osDiskSizeGibibytes = b.osDiskSizeGibibytes
-	object.osDiskStorageAccountType = b.osDiskStorageAccountType
 	object.vmSize = b.vmSize
 	if b.encryptionAtHost != nil {
 		object.encryptionAtHost, err = b.encryptionAtHost.Build()
@@ -177,7 +139,6 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 			return
 		}
 	}
-	object.ephemeralOSDiskEnabled = b.ephemeralOSDiskEnabled
 	if b.osDisk != nil {
 		object.osDisk, err = b.osDisk.Build()
 		if err != nil {

--- a/clientapi/clustersmgmt/v1/azure_node_pool_type.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_type.go
@@ -23,14 +23,11 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 //
 // Representation of azure node pool specific parameters.
 type AzureNodePool struct {
-	fieldSet_                []bool
-	osDiskSizeGibibytes      int
-	osDiskStorageAccountType string
-	vmSize                   string
-	encryptionAtHost         *AzureNodePoolEncryptionAtHost
-	osDisk                   *AzureNodePoolOsDisk
-	resourceName             string
-	ephemeralOSDiskEnabled   bool
+	fieldSet_        []bool
+	vmSize           string
+	encryptionAtHost *AzureNodePoolEncryptionAtHost
+	osDisk           *AzureNodePoolOsDisk
+	resourceName     string
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -46,72 +43,6 @@ func (o *AzureNodePool) Empty() bool {
 	return true
 }
 
-// OSDiskSizeGibibytes returns the value of the 'OS_disk_size_gibibytes' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// The size in GiB to assign to the OS disks of the
-// Nodes in the Node Pool. The property
-// is the number of bytes x 1024^3.
-// If not specified, OS disk size is 30 GiB.
-func (o *AzureNodePool) OSDiskSizeGibibytes() int {
-	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
-		return o.osDiskSizeGibibytes
-	}
-	return 0
-}
-
-// GetOSDiskSizeGibibytes returns the value of the 'OS_disk_size_gibibytes' attribute and
-// a flag indicating if the attribute has a value.
-//
-// The size in GiB to assign to the OS disks of the
-// Nodes in the Node Pool. The property
-// is the number of bytes x 1024^3.
-// If not specified, OS disk size is 30 GiB.
-func (o *AzureNodePool) GetOSDiskSizeGibibytes() (value int, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
-	if ok {
-		value = o.osDiskSizeGibibytes
-	}
-	return
-}
-
-// OSDiskStorageAccountType returns the value of the 'OS_disk_storage_account_type' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// The disk storage account type to use for the OS disks of the Nodes in the
-// Node Pool. Valid values are:
-// * Standard_LRS: HDD
-// * StandardSSD_LRS: Standard SSD
-// * Premium_LRS: Premium SDD
-// * UltraSSD_LRS: Ultra SDD
-//
-// If not specified, `Premium_LRS` is used.
-func (o *AzureNodePool) OSDiskStorageAccountType() string {
-	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
-		return o.osDiskStorageAccountType
-	}
-	return ""
-}
-
-// GetOSDiskStorageAccountType returns the value of the 'OS_disk_storage_account_type' attribute and
-// a flag indicating if the attribute has a value.
-//
-// The disk storage account type to use for the OS disks of the Nodes in the
-// Node Pool. Valid values are:
-// * Standard_LRS: HDD
-// * StandardSSD_LRS: Standard SSD
-// * Premium_LRS: Premium SDD
-// * UltraSSD_LRS: Ultra SDD
-//
-// If not specified, `Premium_LRS` is used.
-func (o *AzureNodePool) GetOSDiskStorageAccountType() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
-	if ok {
-		value = o.osDiskStorageAccountType
-	}
-	return
-}
-
 // VMSize returns the value of the 'VM_size' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -121,7 +52,7 @@ func (o *AzureNodePool) GetOSDiskStorageAccountType() (value string, ok bool) {
 // of the parent Cluster.
 // Required during creation.
 func (o *AzureNodePool) VMSize() string {
-	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
 		return o.vmSize
 	}
 	return ""
@@ -136,7 +67,7 @@ func (o *AzureNodePool) VMSize() string {
 // of the parent Cluster.
 // Required during creation.
 func (o *AzureNodePool) GetVMSize() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
 	if ok {
 		value = o.vmSize
 	}
@@ -152,7 +83,7 @@ func (o *AzureNodePool) GetVMSize() (value string, ok bool) {
 // If not specified, Encryption at Host is not enabled.
 // Immutable.
 func (o *AzureNodePool) EncryptionAtHost() *AzureNodePoolEncryptionAtHost {
-	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
 		return o.encryptionAtHost
 	}
 	return nil
@@ -167,34 +98,9 @@ func (o *AzureNodePool) EncryptionAtHost() *AzureNodePoolEncryptionAtHost {
 // If not specified, Encryption at Host is not enabled.
 // Immutable.
 func (o *AzureNodePool) GetEncryptionAtHost() (value *AzureNodePoolEncryptionAtHost, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
 	if ok {
 		value = o.encryptionAtHost
-	}
-	return
-}
-
-// EphemeralOSDiskEnabled returns the value of the 'ephemeral_OS_disk_enabled' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Enables Ephemeral OS Disks for the Nodes in the Node Pool.
-// If not specified, no Ephemeral OS Disks are used.
-func (o *AzureNodePool) EphemeralOSDiskEnabled() bool {
-	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
-		return o.ephemeralOSDiskEnabled
-	}
-	return false
-}
-
-// GetEphemeralOSDiskEnabled returns the value of the 'ephemeral_OS_disk_enabled' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Enables Ephemeral OS Disks for the Nodes in the Node Pool.
-// If not specified, no Ephemeral OS Disks are used.
-func (o *AzureNodePool) GetEphemeralOSDiskEnabled() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
-	if ok {
-		value = o.ephemeralOSDiskEnabled
 	}
 	return
 }
@@ -204,7 +110,7 @@ func (o *AzureNodePool) GetEphemeralOSDiskEnabled() (value bool, ok bool) {
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
-	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
 		return o.osDisk
 	}
 	return nil
@@ -215,7 +121,7 @@ func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
 	if ok {
 		value = o.osDisk
 	}
@@ -237,7 +143,7 @@ func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
 		return o.resourceName
 	}
 	return ""
@@ -258,7 +164,7 @@ func (o *AzureNodePool) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
 	if ok {
 		value = o.resourceName
 	}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_type_json.go
@@ -47,29 +47,11 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("os_disk_size_gibibytes")
-		stream.WriteInt(object.osDiskSizeGibibytes)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("os_disk_storage_account_type")
-		stream.WriteString(object.osDiskStorageAccountType)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
 		stream.WriteObjectField("vm_size")
 		stream.WriteString(object.vmSize)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3] && object.encryptionAtHost != nil
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.encryptionAtHost != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -78,16 +60,7 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolEncryptionAtHost(object.encryptionAtHost, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("ephemeral_os_disk_enabled")
-		stream.WriteBool(object.ephemeralOSDiskEnabled)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.osDisk != nil
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2] && object.osDisk != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -96,7 +69,7 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolOsDisk(object.osDisk, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -122,7 +95,7 @@ func UnmarshalAzureNodePool(source interface{}) (object *AzureNodePool, err erro
 // ReadAzureNodePool reads a value of the 'azure_node_pool' type from the given iterator.
 func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 	object := &AzureNodePool{
-		fieldSet_: make([]bool, 7),
+		fieldSet_: make([]bool, 4),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -130,34 +103,22 @@ func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 			break
 		}
 		switch field {
-		case "os_disk_size_gibibytes":
-			value := iterator.ReadInt()
-			object.osDiskSizeGibibytes = value
-			object.fieldSet_[0] = true
-		case "os_disk_storage_account_type":
-			value := iterator.ReadString()
-			object.osDiskStorageAccountType = value
-			object.fieldSet_[1] = true
 		case "vm_size":
 			value := iterator.ReadString()
 			object.vmSize = value
-			object.fieldSet_[2] = true
+			object.fieldSet_[0] = true
 		case "encryption_at_host":
 			value := ReadAzureNodePoolEncryptionAtHost(iterator)
 			object.encryptionAtHost = value
-			object.fieldSet_[3] = true
-		case "ephemeral_os_disk_enabled":
-			value := iterator.ReadBool()
-			object.ephemeralOSDiskEnabled = value
-			object.fieldSet_[4] = true
+			object.fieldSet_[1] = true
 		case "os_disk":
 			value := ReadAzureNodePoolOsDisk(iterator)
 			object.osDisk = value
-			object.fieldSet_[5] = true
+			object.fieldSet_[2] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[6] = true
+			object.fieldSet_[3] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/azure_node_pool_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_type.model
@@ -36,26 +36,6 @@ struct AzureNodePool {
     // Required during creation.
     VMSize String
 
-    // The size in GiB to assign to the OS disks of the
-    // Nodes in the Node Pool. The property
-    // is the number of bytes x 1024^3.
-    // If not specified, OS disk size is 30 GiB.
-    OSDiskSizeGibibytes Integer
-
-    // The disk storage account type to use for the OS disks of the Nodes in the
-    // Node Pool. Valid values are:
-    // * Standard_LRS: HDD
-    // * StandardSSD_LRS: Standard SSD
-    // * Premium_LRS: Premium SDD
-    // * UltraSSD_LRS: Ultra SDD
-    //
-    // If not specified, `Premium_LRS` is used.
-    OSDiskStorageAccountType String
-
-    // Enables Ephemeral OS Disks for the Nodes in the Node Pool.
-    // If not specified, no Ephemeral OS Disks are used.
-    EphemeralOSDiskEnabled Boolean
-
     // EncryptionAtHost contains Encryption At Host disk encryption configuration.
     // When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
     // and disk caches are encrypted at rest and flow encrypted to the Storage clusters.

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -1969,15 +1969,6 @@
       "AzureNodePool": {
         "description": "Representation of azure node pool specific parameters.",
         "properties": {
-          "os_disk_size_gibibytes": {
-            "description": "The size in GiB to assign to the OS disks of the\nNodes in the Node Pool. The property\nis the number of bytes x 1024^3.\nIf not specified, OS disk size is 30 GiB.",
-            "type": "integer",
-            "format": "int32"
-          },
-          "os_disk_storage_account_type": {
-            "description": "The disk storage account type to use for the OS disks of the Nodes in the\nNode Pool. Valid values are:\n* Standard_LRS: HDD\n* StandardSSD_LRS: Standard SSD\n* Premium_LRS: Premium SDD\n* UltraSSD_LRS: Ultra SDD\n\nIf not specified, `Premium_LRS` is used.",
-            "type": "string"
-          },
           "vm_size": {
             "description": "The Azure Virtual Machine size identifier used for the\nNodes of the Node Pool.\nAvailability of VM sizes are dependent on the Azure Location\nof the parent Cluster.\nRequired during creation.",
             "type": "string"
@@ -1985,10 +1976,6 @@
           "encryption_at_host": {
             "description": "EncryptionAtHost contains Encryption At Host disk encryption configuration.\nWhen enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks\nand disk caches are encrypted at rest and flow encrypted to the Storage clusters.\nIf not specified, Encryption at Host is not enabled.\nImmutable.",
             "$ref": "#/components/schemas/AzureNodePoolEncryptionAtHost"
-          },
-          "ephemeral_os_disk_enabled": {
-            "description": "Enables Ephemeral OS Disks for the Nodes in the Node Pool.\nIf not specified, no Ephemeral OS Disks are used.",
-            "type": "boolean"
           },
           "os_disk": {
             "description": "The configuration for the OS disk used by the nodes in the Node Pool.",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -15192,15 +15192,6 @@
       "AzureNodePool": {
         "description": "Representation of azure node pool specific parameters.",
         "properties": {
-          "os_disk_size_gibibytes": {
-            "description": "The size in GiB to assign to the OS disks of the\nNodes in the Node Pool. The property\nis the number of bytes x 1024^3.\nIf not specified, OS disk size is 30 GiB.",
-            "type": "integer",
-            "format": "int32"
-          },
-          "os_disk_storage_account_type": {
-            "description": "The disk storage account type to use for the OS disks of the Nodes in the\nNode Pool. Valid values are:\n* Standard_LRS: HDD\n* StandardSSD_LRS: Standard SSD\n* Premium_LRS: Premium SDD\n* UltraSSD_LRS: Ultra SDD\n\nIf not specified, `Premium_LRS` is used.",
-            "type": "string"
-          },
           "vm_size": {
             "description": "The Azure Virtual Machine size identifier used for the\nNodes of the Node Pool.\nAvailability of VM sizes are dependent on the Azure Location\nof the parent Cluster.\nRequired during creation.",
             "type": "string"
@@ -15208,10 +15199,6 @@
           "encryption_at_host": {
             "description": "EncryptionAtHost contains Encryption At Host disk encryption configuration.\nWhen enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks\nand disk caches are encrypted at rest and flow encrypted to the Storage clusters.\nIf not specified, Encryption at Host is not enabled.\nImmutable.",
             "$ref": "#/components/schemas/AzureNodePoolEncryptionAtHost"
-          },
-          "ephemeral_os_disk_enabled": {
-            "description": "Enables Ephemeral OS Disks for the Nodes in the Node Pool.\nIf not specified, no Ephemeral OS Disks are used.",
-            "type": "boolean"
           },
           "os_disk": {
             "description": "The configuration for the OS disk used by the nodes in the Node Pool.",


### PR DESCRIPTION
Remove support for the old OS disk attribute format in NodePool and retained only the new structured os_disk design. Deprecated top-level os disk fields have been removed.