### PR TITLE
OCM-20448 | feat: add register cluster endpoint to OCM CS grafana

### DIFF
--- a/model/clusters_mgmt/v1/register_cluster_resource.model
+++ b/model/clusters_mgmt/v1/register_cluster_resource.model
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Registers clusters that were provisioned outside this service.
+resource RegisterCluster {
+	// Adds an existing cluster to the collection.
+	method Post {
+		// Attributes of the cluster registration request.
+		in Body ClusterRegistration
+
+		// Created cluster record.
+		out Body Cluster
+	}
+}

--- a/model/clusters_mgmt/v1/root_resource.model
+++ b/model/clusters_mgmt/v1/root_resource.model
@@ -31,6 +31,11 @@ resource Root {
 		target Clusters
 	}
 
+	// Reference to cluster registration for externally provisioned clusters.
+	locator RegisterCluster {
+		target RegisterCluster
+	}
+
 	// Reference to the service that manages the collection of flavours.
 	locator Flavours {
 		target Flavours

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -13365,6 +13365,42 @@
         }
       }
     },
+    "/api/clusters_mgmt/v1/register_cluster": {
+      "post": {
+        "description": "Adds an existing cluster to the collection.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClusterRegistration"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/clusters_mgmt/v1/registry_allowlists": {
       "post": {
         "description": "Adds a new break registry allowlist.",


### PR DESCRIPTION
Adding endpoint /api/clusters_mgmt/v1/register_cluster to API model.

(It is missing from https://grafana.stage.devshift.net/d/uhc-clusters-service/uhc-clusters-service?orgId=1&from=now-6h&to=now&timezone=UTC&var-route=$__all&var-datasource=P21873DB8DE1CE799&var-namespace=uhc-stage&var-pod=$__all&var-rds_datasource=P1F52857DAB23CCC8&var-rds_namespace=clusters-service-production&var-max_ready_time=60&var-account=.%2A&var-rds_datasource-2=P1F52857DAB23CCC8&var-rds_namespace-2=clusters-service-production)

