### PR TITLE
OCM-23443 | feat: add zero_egress field to aws spec

### DIFF
--- a/clientapi/clustersmgmt/v1/aws_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_builder.go
@@ -43,13 +43,14 @@ type AWSBuilder struct {
 	subnetIDs                              []string
 	tags                                   map[string]string
 	vpcEndpointRoleArn                     string
+	zeroEgress                             *ZeroEgressBuilder
 	privateLink                            bool
 }
 
 // NewAWS creates a new builder of 'AWS' objects.
 func NewAWS() *AWSBuilder {
 	return &AWSBuilder{
-		fieldSet_: make([]bool, 22),
+		fieldSet_: make([]bool, 23),
 	}
 }
 
@@ -69,7 +70,7 @@ func (b *AWSBuilder) Empty() bool {
 // KMSKeyArn sets the value of the 'KMS_key_arn' attribute to the given value.
 func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.kmsKeyArn = value
 	b.fieldSet_[0] = true
@@ -81,7 +82,7 @@ func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.sts = value
 	if value != nil {
@@ -95,7 +96,7 @@ func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 // AccessKeyID sets the value of the 'access_key_ID' attribute to the given value.
 func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.accessKeyID = value
 	b.fieldSet_[2] = true
@@ -105,7 +106,7 @@ func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 // AccountID sets the value of the 'account_ID' attribute to the given value.
 func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.accountID = value
 	b.fieldSet_[3] = true
@@ -115,7 +116,7 @@ func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 // AdditionalAllowedPrincipals sets the value of the 'additional_allowed_principals' attribute to the given values.
 func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.additionalAllowedPrincipals = make([]string, len(values))
 	copy(b.additionalAllowedPrincipals, values)
@@ -126,7 +127,7 @@ func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 // AdditionalComputeSecurityGroupIds sets the value of the 'additional_compute_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.additionalComputeSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalComputeSecurityGroupIds, values)
@@ -137,7 +138,7 @@ func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBui
 // AdditionalControlPlaneSecurityGroupIds sets the value of the 'additional_control_plane_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.additionalControlPlaneSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalControlPlaneSecurityGroupIds, values)
@@ -148,7 +149,7 @@ func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *A
 // AdditionalInfraSecurityGroupIds sets the value of the 'additional_infra_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.additionalInfraSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalInfraSecurityGroupIds, values)
@@ -161,7 +162,7 @@ func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuild
 // Contains the necessary attributes to support audit log forwarding
 func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.auditLog = value
 	if value != nil {
@@ -177,7 +178,7 @@ func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 // AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
 func (b *AWSBuilder) AutoNode(value *AwsAutoNodeBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.autoNode = value
 	if value != nil {
@@ -191,7 +192,7 @@ func (b *AWSBuilder) AutoNode(value *AwsAutoNodeBuilder) *AWSBuilder {
 // BillingAccountID sets the value of the 'billing_account_ID' attribute to the given value.
 func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.billingAccountID = value
 	b.fieldSet_[10] = true
@@ -203,7 +204,7 @@ func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.ec2MetadataHttpTokens = value
 	b.fieldSet_[11] = true
@@ -215,7 +216,7 @@ func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuil
 // Contains the necessary attributes to support etcd encryption for AWS based clusters.
 func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.etcdEncryption = value
 	if value != nil {
@@ -229,7 +230,7 @@ func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder
 // HcpInternalCommunicationHostedZoneId sets the value of the 'hcp_internal_communication_hosted_zone_id' attribute to the given value.
 func (b *AWSBuilder) HcpInternalCommunicationHostedZoneId(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.hcpInternalCommunicationHostedZoneId = value
 	b.fieldSet_[13] = true
@@ -239,7 +240,7 @@ func (b *AWSBuilder) HcpInternalCommunicationHostedZoneId(value string) *AWSBuil
 // PrivateHostedZoneID sets the value of the 'private_hosted_zone_ID' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.privateHostedZoneID = value
 	b.fieldSet_[14] = true
@@ -249,7 +250,7 @@ func (b *AWSBuilder) PrivateHostedZoneID(value string) *AWSBuilder {
 // PrivateHostedZoneRoleARN sets the value of the 'private_hosted_zone_role_ARN' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneRoleARN(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.privateHostedZoneRoleARN = value
 	b.fieldSet_[15] = true
@@ -259,7 +260,7 @@ func (b *AWSBuilder) PrivateHostedZoneRoleARN(value string) *AWSBuilder {
 // PrivateLink sets the value of the 'private_link' attribute to the given value.
 func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.privateLink = value
 	b.fieldSet_[16] = true
@@ -271,7 +272,7 @@ func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 // Manages the configuration for the Private Links.
 func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigurationBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.privateLinkConfiguration = value
 	if value != nil {
@@ -285,7 +286,7 @@ func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigura
 // SecretAccessKey sets the value of the 'secret_access_key' attribute to the given value.
 func (b *AWSBuilder) SecretAccessKey(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.secretAccessKey = value
 	b.fieldSet_[18] = true
@@ -295,7 +296,7 @@ func (b *AWSBuilder) SecretAccessKey(value string) *AWSBuilder {
 // SubnetIDs sets the value of the 'subnet_IDs' attribute to the given values.
 func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.subnetIDs = make([]string, len(values))
 	copy(b.subnetIDs, values)
@@ -306,7 +307,7 @@ func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 // Tags sets the value of the 'tags' attribute to the given value.
 func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.tags = value
 	if value != nil {
@@ -320,10 +321,26 @@ func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 // VpcEndpointRoleArn sets the value of the 'vpc_endpoint_role_arn' attribute to the given value.
 func (b *AWSBuilder) VpcEndpointRoleArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 22)
+		b.fieldSet_ = make([]bool, 23)
 	}
 	b.vpcEndpointRoleArn = value
 	b.fieldSet_[21] = true
+	return b
+}
+
+// ZeroEgress sets the value of the 'zero_egress' attribute to the given value.
+//
+// Zero egress configuration.
+func (b *AWSBuilder) ZeroEgress(value *ZeroEgressBuilder) *AWSBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 23)
+	}
+	b.zeroEgress = value
+	if value != nil {
+		b.fieldSet_[22] = true
+	} else {
+		b.fieldSet_[22] = false
+	}
 	return b
 }
 
@@ -410,6 +427,11 @@ func (b *AWSBuilder) Copy(object *AWS) *AWSBuilder {
 		b.tags = nil
 	}
 	b.vpcEndpointRoleArn = object.vpcEndpointRoleArn
+	if object.zeroEgress != nil {
+		b.zeroEgress = NewZeroEgress().Copy(object.zeroEgress)
+	} else {
+		b.zeroEgress = nil
+	}
 	return b
 }
 
@@ -487,5 +509,11 @@ func (b *AWSBuilder) Build() (object *AWS, err error) {
 		}
 	}
 	object.vpcEndpointRoleArn = b.vpcEndpointRoleArn
+	if b.zeroEgress != nil {
+		object.zeroEgress, err = b.zeroEgress.Build()
+		if err != nil {
+			return
+		}
+	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/aws_type.go
+++ b/clientapi/clustersmgmt/v1/aws_type.go
@@ -45,6 +45,7 @@ type AWS struct {
 	subnetIDs                              []string
 	tags                                   map[string]string
 	vpcEndpointRoleArn                     string
+	zeroEgress                             *ZeroEgress
 	privateLink                            bool
 }
 
@@ -563,6 +564,29 @@ func (o *AWS) GetVpcEndpointRoleArn() (value string, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
 	if ok {
 		value = o.vpcEndpointRoleArn
+	}
+	return
+}
+
+// ZeroEgress returns the value of the 'zero_egress' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Zero egress configuration.
+func (o *AWS) ZeroEgress() *ZeroEgress {
+	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
+		return o.zeroEgress
+	}
+	return nil
+}
+
+// GetZeroEgress returns the value of the 'zero_egress' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Zero egress configuration.
+func (o *AWS) GetZeroEgress() (value *ZeroEgress, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
+	if ok {
+		value = o.zeroEgress
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/aws_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_type_json.go
@@ -259,6 +259,15 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		}
 		stream.WriteObjectField("vpc_endpoint_role_arn")
 		stream.WriteString(object.vpcEndpointRoleArn)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22] && object.zeroEgress != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("zero_egress")
+		WriteZeroEgress(object.zeroEgress, stream)
 	}
 	stream.WriteObjectEnd()
 }
@@ -278,7 +287,7 @@ func UnmarshalAWS(source interface{}) (object *AWS, err error) {
 // ReadAWS reads a value of the 'AWS' type from the given iterator.
 func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 	object := &AWS{
-		fieldSet_: make([]bool, 22),
+		fieldSet_: make([]bool, 23),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -383,6 +392,10 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 			value := iterator.ReadString()
 			object.vpcEndpointRoleArn = value
 			object.fieldSet_[21] = true
+		case "zero_egress":
+			value := ReadZeroEgress(iterator)
+			object.zeroEgress = value
+			object.fieldSet_[22] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/zero_egress_builder.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_builder.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Zero egress configuration.
+type ZeroEgressBuilder struct {
+	fieldSet_             []bool
+	noProxyDefaultDomains []string
+	enabled               bool
+}
+
+// NewZeroEgress creates a new builder of 'zero_egress' objects.
+func NewZeroEgress() *ZeroEgressBuilder {
+	return &ZeroEgressBuilder{
+		fieldSet_: make([]bool, 2),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *ZeroEgressBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Enabled sets the value of the 'enabled' attribute to the given value.
+func (b *ZeroEgressBuilder) Enabled(value bool) *ZeroEgressBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.enabled = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// NoProxyDefaultDomains sets the value of the 'no_proxy_default_domains' attribute to the given values.
+func (b *ZeroEgressBuilder) NoProxyDefaultDomains(values ...string) *ZeroEgressBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.noProxyDefaultDomains = make([]string, len(values))
+	copy(b.noProxyDefaultDomains, values)
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *ZeroEgressBuilder) Copy(object *ZeroEgress) *ZeroEgressBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.enabled = object.enabled
+	if object.noProxyDefaultDomains != nil {
+		b.noProxyDefaultDomains = make([]string, len(object.noProxyDefaultDomains))
+		copy(b.noProxyDefaultDomains, object.noProxyDefaultDomains)
+	} else {
+		b.noProxyDefaultDomains = nil
+	}
+	return b
+}
+
+// Build creates a 'zero_egress' object using the configuration stored in the builder.
+func (b *ZeroEgressBuilder) Build() (object *ZeroEgress, err error) {
+	object = new(ZeroEgress)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.enabled = b.enabled
+	if b.noProxyDefaultDomains != nil {
+		object.noProxyDefaultDomains = make([]string, len(b.noProxyDefaultDomains))
+		copy(object.noProxyDefaultDomains, b.noProxyDefaultDomains)
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_list_builder.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ZeroEgressListBuilder contains the data and logic needed to build
+// 'zero_egress' objects.
+type ZeroEgressListBuilder struct {
+	items []*ZeroEgressBuilder
+}
+
+// NewZeroEgressList creates a new builder of 'zero_egress' objects.
+func NewZeroEgressList() *ZeroEgressListBuilder {
+	return new(ZeroEgressListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *ZeroEgressListBuilder) Items(values ...*ZeroEgressBuilder) *ZeroEgressListBuilder {
+	b.items = make([]*ZeroEgressBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *ZeroEgressListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *ZeroEgressListBuilder) Copy(list *ZeroEgressList) *ZeroEgressListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*ZeroEgressBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewZeroEgress().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'zero_egress' objects using the
+// configuration stored in the builder.
+func (b *ZeroEgressListBuilder) Build() (list *ZeroEgressList, err error) {
+	items := make([]*ZeroEgress, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(ZeroEgressList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalZeroEgressList writes a list of values of the 'zero_egress' type to
+// the given writer.
+func MarshalZeroEgressList(list []*ZeroEgress, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteZeroEgressList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteZeroEgressList writes a list of value of the 'zero_egress' type to
+// the given stream.
+func WriteZeroEgressList(list []*ZeroEgress, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteZeroEgress(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalZeroEgressList reads a list of values of the 'zero_egress' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalZeroEgressList(source interface{}) (items []*ZeroEgress, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadZeroEgressList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadZeroEgressList reads list of values of the ”zero_egress' type from
+// the given iterator.
+func ReadZeroEgressList(iterator *jsoniter.Iterator) []*ZeroEgress {
+	list := []*ZeroEgress{}
+	for iterator.ReadArray() {
+		item := ReadZeroEgress(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_type.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_type.go
@@ -1,0 +1,199 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// ZeroEgress represents the values of the 'zero_egress' type.
+//
+// Zero egress configuration.
+type ZeroEgress struct {
+	fieldSet_             []bool
+	noProxyDefaultDomains []string
+	enabled               bool
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *ZeroEgress) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Enabled returns the value of the 'enabled' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Indicates if zero egress is enabled for this cluster.
+func (o *ZeroEgress) Enabled() bool {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.enabled
+	}
+	return false
+}
+
+// GetEnabled returns the value of the 'enabled' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Indicates if zero egress is enabled for this cluster.
+func (o *ZeroEgress) GetEnabled() (value bool, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.enabled
+	}
+	return
+}
+
+// NoProxyDefaultDomains returns the value of the 'no_proxy_default_domains' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// List of default no-proxy domains automatically added to the cluster's
+// no-proxy configuration when zero egress is enabled.
+func (o *ZeroEgress) NoProxyDefaultDomains() []string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.noProxyDefaultDomains
+	}
+	return nil
+}
+
+// GetNoProxyDefaultDomains returns the value of the 'no_proxy_default_domains' attribute and
+// a flag indicating if the attribute has a value.
+//
+// List of default no-proxy domains automatically added to the cluster's
+// no-proxy configuration when zero egress is enabled.
+func (o *ZeroEgress) GetNoProxyDefaultDomains() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.noProxyDefaultDomains
+	}
+	return
+}
+
+// ZeroEgressListKind is the name of the type used to represent list of objects of
+// type 'zero_egress'.
+const ZeroEgressListKind = "ZeroEgressList"
+
+// ZeroEgressListLinkKind is the name of the type used to represent links to list
+// of objects of type 'zero_egress'.
+const ZeroEgressListLinkKind = "ZeroEgressListLink"
+
+// ZeroEgressNilKind is the name of the type used to nil lists of objects of
+// type 'zero_egress'.
+const ZeroEgressListNilKind = "ZeroEgressListNil"
+
+// ZeroEgressList is a list of values of the 'zero_egress' type.
+type ZeroEgressList struct {
+	href  string
+	link  bool
+	items []*ZeroEgress
+}
+
+// Len returns the length of the list.
+func (l *ZeroEgressList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *ZeroEgressList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *ZeroEgressList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *ZeroEgressList) SetItems(items []*ZeroEgress) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *ZeroEgressList) Items() []*ZeroEgress {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *ZeroEgressList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *ZeroEgressList) Get(i int) *ZeroEgress {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *ZeroEgressList) Slice() []*ZeroEgress {
+	var slice []*ZeroEgress
+	if l == nil {
+		slice = make([]*ZeroEgress, 0)
+	} else {
+		slice = make([]*ZeroEgress, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *ZeroEgressList) Each(f func(item *ZeroEgress) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *ZeroEgressList) Range(f func(index int, item *ZeroEgress) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/zero_egress_type_json.go
+++ b/clientapi/clustersmgmt/v1/zero_egress_type_json.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalZeroEgress writes a value of the 'zero_egress' type to the given writer.
+func MarshalZeroEgress(object *ZeroEgress, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteZeroEgress(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteZeroEgress writes a value of the 'zero_egress' type to the given stream.
+func WriteZeroEgress(object *ZeroEgress, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("enabled")
+		stream.WriteBool(object.enabled)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.noProxyDefaultDomains != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("no_proxy_default_domains")
+		WriteStringList(object.noProxyDefaultDomains, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalZeroEgress reads a value of the 'zero_egress' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalZeroEgress(source interface{}) (object *ZeroEgress, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadZeroEgress(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadZeroEgress reads a value of the 'zero_egress' type from the given iterator.
+func ReadZeroEgress(iterator *jsoniter.Iterator) *ZeroEgress {
+	object := &ZeroEgress{
+		fieldSet_: make([]bool, 2),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "enabled":
+			value := iterator.ReadBool()
+			object.enabled = value
+			object.fieldSet_[0] = true
+		case "no_proxy_default_domains":
+			value := ReadStringList(iterator)
+			object.noProxyDefaultDomains = value
+			object.fieldSet_[1] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -82,4 +82,7 @@ struct AWS {
 
     // AWS specific configuration for AutoNode
 	AutoNode AwsAutoNode
+
+	// Zero egress configuration.
+	ZeroEgress ZeroEgress
 }

--- a/model/clusters_mgmt/v1/zero_egress_type.model
+++ b/model/clusters_mgmt/v1/zero_egress_type.model
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Zero egress configuration.
+struct ZeroEgress {
+	// Indicates if zero egress is enabled for this cluster.
+	Enabled Boolean
+
+	// List of default no-proxy domains automatically added to the cluster's
+	// no-proxy configuration when zero egress is enabled.
+	NoProxyDefaultDomains []String
+}

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -14196,6 +14196,10 @@
           "vpc_endpoint_role_arn": {
             "description": "Role ARN for VPC Endpoint Service cross account role.",
             "type": "string"
+          },
+          "zero_egress": {
+            "description": "Zero egress configuration.",
+            "$ref": "#/components/schemas/ZeroEgress"
           }
         }
       },
@@ -20866,6 +20870,22 @@
           "WildcardsAllowed",
           "WildcardsDisallowed"
         ]
+      },
+      "ZeroEgress": {
+        "description": "Zero egress configuration.",
+        "properties": {
+          "enabled": {
+            "description": "Indicates if zero egress is enabled for this cluster.",
+            "type": "boolean"
+          },
+          "no_proxy_default_domains": {
+            "description": "List of default no-proxy domains automatically added to the cluster's\nno-proxy configuration when zero egress is enabled.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
       },
       "Error": {
         "type": "object",


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCM-23443

this MR provides a new field `zero_egress` into aws spec. This will provide the zero egress related info of the cluster.
Currently it includes the `no_proxy_default_domains`. A sample is like below
```
{       
    "kind":"Cluster",
    "id":"...",
    "name":"...",     
     ...
     ...                                                                                                                                                                                                     
    "aws": {
          "account_id": "...",
          "subnet_ids": [...],
          "zero_egress": {
            "enabled": true,
            "no_proxy_default_domains": [
              "s3.dualstack.{region}.amazonaws.com",                                                                                                                                                                                                            
```