### PR TITLE
Add creator_id and creator_username to Cluster type

### DIFF
--- a/clientapi/clustersmgmt/v1/cluster_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_builder.go
@@ -86,6 +86,8 @@ type ClusterBuilder struct {
 	console                           *ClusterConsoleBuilder
 	controlPlane                      *ControlPlaneBuilder
 	creationTimestamp                 time.Time
+	creatorId                         string
+	creatorUsername                   string
 	deleteProtection                  *DeleteProtectionBuilder
 	domainPrefix                      string
 	expirationTimestamp               time.Time
@@ -134,14 +136,14 @@ type ClusterBuilder struct {
 // NewCluster creates a new builder of 'cluster' objects.
 func NewCluster() *ClusterBuilder {
 	return &ClusterBuilder{
-		fieldSet_: make([]bool, 66),
+		fieldSet_: make([]bool, 68),
 	}
 }
 
 // Link sets the flag that indicates if this is a link.
 func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.fieldSet_[0] = true
 	return b
@@ -150,7 +152,7 @@ func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 // ID sets the identifier of the object.
 func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.id = value
 	b.fieldSet_[1] = true
@@ -160,7 +162,7 @@ func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 // HREF sets the link to the object.
 func (b *ClusterBuilder) HREF(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.href = value
 	b.fieldSet_[2] = true
@@ -187,7 +189,7 @@ func (b *ClusterBuilder) Empty() bool {
 // Information about the API of a cluster.
 func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.api = value
 	if value != nil {
@@ -203,7 +205,7 @@ func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 // _Amazon Web Services_ specific settings of a cluster.
 func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.aws = value
 	if value != nil {
@@ -217,7 +219,7 @@ func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 // AWSInfrastructureAccessRoleGrants sets the value of the 'AWS_infrastructure_access_role_grants' attribute to the given values.
 func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *AWSInfrastructureAccessRoleGrantListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.awsInfrastructureAccessRoleGrants = value
 	b.fieldSet_[5] = true
@@ -227,7 +229,7 @@ func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *AWSInfrastruct
 // CCS sets the value of the 'CCS' attribute to the given value.
 func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.ccs = value
 	if value != nil {
@@ -243,7 +245,7 @@ func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 // DNS settings of the cluster.
 func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.dns = value
 	if value != nil {
@@ -257,7 +259,7 @@ func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 // FIPS sets the value of the 'FIPS' attribute to the given value.
 func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.fips = value
 	b.fieldSet_[8] = true
@@ -269,7 +271,7 @@ func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 // Google cloud platform settings of a cluster.
 func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.gcp = value
 	if value != nil {
@@ -285,7 +287,7 @@ func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 // GCP Encryption Key for CCS clusters.
 func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.gcpEncryptionKey = value
 	if value != nil {
@@ -301,7 +303,7 @@ func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *Clust
 // GCP Network configuration of a cluster.
 func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.gcpNetwork = value
 	if value != nil {
@@ -315,7 +317,7 @@ func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 // AdditionalTrustBundle sets the value of the 'additional_trust_bundle' attribute to the given value.
 func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.additionalTrustBundle = value
 	b.fieldSet_[12] = true
@@ -325,7 +327,7 @@ func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 // Addons sets the value of the 'addons' attribute to the given values.
 func (b *ClusterBuilder) Addons(value *AddOnInstallationListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.addons = value
 	b.fieldSet_[13] = true
@@ -337,7 +339,7 @@ func (b *ClusterBuilder) Addons(value *AddOnInstallationListBuilder) *ClusterBui
 // The AutoNode configuration for the Cluster.
 func (b *ClusterBuilder) AutoNode(value *ClusterAutoNodeBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.autoNode = value
 	if value != nil {
@@ -353,7 +355,7 @@ func (b *ClusterBuilder) AutoNode(value *ClusterAutoNodeBuilder) *ClusterBuilder
 // Cluster-wide autoscaling configuration.
 func (b *ClusterBuilder) Autoscaler(value *ClusterAutoscalerBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.autoscaler = value
 	if value != nil {
@@ -369,7 +371,7 @@ func (b *ClusterBuilder) Autoscaler(value *ClusterAutoscalerBuilder) *ClusterBui
 // Microsoft Azure settings of a cluster.
 func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.azure = value
 	if value != nil {
@@ -385,7 +387,7 @@ func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 // Billing model for cluster resources.
 func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.billingModel = value
 	b.fieldSet_[17] = true
@@ -397,7 +399,7 @@ func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 // ByoOidc configuration.
 func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.byoOidc = value
 	if value != nil {
@@ -411,7 +413,7 @@ func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 // Channel sets the value of the 'channel' attribute to the given value.
 func (b *ClusterBuilder) Channel(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.channel = value
 	b.fieldSet_[19] = true
@@ -423,7 +425,7 @@ func (b *ClusterBuilder) Channel(value string) *ClusterBuilder {
 // Cloud provider.
 func (b *ClusterBuilder) CloudProvider(value *CloudProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.cloudProvider = value
 	if value != nil {
@@ -439,7 +441,7 @@ func (b *ClusterBuilder) CloudProvider(value *CloudProviderBuilder) *ClusterBuil
 // Information about the console of a cluster.
 func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.console = value
 	if value != nil {
@@ -455,7 +457,7 @@ func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 // Representation of a Control Plane
 func (b *ClusterBuilder) ControlPlane(value *ControlPlaneBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.controlPlane = value
 	if value != nil {
@@ -469,10 +471,30 @@ func (b *ClusterBuilder) ControlPlane(value *ControlPlaneBuilder) *ClusterBuilde
 // CreationTimestamp sets the value of the 'creation_timestamp' attribute to the given value.
 func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.creationTimestamp = value
 	b.fieldSet_[23] = true
+	return b
+}
+
+// CreatorId sets the value of the 'creator_id' attribute to the given value.
+func (b *ClusterBuilder) CreatorId(value string) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 68)
+	}
+	b.creatorId = value
+	b.fieldSet_[24] = true
+	return b
+}
+
+// CreatorUsername sets the value of the 'creator_username' attribute to the given value.
+func (b *ClusterBuilder) CreatorUsername(value string) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 68)
+	}
+	b.creatorUsername = value
+	b.fieldSet_[25] = true
 	return b
 }
 
@@ -481,13 +503,13 @@ func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 // DeleteProtection configuration.
 func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.deleteProtection = value
 	if value != nil {
-		b.fieldSet_[24] = true
+		b.fieldSet_[26] = true
 	} else {
-		b.fieldSet_[24] = false
+		b.fieldSet_[26] = false
 	}
 	return b
 }
@@ -495,50 +517,50 @@ func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *Clust
 // DisableUserWorkloadMonitoring sets the value of the 'disable_user_workload_monitoring' attribute to the given value.
 func (b *ClusterBuilder) DisableUserWorkloadMonitoring(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.disableUserWorkloadMonitoring = value
-	b.fieldSet_[25] = true
+	b.fieldSet_[27] = true
 	return b
 }
 
 // DomainPrefix sets the value of the 'domain_prefix' attribute to the given value.
 func (b *ClusterBuilder) DomainPrefix(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.domainPrefix = value
-	b.fieldSet_[26] = true
+	b.fieldSet_[28] = true
 	return b
 }
 
 // EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
 func (b *ClusterBuilder) EtcdEncryption(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.etcdEncryption = value
-	b.fieldSet_[27] = true
+	b.fieldSet_[29] = true
 	return b
 }
 
 // ExpirationTimestamp sets the value of the 'expiration_timestamp' attribute to the given value.
 func (b *ClusterBuilder) ExpirationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.expirationTimestamp = value
-	b.fieldSet_[28] = true
+	b.fieldSet_[30] = true
 	return b
 }
 
 // ExternalID sets the value of the 'external_ID' attribute to the given value.
 func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.externalID = value
-	b.fieldSet_[29] = true
+	b.fieldSet_[31] = true
 	return b
 }
 
@@ -547,13 +569,13 @@ func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 // Represents an external authentication configuration
 func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.externalAuthConfig = value
 	if value != nil {
-		b.fieldSet_[30] = true
+		b.fieldSet_[32] = true
 	} else {
-		b.fieldSet_[30] = false
+		b.fieldSet_[32] = false
 	}
 	return b
 }
@@ -563,13 +585,13 @@ func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *C
 // Representation of cluster external configuration.
 func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.externalConfiguration = value
 	if value != nil {
-		b.fieldSet_[31] = true
+		b.fieldSet_[33] = true
 	} else {
-		b.fieldSet_[31] = false
+		b.fieldSet_[33] = false
 	}
 	return b
 }
@@ -580,13 +602,13 @@ func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuild
 // with 10 infra nodes and 1000 compute nodes.
 func (b *ClusterBuilder) Flavour(value *FlavourBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.flavour = value
 	if value != nil {
-		b.fieldSet_[32] = true
+		b.fieldSet_[34] = true
 	} else {
-		b.fieldSet_[32] = false
+		b.fieldSet_[34] = false
 	}
 	return b
 }
@@ -594,10 +616,10 @@ func (b *ClusterBuilder) Flavour(value *FlavourBuilder) *ClusterBuilder {
 // Groups sets the value of the 'groups' attribute to the given values.
 func (b *ClusterBuilder) Groups(value *GroupListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.groups = value
-	b.fieldSet_[33] = true
+	b.fieldSet_[35] = true
 	return b
 }
 
@@ -606,10 +628,10 @@ func (b *ClusterBuilder) Groups(value *GroupListBuilder) *ClusterBuilder {
 // ClusterHealthState indicates the health of a cluster.
 func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.healthState = value
-	b.fieldSet_[34] = true
+	b.fieldSet_[36] = true
 	return b
 }
 
@@ -618,13 +640,13 @@ func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 // Details for `htpasswd` identity providers.
 func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.htpasswd = value
 	if value != nil {
-		b.fieldSet_[35] = true
+		b.fieldSet_[37] = true
 	} else {
-		b.fieldSet_[35] = false
+		b.fieldSet_[37] = false
 	}
 	return b
 }
@@ -634,35 +656,9 @@ func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *Clust
 // Hypershift configuration.
 func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.hypershift = value
-	if value != nil {
-		b.fieldSet_[36] = true
-	} else {
-		b.fieldSet_[36] = false
-	}
-	return b
-}
-
-// IdentityProviders sets the value of the 'identity_providers' attribute to the given values.
-func (b *ClusterBuilder) IdentityProviders(value *IdentityProviderListBuilder) *ClusterBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
-	}
-	b.identityProviders = value
-	b.fieldSet_[37] = true
-	return b
-}
-
-// ImageRegistry sets the value of the 'image_registry' attribute to the given value.
-//
-// ClusterImageRegistry represents the configuration for the cluster's internal image registry.
-func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *ClusterBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
-	}
-	b.imageRegistry = value
 	if value != nil {
 		b.fieldSet_[38] = true
 	} else {
@@ -671,33 +667,59 @@ func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *Clus
 	return b
 }
 
+// IdentityProviders sets the value of the 'identity_providers' attribute to the given values.
+func (b *ClusterBuilder) IdentityProviders(value *IdentityProviderListBuilder) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 68)
+	}
+	b.identityProviders = value
+	b.fieldSet_[39] = true
+	return b
+}
+
+// ImageRegistry sets the value of the 'image_registry' attribute to the given value.
+//
+// ClusterImageRegistry represents the configuration for the cluster's internal image registry.
+func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 68)
+	}
+	b.imageRegistry = value
+	if value != nil {
+		b.fieldSet_[40] = true
+	} else {
+		b.fieldSet_[40] = false
+	}
+	return b
+}
+
 // InflightChecks sets the value of the 'inflight_checks' attribute to the given values.
 func (b *ClusterBuilder) InflightChecks(value *InflightCheckListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.inflightChecks = value
-	b.fieldSet_[39] = true
+	b.fieldSet_[41] = true
 	return b
 }
 
 // InfraID sets the value of the 'infra_ID' attribute to the given value.
 func (b *ClusterBuilder) InfraID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.infraID = value
-	b.fieldSet_[40] = true
+	b.fieldSet_[42] = true
 	return b
 }
 
 // Ingresses sets the value of the 'ingresses' attribute to the given values.
 func (b *ClusterBuilder) Ingresses(value *IngressListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.ingresses = value
-	b.fieldSet_[41] = true
+	b.fieldSet_[43] = true
 	return b
 }
 
@@ -707,13 +729,13 @@ func (b *ClusterBuilder) Ingresses(value *IngressListBuilder) *ClusterBuilder {
 // KubeletConfig that can be managed by users
 func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.kubeletConfig = value
 	if value != nil {
-		b.fieldSet_[42] = true
+		b.fieldSet_[44] = true
 	} else {
-		b.fieldSet_[42] = false
+		b.fieldSet_[44] = false
 	}
 	return b
 }
@@ -721,30 +743,30 @@ func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuil
 // LoadBalancerQuota sets the value of the 'load_balancer_quota' attribute to the given value.
 func (b *ClusterBuilder) LoadBalancerQuota(value int) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.loadBalancerQuota = value
-	b.fieldSet_[43] = true
+	b.fieldSet_[45] = true
 	return b
 }
 
 // MachinePools sets the value of the 'machine_pools' attribute to the given values.
 func (b *ClusterBuilder) MachinePools(value *MachinePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.machinePools = value
-	b.fieldSet_[44] = true
+	b.fieldSet_[46] = true
 	return b
 }
 
 // Managed sets the value of the 'managed' attribute to the given value.
 func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.managed = value
-	b.fieldSet_[45] = true
+	b.fieldSet_[47] = true
 	return b
 }
 
@@ -753,13 +775,13 @@ func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.managedService = value
 	if value != nil {
-		b.fieldSet_[46] = true
+		b.fieldSet_[48] = true
 	} else {
-		b.fieldSet_[46] = false
+		b.fieldSet_[48] = false
 	}
 	return b
 }
@@ -767,30 +789,30 @@ func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBu
 // MultiAZ sets the value of the 'multi_AZ' attribute to the given value.
 func (b *ClusterBuilder) MultiAZ(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.multiAZ = value
-	b.fieldSet_[47] = true
+	b.fieldSet_[49] = true
 	return b
 }
 
 // MultiArchEnabled sets the value of the 'multi_arch_enabled' attribute to the given value.
 func (b *ClusterBuilder) MultiArchEnabled(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.multiArchEnabled = value
-	b.fieldSet_[48] = true
+	b.fieldSet_[50] = true
 	return b
 }
 
 // Name sets the value of the 'name' attribute to the given value.
 func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.name = value
-	b.fieldSet_[49] = true
+	b.fieldSet_[51] = true
 	return b
 }
 
@@ -799,13 +821,13 @@ func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 // Network configuration of a cluster.
 func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.network = value
 	if value != nil {
-		b.fieldSet_[50] = true
+		b.fieldSet_[52] = true
 	} else {
-		b.fieldSet_[50] = false
+		b.fieldSet_[52] = false
 	}
 	return b
 }
@@ -832,35 +854,9 @@ func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.nodeDrainGracePeriod = value
-	if value != nil {
-		b.fieldSet_[51] = true
-	} else {
-		b.fieldSet_[51] = false
-	}
-	return b
-}
-
-// NodePools sets the value of the 'node_pools' attribute to the given values.
-func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
-	}
-	b.nodePools = value
-	b.fieldSet_[52] = true
-	return b
-}
-
-// Nodes sets the value of the 'nodes' attribute to the given value.
-//
-// Counts of different classes of nodes inside a cluster.
-func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
-	}
-	b.nodes = value
 	if value != nil {
 		b.fieldSet_[53] = true
 	} else {
@@ -869,24 +865,24 @@ func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 	return b
 }
 
-// OpenshiftVersion sets the value of the 'openshift_version' attribute to the given value.
-func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
+// NodePools sets the value of the 'node_pools' attribute to the given values.
+func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
-	b.openshiftVersion = value
+	b.nodePools = value
 	b.fieldSet_[54] = true
 	return b
 }
 
-// Product sets the value of the 'product' attribute to the given value.
+// Nodes sets the value of the 'nodes' attribute to the given value.
 //
-// Representation of an product that can be selected as a cluster type.
-func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
+// Counts of different classes of nodes inside a cluster.
+func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
-	b.product = value
+	b.nodes = value
 	if value != nil {
 		b.fieldSet_[55] = true
 	} else {
@@ -895,16 +891,42 @@ func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
 	return b
 }
 
+// OpenshiftVersion sets the value of the 'openshift_version' attribute to the given value.
+func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 68)
+	}
+	b.openshiftVersion = value
+	b.fieldSet_[56] = true
+	return b
+}
+
+// Product sets the value of the 'product' attribute to the given value.
+//
+// Representation of an product that can be selected as a cluster type.
+func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 68)
+	}
+	b.product = value
+	if value != nil {
+		b.fieldSet_[57] = true
+	} else {
+		b.fieldSet_[57] = false
+	}
+	return b
+}
+
 // Properties sets the value of the 'properties' attribute to the given value.
 func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.properties = value
 	if value != nil {
-		b.fieldSet_[56] = true
+		b.fieldSet_[58] = true
 	} else {
-		b.fieldSet_[56] = false
+		b.fieldSet_[58] = false
 	}
 	return b
 }
@@ -914,13 +936,13 @@ func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 // Contains the properties of the provision shard, including AWS and GCP related configurations
 func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.provisionShard = value
 	if value != nil {
-		b.fieldSet_[57] = true
+		b.fieldSet_[59] = true
 	} else {
-		b.fieldSet_[57] = false
+		b.fieldSet_[59] = false
 	}
 	return b
 }
@@ -930,13 +952,13 @@ func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBu
 // Proxy configuration of a cluster.
 func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.proxy = value
 	if value != nil {
-		b.fieldSet_[58] = true
+		b.fieldSet_[60] = true
 	} else {
-		b.fieldSet_[58] = false
+		b.fieldSet_[60] = false
 	}
 	return b
 }
@@ -946,13 +968,13 @@ func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 // Description of a region of a cloud provider.
 func (b *ClusterBuilder) Region(value *CloudRegionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.region = value
 	if value != nil {
-		b.fieldSet_[59] = true
+		b.fieldSet_[61] = true
 	} else {
-		b.fieldSet_[59] = false
+		b.fieldSet_[61] = false
 	}
 	return b
 }
@@ -978,13 +1000,13 @@ func (b *ClusterBuilder) Region(value *CloudRegionBuilder) *ClusterBuilder {
 // ```
 func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.registryConfig = value
 	if value != nil {
-		b.fieldSet_[60] = true
+		b.fieldSet_[62] = true
 	} else {
-		b.fieldSet_[60] = false
+		b.fieldSet_[62] = false
 	}
 	return b
 }
@@ -994,10 +1016,10 @@ func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *Cl
 // Overall state of a cluster.
 func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.state = value
-	b.fieldSet_[61] = true
+	b.fieldSet_[63] = true
 	return b
 }
 
@@ -1006,13 +1028,13 @@ func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 // Detailed status of a cluster.
 func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.status = value
 	if value != nil {
-		b.fieldSet_[62] = true
+		b.fieldSet_[64] = true
 	} else {
-		b.fieldSet_[62] = false
+		b.fieldSet_[64] = false
 	}
 	return b
 }
@@ -1039,13 +1061,13 @@ func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.storageQuota = value
 	if value != nil {
-		b.fieldSet_[63] = true
+		b.fieldSet_[65] = true
 	} else {
-		b.fieldSet_[63] = false
+		b.fieldSet_[65] = false
 	}
 	return b
 }
@@ -1055,13 +1077,13 @@ func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 // Definition of a subscription.
 func (b *ClusterBuilder) Subscription(value *SubscriptionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.subscription = value
 	if value != nil {
-		b.fieldSet_[64] = true
+		b.fieldSet_[66] = true
 	} else {
-		b.fieldSet_[64] = false
+		b.fieldSet_[66] = false
 	}
 	return b
 }
@@ -1071,13 +1093,13 @@ func (b *ClusterBuilder) Subscription(value *SubscriptionBuilder) *ClusterBuilde
 // Representation of an _OpenShift_ version.
 func (b *ClusterBuilder) Version(value *VersionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 66)
+		b.fieldSet_ = make([]bool, 68)
 	}
 	b.version = value
 	if value != nil {
-		b.fieldSet_[65] = true
+		b.fieldSet_[67] = true
 	} else {
-		b.fieldSet_[65] = false
+		b.fieldSet_[67] = false
 	}
 	return b
 }
@@ -1178,6 +1200,8 @@ func (b *ClusterBuilder) Copy(object *Cluster) *ClusterBuilder {
 		b.controlPlane = nil
 	}
 	b.creationTimestamp = object.creationTimestamp
+	b.creatorId = object.creatorId
+	b.creatorUsername = object.creatorUsername
 	if object.deleteProtection != nil {
 		b.deleteProtection = NewDeleteProtection().Copy(object.deleteProtection)
 	} else {
@@ -1448,6 +1472,8 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 		}
 	}
 	object.creationTimestamp = b.creationTimestamp
+	object.creatorId = b.creatorId
+	object.creatorUsername = b.creatorUsername
 	if b.deleteProtection != nil {
 		object.deleteProtection, err = b.deleteProtection.Build()
 		if err != nil {

--- a/clientapi/clustersmgmt/v1/cluster_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_type.go
@@ -100,6 +100,8 @@ type Cluster struct {
 	console                           *ClusterConsole
 	controlPlane                      *ControlPlane
 	creationTimestamp                 time.Time
+	creatorId                         string
+	creatorUsername                   string
 	deleteProtection                  *DeleteProtection
 	domainPrefix                      string
 	expirationTimestamp               time.Time
@@ -137,8 +139,6 @@ type Cluster struct {
 	storageQuota                      *Value
 	subscription                      *Subscription
 	version                           *Version
-	creatorId                         string
-	creatorUsername                   string
 	fips                              bool
 	disableUserWorkloadMonitoring     bool
 	etcdEncryption                    bool
@@ -705,12 +705,62 @@ func (o *Cluster) GetCreationTimestamp() (value time.Time, ok bool) {
 	return
 }
 
+// CreatorId returns the value of the 'creator_id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Identifier of the account that created the cluster, populated from the subscription creator.
+// This is a convenience field to avoid a secondary lookup to the subscription resource.
+func (o *Cluster) CreatorId() string {
+	if o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24] {
+		return o.creatorId
+	}
+	return ""
+}
+
+// GetCreatorId returns the value of the 'creator_id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Identifier of the account that created the cluster, populated from the subscription creator.
+// This is a convenience field to avoid a secondary lookup to the subscription resource.
+func (o *Cluster) GetCreatorId() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24]
+	if ok {
+		value = o.creatorId
+	}
+	return
+}
+
+// CreatorUsername returns the value of the 'creator_username' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Username of the account that created the cluster, populated from the subscription creator.
+// This is a convenience field to avoid a secondary lookup to the subscription resource.
+func (o *Cluster) CreatorUsername() string {
+	if o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25] {
+		return o.creatorUsername
+	}
+	return ""
+}
+
+// GetCreatorUsername returns the value of the 'creator_username' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Username of the account that created the cluster, populated from the subscription creator.
+// This is a convenience field to avoid a secondary lookup to the subscription resource.
+func (o *Cluster) GetCreatorUsername() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25]
+	if ok {
+		value = o.creatorUsername
+	}
+	return
+}
+
 // DeleteProtection returns the value of the 'delete_protection' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Delete protection
 func (o *Cluster) DeleteProtection() *DeleteProtection {
-	if o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24] {
+	if o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26] {
 		return o.deleteProtection
 	}
 	return nil
@@ -721,7 +771,7 @@ func (o *Cluster) DeleteProtection() *DeleteProtection {
 //
 // Delete protection
 func (o *Cluster) GetDeleteProtection() (value *DeleteProtection, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 24 && o.fieldSet_[24]
+	ok = o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26]
 	if ok {
 		value = o.deleteProtection
 	}
@@ -735,7 +785,7 @@ func (o *Cluster) GetDeleteProtection() (value *DeleteProtection, ok bool) {
 // It is enabled by default
 // This field is deprecated for ROSA Hosted Control Plane clusters and will be removed
 func (o *Cluster) DisableUserWorkloadMonitoring() bool {
-	if o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25] {
+	if o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27] {
 		return o.disableUserWorkloadMonitoring
 	}
 	return false
@@ -748,7 +798,7 @@ func (o *Cluster) DisableUserWorkloadMonitoring() bool {
 // It is enabled by default
 // This field is deprecated for ROSA Hosted Control Plane clusters and will be removed
 func (o *Cluster) GetDisableUserWorkloadMonitoring() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 25 && o.fieldSet_[25]
+	ok = o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27]
 	if ok {
 		value = o.disableUserWorkloadMonitoring
 	}
@@ -761,7 +811,7 @@ func (o *Cluster) GetDisableUserWorkloadMonitoring() (value bool, ok bool) {
 // DomainPrefix of the cluster. This prefix is optionally assigned by the user when the
 // cluster is created. It will appear in the Cluster's domain when the cluster is provisioned.
 func (o *Cluster) DomainPrefix() string {
-	if o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26] {
+	if o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28] {
 		return o.domainPrefix
 	}
 	return ""
@@ -773,7 +823,7 @@ func (o *Cluster) DomainPrefix() string {
 // DomainPrefix of the cluster. This prefix is optionally assigned by the user when the
 // cluster is created. It will appear in the Cluster's domain when the cluster is provisioned.
 func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 26 && o.fieldSet_[26]
+	ok = o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28]
 	if ok {
 		value = o.domainPrefix
 	}
@@ -789,7 +839,7 @@ func (o *Cluster) GetDomainPrefix() (value string, ok bool) {
 // defaults true indicates 'encrypted by internal key'.
 // For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) EtcdEncryption() bool {
-	if o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27] {
+	if o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29] {
 		return o.etcdEncryption
 	}
 	return false
@@ -804,7 +854,7 @@ func (o *Cluster) EtcdEncryption() bool {
 // defaults true indicates 'encrypted by internal key'.
 // For ARO-HCP Clusters, this is a readonly attribute, always set to true.
 func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 27 && o.fieldSet_[27]
+	ok = o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29]
 	if ok {
 		value = o.etcdEncryption
 	}
@@ -820,7 +870,7 @@ func (o *Cluster) GetEtcdEncryption() (value bool, ok bool) {
 //
 // This option is unsupported.
 func (o *Cluster) ExpirationTimestamp() time.Time {
-	if o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28] {
+	if o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30] {
 		return o.expirationTimestamp
 	}
 	return time.Time{}
@@ -835,7 +885,7 @@ func (o *Cluster) ExpirationTimestamp() time.Time {
 //
 // This option is unsupported.
 func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 28 && o.fieldSet_[28]
+	ok = o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30]
 	if ok {
 		value = o.expirationTimestamp
 	}
@@ -847,7 +897,7 @@ func (o *Cluster) GetExpirationTimestamp() (value time.Time, ok bool) {
 //
 // External identifier of the cluster, generated by the installer.
 func (o *Cluster) ExternalID() string {
-	if o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29] {
+	if o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31] {
 		return o.externalID
 	}
 	return ""
@@ -858,7 +908,7 @@ func (o *Cluster) ExternalID() string {
 //
 // External identifier of the cluster, generated by the installer.
 func (o *Cluster) GetExternalID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 29 && o.fieldSet_[29]
+	ok = o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31]
 	if ok {
 		value = o.externalID
 	}
@@ -873,7 +923,7 @@ func (o *Cluster) GetExternalID() (value string, ok bool) {
 // For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
 // For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
-	if o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30] {
+	if o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32] {
 		return o.externalAuthConfig
 	}
 	return nil
@@ -887,7 +937,7 @@ func (o *Cluster) ExternalAuthConfig() *ExternalAuthConfig {
 // For ROSA HCP, if this is not specified, external authentication configuration will be disabled by default
 // For ARO HCP, if this is not specified, external authentication configuration will be enabled by default
 func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 30 && o.fieldSet_[30]
+	ok = o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32]
 	if ok {
 		value = o.externalAuthConfig
 	}
@@ -899,7 +949,7 @@ func (o *Cluster) GetExternalAuthConfig() (value *ExternalAuthConfig, ok bool) {
 //
 // ExternalConfiguration shows external configuration on the cluster.
 func (o *Cluster) ExternalConfiguration() *ExternalConfiguration {
-	if o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31] {
+	if o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33] {
 		return o.externalConfiguration
 	}
 	return nil
@@ -910,7 +960,7 @@ func (o *Cluster) ExternalConfiguration() *ExternalConfiguration {
 //
 // ExternalConfiguration shows external configuration on the cluster.
 func (o *Cluster) GetExternalConfiguration() (value *ExternalConfiguration, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 31 && o.fieldSet_[31]
+	ok = o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33]
 	if ok {
 		value = o.externalConfiguration
 	}
@@ -922,7 +972,7 @@ func (o *Cluster) GetExternalConfiguration() (value *ExternalConfiguration, ok b
 //
 // Link to the _flavour_ that was used to create the cluster.
 func (o *Cluster) Flavour() *Flavour {
-	if o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32] {
+	if o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34] {
 		return o.flavour
 	}
 	return nil
@@ -933,7 +983,7 @@ func (o *Cluster) Flavour() *Flavour {
 //
 // Link to the _flavour_ that was used to create the cluster.
 func (o *Cluster) GetFlavour() (value *Flavour, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 32 && o.fieldSet_[32]
+	ok = o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34]
 	if ok {
 		value = o.flavour
 	}
@@ -945,7 +995,7 @@ func (o *Cluster) GetFlavour() (value *Flavour, ok bool) {
 //
 // Link to the collection of groups of user of the cluster.
 func (o *Cluster) Groups() *GroupList {
-	if o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33] {
+	if o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35] {
 		return o.groups
 	}
 	return nil
@@ -956,7 +1006,7 @@ func (o *Cluster) Groups() *GroupList {
 //
 // Link to the collection of groups of user of the cluster.
 func (o *Cluster) GetGroups() (value *GroupList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 33 && o.fieldSet_[33]
+	ok = o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35]
 	if ok {
 		value = o.groups
 	}
@@ -968,7 +1018,7 @@ func (o *Cluster) GetGroups() (value *GroupList, ok bool) {
 //
 // HealthState indicates the overall health state of the cluster.
 func (o *Cluster) HealthState() ClusterHealthState {
-	if o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34] {
+	if o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36] {
 		return o.healthState
 	}
 	return ClusterHealthState("")
@@ -979,7 +1029,7 @@ func (o *Cluster) HealthState() ClusterHealthState {
 //
 // HealthState indicates the overall health state of the cluster.
 func (o *Cluster) GetHealthState() (value ClusterHealthState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 34 && o.fieldSet_[34]
+	ok = o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36]
 	if ok {
 		value = o.healthState
 	}
@@ -991,7 +1041,7 @@ func (o *Cluster) GetHealthState() (value ClusterHealthState, ok bool) {
 //
 // Details for `htpasswd` identity provider.
 func (o *Cluster) Htpasswd() *HTPasswdIdentityProvider {
-	if o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35] {
+	if o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37] {
 		return o.htpasswd
 	}
 	return nil
@@ -1002,7 +1052,7 @@ func (o *Cluster) Htpasswd() *HTPasswdIdentityProvider {
 //
 // Details for `htpasswd` identity provider.
 func (o *Cluster) GetHtpasswd() (value *HTPasswdIdentityProvider, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 35 && o.fieldSet_[35]
+	ok = o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37]
 	if ok {
 		value = o.htpasswd
 	}
@@ -1014,7 +1064,7 @@ func (o *Cluster) GetHtpasswd() (value *HTPasswdIdentityProvider, ok bool) {
 //
 // Hypershift configuration.
 func (o *Cluster) Hypershift() *Hypershift {
-	if o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36] {
+	if o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38] {
 		return o.hypershift
 	}
 	return nil
@@ -1025,7 +1075,7 @@ func (o *Cluster) Hypershift() *Hypershift {
 //
 // Hypershift configuration.
 func (o *Cluster) GetHypershift() (value *Hypershift, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 36 && o.fieldSet_[36]
+	ok = o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38]
 	if ok {
 		value = o.hypershift
 	}
@@ -1037,7 +1087,7 @@ func (o *Cluster) GetHypershift() (value *Hypershift, ok bool) {
 //
 // Link to the collection of identity providers of the cluster.
 func (o *Cluster) IdentityProviders() *IdentityProviderList {
-	if o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37] {
+	if o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39] {
 		return o.identityProviders
 	}
 	return nil
@@ -1048,7 +1098,7 @@ func (o *Cluster) IdentityProviders() *IdentityProviderList {
 //
 // Link to the collection of identity providers of the cluster.
 func (o *Cluster) GetIdentityProviders() (value *IdentityProviderList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 37 && o.fieldSet_[37]
+	ok = o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39]
 	if ok {
 		value = o.identityProviders
 	}
@@ -1062,7 +1112,7 @@ func (o *Cluster) GetIdentityProviders() (value *IdentityProviderList, ok bool) 
 // It provides an internal, integrated container image registry to locally manage images.
 // For non ARO-HCP clusters, it is readonly and always enabled
 func (o *Cluster) ImageRegistry() *ClusterImageRegistry {
-	if o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38] {
+	if o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40] {
 		return o.imageRegistry
 	}
 	return nil
@@ -1075,7 +1125,7 @@ func (o *Cluster) ImageRegistry() *ClusterImageRegistry {
 // It provides an internal, integrated container image registry to locally manage images.
 // For non ARO-HCP clusters, it is readonly and always enabled
 func (o *Cluster) GetImageRegistry() (value *ClusterImageRegistry, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 38 && o.fieldSet_[38]
+	ok = o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40]
 	if ok {
 		value = o.imageRegistry
 	}
@@ -1087,7 +1137,7 @@ func (o *Cluster) GetImageRegistry() (value *ClusterImageRegistry, ok bool) {
 //
 // List of inflight checks on this cluster.
 func (o *Cluster) InflightChecks() *InflightCheckList {
-	if o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39] {
+	if o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41] {
 		return o.inflightChecks
 	}
 	return nil
@@ -1098,7 +1148,7 @@ func (o *Cluster) InflightChecks() *InflightCheckList {
 //
 // List of inflight checks on this cluster.
 func (o *Cluster) GetInflightChecks() (value *InflightCheckList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 39 && o.fieldSet_[39]
+	ok = o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41]
 	if ok {
 		value = o.inflightChecks
 	}
@@ -1110,7 +1160,7 @@ func (o *Cluster) GetInflightChecks() (value *InflightCheckList, ok bool) {
 //
 // InfraID is used for example to name the VPCs.
 func (o *Cluster) InfraID() string {
-	if o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40] {
+	if o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42] {
 		return o.infraID
 	}
 	return ""
@@ -1121,7 +1171,7 @@ func (o *Cluster) InfraID() string {
 //
 // InfraID is used for example to name the VPCs.
 func (o *Cluster) GetInfraID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 40 && o.fieldSet_[40]
+	ok = o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42]
 	if ok {
 		value = o.infraID
 	}
@@ -1133,7 +1183,7 @@ func (o *Cluster) GetInfraID() (value string, ok bool) {
 //
 // List of ingresses on this cluster.
 func (o *Cluster) Ingresses() *IngressList {
-	if o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41] {
+	if o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43] {
 		return o.ingresses
 	}
 	return nil
@@ -1144,7 +1194,7 @@ func (o *Cluster) Ingresses() *IngressList {
 //
 // List of ingresses on this cluster.
 func (o *Cluster) GetIngresses() (value *IngressList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 41 && o.fieldSet_[41]
+	ok = o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43]
 	if ok {
 		value = o.ingresses
 	}
@@ -1156,7 +1206,7 @@ func (o *Cluster) GetIngresses() (value *IngressList, ok bool) {
 //
 // Details of cluster-wide KubeletConfig
 func (o *Cluster) KubeletConfig() *KubeletConfig {
-	if o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42] {
+	if o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44] {
 		return o.kubeletConfig
 	}
 	return nil
@@ -1167,7 +1217,7 @@ func (o *Cluster) KubeletConfig() *KubeletConfig {
 //
 // Details of cluster-wide KubeletConfig
 func (o *Cluster) GetKubeletConfig() (value *KubeletConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 42 && o.fieldSet_[42]
+	ok = o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44]
 	if ok {
 		value = o.kubeletConfig
 	}
@@ -1179,7 +1229,7 @@ func (o *Cluster) GetKubeletConfig() (value *KubeletConfig, ok bool) {
 //
 // Load Balancer quota to be assigned to the cluster.
 func (o *Cluster) LoadBalancerQuota() int {
-	if o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43] {
+	if o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45] {
 		return o.loadBalancerQuota
 	}
 	return 0
@@ -1190,7 +1240,7 @@ func (o *Cluster) LoadBalancerQuota() int {
 //
 // Load Balancer quota to be assigned to the cluster.
 func (o *Cluster) GetLoadBalancerQuota() (value int, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 43 && o.fieldSet_[43]
+	ok = o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45]
 	if ok {
 		value = o.loadBalancerQuota
 	}
@@ -1202,7 +1252,7 @@ func (o *Cluster) GetLoadBalancerQuota() (value int, ok bool) {
 //
 // List of machine pools on this cluster.
 func (o *Cluster) MachinePools() *MachinePoolList {
-	if o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44] {
+	if o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46] {
 		return o.machinePools
 	}
 	return nil
@@ -1213,7 +1263,7 @@ func (o *Cluster) MachinePools() *MachinePoolList {
 //
 // List of machine pools on this cluster.
 func (o *Cluster) GetMachinePools() (value *MachinePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 44 && o.fieldSet_[44]
+	ok = o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46]
 	if ok {
 		value = o.machinePools
 	}
@@ -1226,7 +1276,7 @@ func (o *Cluster) GetMachinePools() (value *MachinePoolList, ok bool) {
 // Flag indicating if the cluster is managed (by Red Hat) or
 // self-managed by the user.
 func (o *Cluster) Managed() bool {
-	if o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45] {
+	if o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47] {
 		return o.managed
 	}
 	return false
@@ -1238,7 +1288,7 @@ func (o *Cluster) Managed() bool {
 // Flag indicating if the cluster is managed (by Red Hat) or
 // self-managed by the user.
 func (o *Cluster) GetManaged() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 45 && o.fieldSet_[45]
+	ok = o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47]
 	if ok {
 		value = o.managed
 	}
@@ -1250,7 +1300,7 @@ func (o *Cluster) GetManaged() (value bool, ok bool) {
 //
 // Contains information about Managed Service
 func (o *Cluster) ManagedService() *ManagedService {
-	if o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46] {
+	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
 		return o.managedService
 	}
 	return nil
@@ -1261,7 +1311,7 @@ func (o *Cluster) ManagedService() *ManagedService {
 //
 // Contains information about Managed Service
 func (o *Cluster) GetManagedService() (value *ManagedService, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 46 && o.fieldSet_[46]
+	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
 	if ok {
 		value = o.managedService
 	}
@@ -1278,7 +1328,7 @@ func (o *Cluster) GetManagedService() (value *ManagedService, ok bool) {
 // is deployed in multiple availability zones when the Azure region where
 // it is deployed supports multiple availability zones.
 func (o *Cluster) MultiAZ() bool {
-	if o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47] {
+	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
 		return o.multiAZ
 	}
 	return false
@@ -1294,7 +1344,7 @@ func (o *Cluster) MultiAZ() bool {
 // is deployed in multiple availability zones when the Azure region where
 // it is deployed supports multiple availability zones.
 func (o *Cluster) GetMultiAZ() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 47 && o.fieldSet_[47]
+	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
 	if ok {
 		value = o.multiAZ
 	}
@@ -1306,7 +1356,7 @@ func (o *Cluster) GetMultiAZ() (value bool, ok bool) {
 //
 // Indicate whether the cluster is enabled for multi arch workers
 func (o *Cluster) MultiArchEnabled() bool {
-	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
+	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
 		return o.multiArchEnabled
 	}
 	return false
@@ -1317,7 +1367,7 @@ func (o *Cluster) MultiArchEnabled() bool {
 //
 // Indicate whether the cluster is enabled for multi arch workers
 func (o *Cluster) GetMultiArchEnabled() (value bool, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
+	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
 	if ok {
 		value = o.multiArchEnabled
 	}
@@ -1330,7 +1380,7 @@ func (o *Cluster) GetMultiArchEnabled() (value bool, ok bool) {
 // Name of the cluster. This name is assigned by the user when the
 // cluster is created. This is used to uniquely identify the cluster
 func (o *Cluster) Name() string {
-	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
+	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
 		return o.name
 	}
 	return ""
@@ -1342,7 +1392,7 @@ func (o *Cluster) Name() string {
 // Name of the cluster. This name is assigned by the user when the
 // cluster is created. This is used to uniquely identify the cluster
 func (o *Cluster) GetName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
+	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
 	if ok {
 		value = o.name
 	}
@@ -1354,7 +1404,7 @@ func (o *Cluster) GetName() (value string, ok bool) {
 //
 // Network settings of the cluster.
 func (o *Cluster) Network() *Network {
-	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
+	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
 		return o.network
 	}
 	return nil
@@ -1365,7 +1415,7 @@ func (o *Cluster) Network() *Network {
 //
 // Network settings of the cluster.
 func (o *Cluster) GetNetwork() (value *Network, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
+	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
 	if ok {
 		value = o.network
 	}
@@ -1377,7 +1427,7 @@ func (o *Cluster) GetNetwork() (value *Network, ok bool) {
 //
 // Node drain grace period.
 func (o *Cluster) NodeDrainGracePeriod() *Value {
-	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
+	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
 		return o.nodeDrainGracePeriod
 	}
 	return nil
@@ -1388,7 +1438,7 @@ func (o *Cluster) NodeDrainGracePeriod() *Value {
 //
 // Node drain grace period.
 func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
+	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
 	if ok {
 		value = o.nodeDrainGracePeriod
 	}
@@ -1401,7 +1451,7 @@ func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) NodePools() *NodePoolList {
-	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
+	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
 		return o.nodePools
 	}
 	return nil
@@ -1413,7 +1463,7 @@ func (o *Cluster) NodePools() *NodePoolList {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
+	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
 	if ok {
 		value = o.nodePools
 	}
@@ -1425,7 +1475,7 @@ func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) Nodes() *ClusterNodes {
-	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
+	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
 		return o.nodes
 	}
 	return nil
@@ -1436,7 +1486,7 @@ func (o *Cluster) Nodes() *ClusterNodes {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
+	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
 	if ok {
 		value = o.nodes
 	}
@@ -1453,7 +1503,7 @@ func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) OpenshiftVersion() string {
-	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
+	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
 		return o.openshiftVersion
 	}
 	return ""
@@ -1469,7 +1519,7 @@ func (o *Cluster) OpenshiftVersion() string {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
+	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
 	if ok {
 		value = o.openshiftVersion
 	}
@@ -1481,7 +1531,7 @@ func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) Product() *Product {
-	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
+	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
 		return o.product
 	}
 	return nil
@@ -1492,7 +1542,7 @@ func (o *Cluster) Product() *Product {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) GetProduct() (value *Product, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
+	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
 	if ok {
 		value = o.product
 	}
@@ -1504,7 +1554,7 @@ func (o *Cluster) GetProduct() (value *Product, ok bool) {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) Properties() map[string]string {
-	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
+	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
 		return o.properties
 	}
 	return nil
@@ -1515,7 +1565,7 @@ func (o *Cluster) Properties() map[string]string {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
+	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
 	if ok {
 		value = o.properties
 	}
@@ -1527,7 +1577,7 @@ func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) ProvisionShard() *ProvisionShard {
-	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
+	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
 		return o.provisionShard
 	}
 	return nil
@@ -1538,7 +1588,7 @@ func (o *Cluster) ProvisionShard() *ProvisionShard {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
+	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
 	if ok {
 		value = o.provisionShard
 	}
@@ -1550,7 +1600,7 @@ func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
 //
 // Proxy.
 func (o *Cluster) Proxy() *Proxy {
-	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
+	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
 		return o.proxy
 	}
 	return nil
@@ -1561,7 +1611,7 @@ func (o *Cluster) Proxy() *Proxy {
 //
 // Proxy.
 func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
+	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
 	if ok {
 		value = o.proxy
 	}
@@ -1573,7 +1623,7 @@ func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) Region() *CloudRegion {
-	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
+	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
 		return o.region
 	}
 	return nil
@@ -1584,7 +1634,7 @@ func (o *Cluster) Region() *CloudRegion {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) GetRegion() (value *CloudRegion, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
+	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
 	if ok {
 		value = o.region
 	}
@@ -1596,7 +1646,7 @@ func (o *Cluster) GetRegion() (value *CloudRegion, ok bool) {
 //
 // External registry configuration for the cluster
 func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
-	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
+	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
 		return o.registryConfig
 	}
 	return nil
@@ -1607,7 +1657,7 @@ func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
 //
 // External registry configuration for the cluster
 func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
+	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
 	if ok {
 		value = o.registryConfig
 	}
@@ -1619,7 +1669,7 @@ func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
 //
 // Overall state of the cluster.
 func (o *Cluster) State() ClusterState {
-	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
+	if o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63] {
 		return o.state
 	}
 	return ClusterState("")
@@ -1630,7 +1680,7 @@ func (o *Cluster) State() ClusterState {
 //
 // Overall state of the cluster.
 func (o *Cluster) GetState() (value ClusterState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
+	ok = o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63]
 	if ok {
 		value = o.state
 	}
@@ -1642,7 +1692,7 @@ func (o *Cluster) GetState() (value ClusterState, ok bool) {
 //
 // Status of cluster
 func (o *Cluster) Status() *ClusterStatus {
-	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
+	if o != nil && len(o.fieldSet_) > 64 && o.fieldSet_[64] {
 		return o.status
 	}
 	return nil
@@ -1653,7 +1703,7 @@ func (o *Cluster) Status() *ClusterStatus {
 //
 // Status of cluster
 func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
+	ok = o != nil && len(o.fieldSet_) > 64 && o.fieldSet_[64]
 	if ok {
 		value = o.status
 	}
@@ -1665,7 +1715,7 @@ func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) StorageQuota() *Value {
-	if o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63] {
+	if o != nil && len(o.fieldSet_) > 65 && o.fieldSet_[65] {
 		return o.storageQuota
 	}
 	return nil
@@ -1676,7 +1726,7 @@ func (o *Cluster) StorageQuota() *Value {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63]
+	ok = o != nil && len(o.fieldSet_) > 65 && o.fieldSet_[65]
 	if ok {
 		value = o.storageQuota
 	}
@@ -1689,7 +1739,7 @@ func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) Subscription() *Subscription {
-	if o != nil && len(o.fieldSet_) > 64 && o.fieldSet_[64] {
+	if o != nil && len(o.fieldSet_) > 66 && o.fieldSet_[66] {
 		return o.subscription
 	}
 	return nil
@@ -1701,7 +1751,7 @@ func (o *Cluster) Subscription() *Subscription {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) GetSubscription() (value *Subscription, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 64 && o.fieldSet_[64]
+	ok = o != nil && len(o.fieldSet_) > 66 && o.fieldSet_[66]
 	if ok {
 		value = o.subscription
 	}
@@ -1713,7 +1763,7 @@ func (o *Cluster) GetSubscription() (value *Subscription, ok bool) {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) Version() *Version {
-	if o != nil && len(o.fieldSet_) > 65 && o.fieldSet_[65] {
+	if o != nil && len(o.fieldSet_) > 67 && o.fieldSet_[67] {
 		return o.version
 	}
 	return nil
@@ -1724,55 +1774,9 @@ func (o *Cluster) Version() *Version {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) GetVersion() (value *Version, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 65 && o.fieldSet_[65]
-	if ok {
-		value = o.version
-	}
-	return
-}
-
-// CreatorId returns the value of the 'creator_id' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Identifier of the account that created the cluster, populated from the subscription creator.
-func (o *Cluster) CreatorId() string {
-	if o != nil && len(o.fieldSet_) > 66 && o.fieldSet_[66] {
-		return o.creatorId
-	}
-	return ""
-}
-
-// GetCreatorId returns the value of the 'creator_id' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Identifier of the account that created the cluster, populated from the subscription creator.
-func (o *Cluster) GetCreatorId() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 66 && o.fieldSet_[66]
-	if ok {
-		value = o.creatorId
-	}
-	return
-}
-
-// CreatorUsername returns the value of the 'creator_username' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// Username of the account that created the cluster, populated from the subscription creator.
-func (o *Cluster) CreatorUsername() string {
-	if o != nil && len(o.fieldSet_) > 67 && o.fieldSet_[67] {
-		return o.creatorUsername
-	}
-	return ""
-}
-
-// GetCreatorUsername returns the value of the 'creator_username' attribute and
-// a flag indicating if the attribute has a value.
-//
-// Username of the account that created the cluster, populated from the subscription creator.
-func (o *Cluster) GetCreatorUsername() (value string, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 67 && o.fieldSet_[67]
 	if ok {
-		value = o.creatorUsername
+		value = o.version
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/cluster_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_type.go
@@ -137,6 +137,8 @@ type Cluster struct {
 	storageQuota                      *Value
 	subscription                      *Subscription
 	version                           *Version
+	creatorId                         string
+	creatorUsername                   string
 	fips                              bool
 	disableUserWorkloadMonitoring     bool
 	etcdEncryption                    bool
@@ -1725,6 +1727,52 @@ func (o *Cluster) GetVersion() (value *Version, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 65 && o.fieldSet_[65]
 	if ok {
 		value = o.version
+	}
+	return
+}
+
+// CreatorId returns the value of the 'creator_id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Identifier of the account that created the cluster, populated from the subscription creator.
+func (o *Cluster) CreatorId() string {
+	if o != nil && len(o.fieldSet_) > 66 && o.fieldSet_[66] {
+		return o.creatorId
+	}
+	return ""
+}
+
+// GetCreatorId returns the value of the 'creator_id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Identifier of the account that created the cluster, populated from the subscription creator.
+func (o *Cluster) GetCreatorId() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 66 && o.fieldSet_[66]
+	if ok {
+		value = o.creatorId
+	}
+	return
+}
+
+// CreatorUsername returns the value of the 'creator_username' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Username of the account that created the cluster, populated from the subscription creator.
+func (o *Cluster) CreatorUsername() string {
+	if o != nil && len(o.fieldSet_) > 67 && o.fieldSet_[67] {
+		return o.creatorUsername
+	}
+	return ""
+}
+
+// GetCreatorUsername returns the value of the 'creator_username' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Username of the account that created the cluster, populated from the subscription creator.
+func (o *Cluster) GetCreatorUsername() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 67 && o.fieldSet_[67]
+	if ok {
+		value = o.creatorUsername
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/cluster_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_type_json.go
@@ -676,6 +676,24 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		}
 		stream.WriteObjectField("version")
 		WriteVersion(object.version, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 66 && object.fieldSet_[66]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("creator_id")
+		stream.WriteString(object.creatorId)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 67 && object.fieldSet_[67]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("creator_username")
+		stream.WriteString(object.creatorUsername)
 	}
 	stream.WriteObjectEnd()
 }
@@ -695,7 +713,7 @@ func UnmarshalCluster(source interface{}) (object *Cluster, err error) {
 // ReadCluster reads a value of the 'cluster' type from the given iterator.
 func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 	object := &Cluster{
-		fieldSet_: make([]bool, 66),
+		fieldSet_: make([]bool, 68),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -1121,6 +1139,14 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 			value := ReadVersion(iterator)
 			object.version = value
 			object.fieldSet_[65] = true
+		case "creator_id":
+			value := iterator.ReadString()
+			object.creatorId = value
+			object.fieldSet_[66] = true
+		case "creator_username":
+			value := iterator.ReadString()
+			object.creatorUsername = value
+			object.fieldSet_[67] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/cluster_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_type_json.go
@@ -262,7 +262,25 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString((object.creationTimestamp).Format(time.RFC3339))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 24 && object.fieldSet_[24] && object.deleteProtection != nil
+	present_ = len(object.fieldSet_) > 24 && object.fieldSet_[24]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("creator_id")
+		stream.WriteString(object.creatorId)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 25 && object.fieldSet_[25]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("creator_username")
+		stream.WriteString(object.creatorUsername)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 26 && object.fieldSet_[26] && object.deleteProtection != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -271,7 +289,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteDeleteProtection(object.deleteProtection, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 25 && object.fieldSet_[25]
+	present_ = len(object.fieldSet_) > 27 && object.fieldSet_[27]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -280,7 +298,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.disableUserWorkloadMonitoring)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 26 && object.fieldSet_[26]
+	present_ = len(object.fieldSet_) > 28 && object.fieldSet_[28]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -289,7 +307,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.domainPrefix)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 27 && object.fieldSet_[27]
+	present_ = len(object.fieldSet_) > 29 && object.fieldSet_[29]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -298,7 +316,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.etcdEncryption)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 28 && object.fieldSet_[28]
+	present_ = len(object.fieldSet_) > 30 && object.fieldSet_[30]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -307,7 +325,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString((object.expirationTimestamp).Format(time.RFC3339))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 29 && object.fieldSet_[29]
+	present_ = len(object.fieldSet_) > 31 && object.fieldSet_[31]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -316,7 +334,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.externalID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 30 && object.fieldSet_[30] && object.externalAuthConfig != nil
+	present_ = len(object.fieldSet_) > 32 && object.fieldSet_[32] && object.externalAuthConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -325,7 +343,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteExternalAuthConfig(object.externalAuthConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 31 && object.fieldSet_[31] && object.externalConfiguration != nil
+	present_ = len(object.fieldSet_) > 33 && object.fieldSet_[33] && object.externalConfiguration != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -334,7 +352,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteExternalConfiguration(object.externalConfiguration, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 32 && object.fieldSet_[32] && object.flavour != nil
+	present_ = len(object.fieldSet_) > 34 && object.fieldSet_[34] && object.flavour != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -343,7 +361,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteFlavour(object.flavour, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 33 && object.fieldSet_[33] && object.groups != nil
+	present_ = len(object.fieldSet_) > 35 && object.fieldSet_[35] && object.groups != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -355,7 +373,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 34 && object.fieldSet_[34]
+	present_ = len(object.fieldSet_) > 36 && object.fieldSet_[36]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -364,7 +382,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.healthState))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 35 && object.fieldSet_[35] && object.htpasswd != nil
+	present_ = len(object.fieldSet_) > 37 && object.fieldSet_[37] && object.htpasswd != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -373,7 +391,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteHTPasswdIdentityProvider(object.htpasswd, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 36 && object.fieldSet_[36] && object.hypershift != nil
+	present_ = len(object.fieldSet_) > 38 && object.fieldSet_[38] && object.hypershift != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -382,7 +400,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteHypershift(object.hypershift, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 37 && object.fieldSet_[37] && object.identityProviders != nil
+	present_ = len(object.fieldSet_) > 39 && object.fieldSet_[39] && object.identityProviders != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -394,7 +412,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 38 && object.fieldSet_[38] && object.imageRegistry != nil
+	present_ = len(object.fieldSet_) > 40 && object.fieldSet_[40] && object.imageRegistry != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -403,7 +421,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterImageRegistry(object.imageRegistry, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 39 && object.fieldSet_[39] && object.inflightChecks != nil
+	present_ = len(object.fieldSet_) > 41 && object.fieldSet_[41] && object.inflightChecks != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -415,7 +433,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 40 && object.fieldSet_[40]
+	present_ = len(object.fieldSet_) > 42 && object.fieldSet_[42]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -424,7 +442,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.infraID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 41 && object.fieldSet_[41] && object.ingresses != nil
+	present_ = len(object.fieldSet_) > 43 && object.fieldSet_[43] && object.ingresses != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -436,7 +454,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 42 && object.fieldSet_[42] && object.kubeletConfig != nil
+	present_ = len(object.fieldSet_) > 44 && object.fieldSet_[44] && object.kubeletConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -445,7 +463,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteKubeletConfig(object.kubeletConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 43 && object.fieldSet_[43]
+	present_ = len(object.fieldSet_) > 45 && object.fieldSet_[45]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -454,7 +472,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteInt(object.loadBalancerQuota)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 44 && object.fieldSet_[44] && object.machinePools != nil
+	present_ = len(object.fieldSet_) > 46 && object.fieldSet_[46] && object.machinePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -466,7 +484,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 45 && object.fieldSet_[45]
+	present_ = len(object.fieldSet_) > 47 && object.fieldSet_[47]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -475,7 +493,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.managed)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 46 && object.fieldSet_[46] && object.managedService != nil
+	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48] && object.managedService != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -484,7 +502,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteManagedService(object.managedService, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 47 && object.fieldSet_[47]
+	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -493,7 +511,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.multiAZ)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48]
+	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -502,7 +520,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteBool(object.multiArchEnabled)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49]
+	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -511,7 +529,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.name)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.network != nil
+	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52] && object.network != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -520,7 +538,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteNetwork(object.network, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51] && object.nodeDrainGracePeriod != nil
+	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.nodeDrainGracePeriod != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -529,7 +547,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.nodeDrainGracePeriod, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52] && object.nodePools != nil
+	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.nodePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -541,7 +559,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.nodes != nil
+	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.nodes != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -550,7 +568,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterNodes(object.nodes, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54]
+	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -559,7 +577,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.openshiftVersion)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.product != nil
+	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.product != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -568,7 +586,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProduct(object.product, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.properties != nil
+	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58] && object.properties != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -597,7 +615,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.provisionShard != nil
+	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59] && object.provisionShard != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -606,7 +624,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProvisionShard(object.provisionShard, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58] && object.proxy != nil
+	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.proxy != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -615,7 +633,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProxy(object.proxy, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59] && object.region != nil
+	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.region != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -624,7 +642,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteCloudRegion(object.region, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.registryConfig != nil
+	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.registryConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -633,7 +651,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterRegistryConfig(object.registryConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61]
+	present_ = len(object.fieldSet_) > 63 && object.fieldSet_[63]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -642,7 +660,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.state))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.status != nil
+	present_ = len(object.fieldSet_) > 64 && object.fieldSet_[64] && object.status != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -651,7 +669,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterStatus(object.status, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 63 && object.fieldSet_[63] && object.storageQuota != nil
+	present_ = len(object.fieldSet_) > 65 && object.fieldSet_[65] && object.storageQuota != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -660,7 +678,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.storageQuota, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 64 && object.fieldSet_[64] && object.subscription != nil
+	present_ = len(object.fieldSet_) > 66 && object.fieldSet_[66] && object.subscription != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -669,31 +687,13 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteSubscription(object.subscription, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 65 && object.fieldSet_[65] && object.version != nil
+	present_ = len(object.fieldSet_) > 67 && object.fieldSet_[67] && object.version != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
 		}
 		stream.WriteObjectField("version")
 		WriteVersion(object.version, stream)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 66 && object.fieldSet_[66]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("creator_id")
-		stream.WriteString(object.creatorId)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 67 && object.fieldSet_[67]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("creator_username")
-		stream.WriteString(object.creatorUsername)
 	}
 	stream.WriteObjectEnd()
 }
@@ -855,22 +855,30 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 			}
 			object.creationTimestamp = value
 			object.fieldSet_[23] = true
+		case "creator_id":
+			value := iterator.ReadString()
+			object.creatorId = value
+			object.fieldSet_[24] = true
+		case "creator_username":
+			value := iterator.ReadString()
+			object.creatorUsername = value
+			object.fieldSet_[25] = true
 		case "delete_protection":
 			value := ReadDeleteProtection(iterator)
 			object.deleteProtection = value
-			object.fieldSet_[24] = true
+			object.fieldSet_[26] = true
 		case "disable_user_workload_monitoring":
 			value := iterator.ReadBool()
 			object.disableUserWorkloadMonitoring = value
-			object.fieldSet_[25] = true
+			object.fieldSet_[27] = true
 		case "domain_prefix":
 			value := iterator.ReadString()
 			object.domainPrefix = value
-			object.fieldSet_[26] = true
+			object.fieldSet_[28] = true
 		case "etcd_encryption":
 			value := iterator.ReadBool()
 			object.etcdEncryption = value
-			object.fieldSet_[27] = true
+			object.fieldSet_[29] = true
 		case "expiration_timestamp":
 			text := iterator.ReadString()
 			value, err := time.Parse(time.RFC3339, text)
@@ -878,23 +886,23 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				iterator.ReportError("", err.Error())
 			}
 			object.expirationTimestamp = value
-			object.fieldSet_[28] = true
+			object.fieldSet_[30] = true
 		case "external_id":
 			value := iterator.ReadString()
 			object.externalID = value
-			object.fieldSet_[29] = true
+			object.fieldSet_[31] = true
 		case "external_auth_config":
 			value := ReadExternalAuthConfig(iterator)
 			object.externalAuthConfig = value
-			object.fieldSet_[30] = true
+			object.fieldSet_[32] = true
 		case "external_configuration":
 			value := ReadExternalConfiguration(iterator)
 			object.externalConfiguration = value
-			object.fieldSet_[31] = true
+			object.fieldSet_[33] = true
 		case "flavour":
 			value := ReadFlavour(iterator)
 			object.flavour = value
-			object.fieldSet_[32] = true
+			object.fieldSet_[34] = true
 		case "groups":
 			value := &GroupList{}
 			for {
@@ -915,20 +923,20 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.groups = value
-			object.fieldSet_[33] = true
+			object.fieldSet_[35] = true
 		case "health_state":
 			text := iterator.ReadString()
 			value := ClusterHealthState(text)
 			object.healthState = value
-			object.fieldSet_[34] = true
+			object.fieldSet_[36] = true
 		case "htpasswd":
 			value := ReadHTPasswdIdentityProvider(iterator)
 			object.htpasswd = value
-			object.fieldSet_[35] = true
+			object.fieldSet_[37] = true
 		case "hypershift":
 			value := ReadHypershift(iterator)
 			object.hypershift = value
-			object.fieldSet_[36] = true
+			object.fieldSet_[38] = true
 		case "identity_providers":
 			value := &IdentityProviderList{}
 			for {
@@ -949,11 +957,11 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.identityProviders = value
-			object.fieldSet_[37] = true
+			object.fieldSet_[39] = true
 		case "image_registry":
 			value := ReadClusterImageRegistry(iterator)
 			object.imageRegistry = value
-			object.fieldSet_[38] = true
+			object.fieldSet_[40] = true
 		case "inflight_checks":
 			value := &InflightCheckList{}
 			for {
@@ -974,11 +982,11 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.inflightChecks = value
-			object.fieldSet_[39] = true
+			object.fieldSet_[41] = true
 		case "infra_id":
 			value := iterator.ReadString()
 			object.infraID = value
-			object.fieldSet_[40] = true
+			object.fieldSet_[42] = true
 		case "ingresses":
 			value := &IngressList{}
 			for {
@@ -999,15 +1007,15 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.ingresses = value
-			object.fieldSet_[41] = true
+			object.fieldSet_[43] = true
 		case "kubelet_config":
 			value := ReadKubeletConfig(iterator)
 			object.kubeletConfig = value
-			object.fieldSet_[42] = true
+			object.fieldSet_[44] = true
 		case "load_balancer_quota":
 			value := iterator.ReadInt()
 			object.loadBalancerQuota = value
-			object.fieldSet_[43] = true
+			object.fieldSet_[45] = true
 		case "machine_pools":
 			value := &MachinePoolList{}
 			for {
@@ -1028,35 +1036,35 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.machinePools = value
-			object.fieldSet_[44] = true
+			object.fieldSet_[46] = true
 		case "managed":
 			value := iterator.ReadBool()
 			object.managed = value
-			object.fieldSet_[45] = true
+			object.fieldSet_[47] = true
 		case "managed_service":
 			value := ReadManagedService(iterator)
 			object.managedService = value
-			object.fieldSet_[46] = true
+			object.fieldSet_[48] = true
 		case "multi_az":
 			value := iterator.ReadBool()
 			object.multiAZ = value
-			object.fieldSet_[47] = true
+			object.fieldSet_[49] = true
 		case "multi_arch_enabled":
 			value := iterator.ReadBool()
 			object.multiArchEnabled = value
-			object.fieldSet_[48] = true
+			object.fieldSet_[50] = true
 		case "name":
 			value := iterator.ReadString()
 			object.name = value
-			object.fieldSet_[49] = true
+			object.fieldSet_[51] = true
 		case "network":
 			value := ReadNetwork(iterator)
 			object.network = value
-			object.fieldSet_[50] = true
+			object.fieldSet_[52] = true
 		case "node_drain_grace_period":
 			value := ReadValue(iterator)
 			object.nodeDrainGracePeriod = value
-			object.fieldSet_[51] = true
+			object.fieldSet_[53] = true
 		case "node_pools":
 			value := &NodePoolList{}
 			for {
@@ -1077,19 +1085,19 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.nodePools = value
-			object.fieldSet_[52] = true
+			object.fieldSet_[54] = true
 		case "nodes":
 			value := ReadClusterNodes(iterator)
 			object.nodes = value
-			object.fieldSet_[53] = true
+			object.fieldSet_[55] = true
 		case "openshift_version":
 			value := iterator.ReadString()
 			object.openshiftVersion = value
-			object.fieldSet_[54] = true
+			object.fieldSet_[56] = true
 		case "product":
 			value := ReadProduct(iterator)
 			object.product = value
-			object.fieldSet_[55] = true
+			object.fieldSet_[57] = true
 		case "properties":
 			value := map[string]string{}
 			for {
@@ -1101,51 +1109,43 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				value[key] = item
 			}
 			object.properties = value
-			object.fieldSet_[56] = true
+			object.fieldSet_[58] = true
 		case "provision_shard":
 			value := ReadProvisionShard(iterator)
 			object.provisionShard = value
-			object.fieldSet_[57] = true
+			object.fieldSet_[59] = true
 		case "proxy":
 			value := ReadProxy(iterator)
 			object.proxy = value
-			object.fieldSet_[58] = true
+			object.fieldSet_[60] = true
 		case "region":
 			value := ReadCloudRegion(iterator)
 			object.region = value
-			object.fieldSet_[59] = true
+			object.fieldSet_[61] = true
 		case "registry_config":
 			value := ReadClusterRegistryConfig(iterator)
 			object.registryConfig = value
-			object.fieldSet_[60] = true
+			object.fieldSet_[62] = true
 		case "state":
 			text := iterator.ReadString()
 			value := ClusterState(text)
 			object.state = value
-			object.fieldSet_[61] = true
+			object.fieldSet_[63] = true
 		case "status":
 			value := ReadClusterStatus(iterator)
 			object.status = value
-			object.fieldSet_[62] = true
+			object.fieldSet_[64] = true
 		case "storage_quota":
 			value := ReadValue(iterator)
 			object.storageQuota = value
-			object.fieldSet_[63] = true
+			object.fieldSet_[65] = true
 		case "subscription":
 			value := ReadSubscription(iterator)
 			object.subscription = value
-			object.fieldSet_[64] = true
+			object.fieldSet_[66] = true
 		case "version":
 			value := ReadVersion(iterator)
 			object.version = value
-			object.fieldSet_[65] = true
-		case "creator_id":
-			value := iterator.ReadString()
-			object.creatorId = value
-			object.fieldSet_[66] = true
-		case "creator_username":
-			value := iterator.ReadString()
-			object.creatorUsername = value
 			object.fieldSet_[67] = true
 		default:
 			iterator.ReadAny()

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -272,4 +272,12 @@ class Cluster {
 	// The AutoNode settings for this cluster.
 	// This is currently only supported for ROSA HCP
 	AutoNode ClusterAutoNode
+
+	// Identifier of the account that created the cluster, populated from the subscription creator.
+	// This is a convenience field to avoid a secondary lookup to the subscription resource.
+	CreatorId String
+
+	// Username of the account that created the cluster, populated from the subscription creator.
+	// This is a convenience field to avoid a secondary lookup to the subscription resource.
+	CreatorUsername String
 }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16648,6 +16648,14 @@
             "type": "string",
             "format": "date-time"
           },
+          "creator_id": {
+            "description": "Identifier of the account that created the cluster, populated from the subscription creator.\nThis is a convenience field to avoid a secondary lookup to the subscription resource.",
+            "type": "string"
+          },
+          "creator_username": {
+            "description": "Username of the account that created the cluster, populated from the subscription creator.\nThis is a convenience field to avoid a secondary lookup to the subscription resource.",
+            "type": "string"
+          },
           "delete_protection": {
             "description": "Delete protection",
             "$ref": "#/components/schemas/DeleteProtection"


### PR DESCRIPTION
## Summary

- Add `CreatorId` (string) to the `Cluster` type in `clusters_mgmt/v1`
- Add `CreatorUsername` (string) to the `Cluster` type in `clusters_mgmt/v1`
- Update generated clientapi: struct fields, accessors, JSON read/write

## Motivation

`ocm describe cluster` already surfaces creator details by following the
`Subscription → Creator (Account)` link. However, API consumers currently
need to make two calls to get the same information:
1. `GET /api/clusters_mgmt/v1/clusters/{id}` — to get the subscription ID
2. `GET /api/accounts_mgmt/v1/subscriptions/{id}` — to read `creator.id` and `creator.username`

These fields denormalize that data onto the Cluster response directly,
removing the cross-service round trip for a common use case.

## Test plan

- [ ] `make check` passes (model validation)
- [ ] `go build ./...` passes in `clientapi/`
- [ ] Backend populates `creator_id` and `creator_username` from `subscription.creator.id` / `subscription.creator.username`
- [ ] Values match output of `ocm describe cluster <id>` (Creator field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)