### PR TITLE
OCM-23443 | feat: Add `ZeroEgressDefaultDomains` resource and type for ROSA HCP

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 This document describes the relevant changes between releases of the API model.
 
+## 0.0.454 Apr 24 2026
+- Add `ZeroEgress` resource and type for ROSA HCP
+
 ## 0.0.453 Mar 11 2026
 - Add `Visibility` field of type `AzureKmsEncryptionVisibility` to the `AzureKmsEncryption` type.
 - Add `OidcIssuerUrl` field to ARO-HCP `Azure` type.

--- a/clientapi/clustersmgmt/v1/zero_egress_configuration_builder.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_configuration_builder.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Configuration for zero egress clusters.
+type ZeroEgressConfigurationBuilder struct {
+	fieldSet_      []bool
+	defaultDomains []string
+}
+
+// NewZeroEgressConfiguration creates a new builder of 'zero_egress_configuration' objects.
+func NewZeroEgressConfiguration() *ZeroEgressConfigurationBuilder {
+	return &ZeroEgressConfigurationBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ZeroEgressConfigurationBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// DefaultDomains sets the value of the 'default_domains' attribute to the given values.
+func (b *ZeroEgressConfigurationBuilder) DefaultDomains(values ...string) *ZeroEgressConfigurationBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.defaultDomains = make([]string, len(values))
+	copy(b.defaultDomains, values)
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ZeroEgressConfigurationBuilder) Copy(object *ZeroEgressConfiguration) *ZeroEgressConfigurationBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	if object.defaultDomains != nil {
+		b.defaultDomains = make([]string, len(object.defaultDomains))
+		copy(b.defaultDomains, object.defaultDomains)
+	} else {
+		b.defaultDomains = nil
+	}
+	return b
+}
+
+// Build creates a 'zero_egress_configuration' object using the configuration stored in the builder.
+func (b *ZeroEgressConfigurationBuilder) Build() (object *ZeroEgressConfiguration, err error) {
+	object = new(ZeroEgressConfiguration)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.defaultDomains != nil {
+		object.defaultDomains = make([]string, len(b.defaultDomains))
+		copy(object.defaultDomains, b.defaultDomains)
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_configuration_list_builder.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_configuration_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ZeroEgressConfigurationListBuilder contains the data and logic needed to build
+// 'zero_egress_configuration' objects.
+type ZeroEgressConfigurationListBuilder struct {
+	items []*ZeroEgressConfigurationBuilder
+}
+
+// NewZeroEgressConfigurationList creates a new builder of 'zero_egress_configuration' objects.
+func NewZeroEgressConfigurationList() *ZeroEgressConfigurationListBuilder {
+	return new(ZeroEgressConfigurationListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ZeroEgressConfigurationListBuilder) Items(values ...*ZeroEgressConfigurationBuilder) *ZeroEgressConfigurationListBuilder {
+	b.items = make([]*ZeroEgressConfigurationBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ZeroEgressConfigurationListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ZeroEgressConfigurationListBuilder) Copy(list *ZeroEgressConfigurationList) *ZeroEgressConfigurationListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ZeroEgressConfigurationBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewZeroEgressConfiguration().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'zero_egress_configuration' objects using the
+// configuration stored in the builder.
+func (b *ZeroEgressConfigurationListBuilder) Build() (list *ZeroEgressConfigurationList, err error) {
+	items := make([]*ZeroEgressConfiguration, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ZeroEgressConfigurationList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_configuration_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_configuration_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalZeroEgressConfigurationList writes a list of values of the 'zero_egress_configuration' type to
+// the given writer.
+func MarshalZeroEgressConfigurationList(list []*ZeroEgressConfiguration, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteZeroEgressConfigurationList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteZeroEgressConfigurationList writes a list of value of the 'zero_egress_configuration' type to
+// the given stream.
+func WriteZeroEgressConfigurationList(list []*ZeroEgressConfiguration, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteZeroEgressConfiguration(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalZeroEgressConfigurationList reads a list of values of the 'zero_egress_configuration' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalZeroEgressConfigurationList(source interface{}) (items []*ZeroEgressConfiguration, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadZeroEgressConfigurationList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadZeroEgressConfigurationList reads list of values of the ”zero_egress_configuration' type from
+// the given iterator.
+func ReadZeroEgressConfigurationList(iterator *jsoniter.Iterator) []*ZeroEgressConfiguration {
+	list := []*ZeroEgressConfiguration{}
+	for iterator.ReadArray() {
+		item := ReadZeroEgressConfiguration(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_configuration_type.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_configuration_type.go
@@ -1,0 +1,175 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ZeroEgressConfiguration represents the values of the 'zero_egress_configuration' type.
+//
+// Configuration for zero egress clusters.
+type ZeroEgressConfiguration struct {
+	fieldSet_      []bool
+	defaultDomains []string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ZeroEgressConfiguration) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// DefaultDomains returns the value of the 'default_domains' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// List of default no-proxy domain patterns that are automatically added
+// to the cluster's proxy configuration for zero egress enablement.
+func (o *ZeroEgressConfiguration) DefaultDomains() []string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.defaultDomains
+	}
+	return nil
+}
+
+// GetDefaultDomains returns the value of the 'default_domains' attribute and
+// a flag indicating if the attribute has a value.
+//
+// List of default no-proxy domain patterns that are automatically added
+// to the cluster's proxy configuration for zero egress enablement.
+func (o *ZeroEgressConfiguration) GetDefaultDomains() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.defaultDomains
+	}
+	return
+}
+
+// ZeroEgressConfigurationListKind is the name of the type used to represent list of objects of
+// type 'zero_egress_configuration'.
+const ZeroEgressConfigurationListKind = "ZeroEgressConfigurationList"
+
+// ZeroEgressConfigurationListLinkKind is the name of the type used to represent links to list
+// of objects of type 'zero_egress_configuration'.
+const ZeroEgressConfigurationListLinkKind = "ZeroEgressConfigurationListLink"
+
+// ZeroEgressConfigurationNilKind is the name of the type used to nil lists of objects of
+// type 'zero_egress_configuration'.
+const ZeroEgressConfigurationListNilKind = "ZeroEgressConfigurationListNil"
+
+// ZeroEgressConfigurationList is a list of values of the 'zero_egress_configuration' type.
+type ZeroEgressConfigurationList struct {
+	href  string
+	link  bool
+	items []*ZeroEgressConfiguration
+}
+
+// Len returns the length of the list.
+func (l *ZeroEgressConfigurationList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ZeroEgressConfigurationList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ZeroEgressConfigurationList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ZeroEgressConfigurationList) SetItems(items []*ZeroEgressConfiguration) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ZeroEgressConfigurationList) Items() []*ZeroEgressConfiguration {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ZeroEgressConfigurationList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ZeroEgressConfigurationList) Get(i int) *ZeroEgressConfiguration {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ZeroEgressConfigurationList) Slice() []*ZeroEgressConfiguration {
+	var slice []*ZeroEgressConfiguration
+	if l == nil {
+		slice = make([]*ZeroEgressConfiguration, 0)
+	} else {
+		slice = make([]*ZeroEgressConfiguration, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ZeroEgressConfigurationList) Each(f func(item *ZeroEgressConfiguration) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ZeroEgressConfigurationList) Range(f func(index int, item *ZeroEgressConfiguration) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_configuration_type_json.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_configuration_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalZeroEgressConfiguration writes a value of the 'zero_egress_configuration' type to the given writer.
+func MarshalZeroEgressConfiguration(object *ZeroEgressConfiguration, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteZeroEgressConfiguration(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteZeroEgressConfiguration writes a value of the 'zero_egress_configuration' type to the given stream.
+func WriteZeroEgressConfiguration(object *ZeroEgressConfiguration, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.defaultDomains != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("default_domains")
+		WriteStringList(object.defaultDomains, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalZeroEgressConfiguration reads a value of the 'zero_egress_configuration' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalZeroEgressConfiguration(source interface{}) (object *ZeroEgressConfiguration, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadZeroEgressConfiguration(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadZeroEgressConfiguration reads a value of the 'zero_egress_configuration' type from the given iterator.
+func ReadZeroEgressConfiguration(iterator *jsoniter.Iterator) *ZeroEgressConfiguration {
+	object := &ZeroEgressConfiguration{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "default_domains":
+			value := ReadStringList(iterator)
+			object.defaultDomains = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -222,4 +222,9 @@ resource Cluster {
 	locator ImageMirrors {
 		target ImageMirrors
 	}
+
+	// Reference to the resource that manages service inquiries for the cluster.
+	locator ServiceInquiries {
+		target ServiceInquiries
+	}
 }

--- a/model/clusters_mgmt/v1/service_inquiries_resource.model
+++ b/model/clusters_mgmt/v1/service_inquiries_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages service inquiries for a cluster.
+resource ServiceInquiries {
+	// Reference to the resource that manages zero egress inquiry.
+	locator ZeroEgress {
+		target ZeroEgress
+	}
+}

--- a/model/clusters_mgmt/v1/zero_egress_configuration_type.model
+++ b/model/clusters_mgmt/v1/zero_egress_configuration_type.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Configuration for zero egress clusters.
+struct ZeroEgressConfiguration {
+	// List of default no-proxy domain patterns that are automatically added
+	// to the cluster's proxy configuration for zero egress enablement.
+	DefaultDomains []String
+}

--- a/model/clusters_mgmt/v1/zero_egress_resource.model
+++ b/model/clusters_mgmt/v1/zero_egress_resource.model
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages zero egress inquiry for a cluster.
+resource ZeroEgress {
+	// Retrieves the zero egress configuration for this cluster.
+	method Get {
+		out Body ZeroEgressConfiguration
+	}
+}

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -9690,6 +9690,43 @@
         }
       }
     },
+    "/api/clusters_mgmt/v1/clusters/{cluster_id}/service_inquiries/zero_egress": {
+      "get": {
+        "description": "Retrieves the zero egress configuration for this cluster.",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZeroEgressConfiguration"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/clusters_mgmt/v1/clusters/{cluster_id}/status": {
       "get": {
         "parameters": [
@@ -20866,6 +20903,18 @@
           "WildcardsAllowed",
           "WildcardsDisallowed"
         ]
+      },
+      "ZeroEgressConfiguration": {
+        "description": "Configuration for zero egress clusters.",
+        "properties": {
+          "default_domains": {
+            "description": "List of default no-proxy domain patterns that are automatically added\nto the cluster's proxy configuration for zero egress enablement.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       },
       "Error": {
         "type": "object",


### PR DESCRIPTION
sample request
```
  GET /api/clusters_mgmt/v1/clusters/2ps9kkfk04u0rcv4fgaiuplpqcuvt11j/service_inquiries/zero_egress                                                                                                                  
                                                                                                                                                                                                                     
  HTTP 200 OK                                                                                                                                                                                                        
  {                                                                                                                                                                                                                  
    "kind": "ZeroEgressConfiguration,                                                                                                                                                                              
    "default_domains": [                                                                                                                                                                                                   
        "s3.dualstack.us-west-2.amazonaws.com",
        ".s3.us-west-2.amazonaws.com",
        "sts.us-west-2.amazonaws.com",
        "api.ecr.us-west-2.amazonaws.com",
        ".dkr.ecr.us-west-2.amazonaws.com"                                                                                                                                                                                         
    ]                                                                                                                                                                                                                
  } 
```