### PR TITLE
[OCM-17752] update MarketType enum to match the camelcase values expected by CS

### DIFF
--- a/clientapi/arohcp/v1alpha1/market_type_type.go
+++ b/clientapi/arohcp/v1alpha1/market_type_type.go
@@ -24,7 +24,7 @@ type MarketType string
 
 const (
 	// Scheduled pre-purchased compute capacity.
-	MarketTypeCapacityBlocks MarketType = "capacity_blocks"
+	MarketTypeCapacityBlocks MarketType = "CapacityBlocks"
 	// EC2 instances run as standard On-Demand instances.
-	MarketTypeOnDemand MarketType = "on_demand"
+	MarketTypeOnDemand MarketType = "OnDemand"
 )

--- a/clientapi/clustersmgmt/v1/market_type_type.go
+++ b/clientapi/clustersmgmt/v1/market_type_type.go
@@ -24,7 +24,7 @@ type MarketType string
 
 const (
 	// Scheduled pre-purchased compute capacity.
-	MarketTypeCapacityBlocks MarketType = "capacity_blocks"
+	MarketTypeCapacityBlocks MarketType = "CapacityBlocks"
 	// EC2 instances run as standard On-Demand instances.
-	MarketTypeOnDemand MarketType = "on_demand"
+	MarketTypeOnDemand MarketType = "OnDemand"
 )

--- a/model/clusters_mgmt/v1/market_type.model
+++ b/model/clusters_mgmt/v1/market_type.model
@@ -17,8 +17,10 @@ limitations under the License.
 // Market type for AWS Capacity Reservations.
 enum MarketType {
     // EC2 instances run as standard On-Demand instances.
+	@json(name = "OnDemand")
     OnDemand
 
     // Scheduled pre-purchased compute capacity.
+	@json(name = "CapacityBlocks")
     CapacityBlocks
 } 

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -3539,8 +3539,8 @@
         "description": "Market type for AWS Capacity Reservations.",
         "type": "string",
         "enum": [
-          "capacity_blocks",
-          "on_demand"
+          "CapacityBlocks",
+          "OnDemand"
         ]
       },
       "Network": {

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -17736,8 +17736,8 @@
         "description": "Market type for AWS Capacity Reservations.",
         "type": "string",
         "enum": [
-          "capacity_blocks",
-          "on_demand"
+          "CapacityBlocks",
+          "OnDemand"
         ]
       },
       "NamespaceOwnershipPolicy": {


### PR DESCRIPTION
generators convert camelcase enum values into snake_case go consts, which means that the enum values defined for MarketType in the api model do not match those defined in CS's internal expected values.

This updates the JSON directives for the generator on this particular enum type to match the expected values.