### PR TITLE
add AzureContainerRegistryPullCredentials type to ARO HCP API model

### DIFF
--- a/clientapi/arohcp/v1alpha1/azure_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_builder.go
@@ -22,6 +22,7 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 // Microsoft Azure settings of a cluster.
 type AzureBuilder struct {
 	fieldSet_                       []bool
+	containerRegistry               *AzureContainerRegistryBuilder
 	etcdEncryption                  *AzureEtcdEncryptionBuilder
 	managedResourceGroupName        string
 	networkSecurityGroupResourceID  string
@@ -39,7 +40,7 @@ type AzureBuilder struct {
 // NewAzure creates a new builder of 'azure' objects.
 func NewAzure() *AzureBuilder {
 	return &AzureBuilder{
-		fieldSet_: make([]bool, 12),
+		fieldSet_: make([]bool, 13),
 	}
 }
 
@@ -56,14 +57,16 @@ func (b *AzureBuilder) Empty() bool {
 	return true
 }
 
-// EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
+// ContainerRegistry sets the value of the 'container_registry' attribute to the given value.
 //
-// Contains the necessary attributes to support etcd encryption for Azure based clusters.
-func (b *AzureBuilder) EtcdEncryption(value *AzureEtcdEncryptionBuilder) *AzureBuilder {
+// Azure Container Registry configuration for an ARO HCP Cluster.
+// Configures how Data Plane worker nodes authenticate container image
+// pulls from Azure Container Registry (ACR).
+func (b *AzureBuilder) ContainerRegistry(value *AzureContainerRegistryBuilder) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
-	b.etcdEncryption = value
+	b.containerRegistry = value
 	if value != nil {
 		b.fieldSet_[0] = true
 	} else {
@@ -72,23 +75,39 @@ func (b *AzureBuilder) EtcdEncryption(value *AzureEtcdEncryptionBuilder) *AzureB
 	return b
 }
 
+// EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
+//
+// Contains the necessary attributes to support etcd encryption for Azure based clusters.
+func (b *AzureBuilder) EtcdEncryption(value *AzureEtcdEncryptionBuilder) *AzureBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 13)
+	}
+	b.etcdEncryption = value
+	if value != nil {
+		b.fieldSet_[1] = true
+	} else {
+		b.fieldSet_[1] = false
+	}
+	return b
+}
+
 // ManagedResourceGroupName sets the value of the 'managed_resource_group_name' attribute to the given value.
 func (b *AzureBuilder) ManagedResourceGroupName(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.managedResourceGroupName = value
-	b.fieldSet_[1] = true
+	b.fieldSet_[2] = true
 	return b
 }
 
 // NetworkSecurityGroupResourceID sets the value of the 'network_security_group_resource_ID' attribute to the given value.
 func (b *AzureBuilder) NetworkSecurityGroupResourceID(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.networkSecurityGroupResourceID = value
-	b.fieldSet_[2] = true
+	b.fieldSet_[3] = true
 	return b
 }
 
@@ -97,13 +116,13 @@ func (b *AzureBuilder) NetworkSecurityGroupResourceID(value string) *AzureBuilde
 // The configuration of the node outbound connectivity
 func (b *AzureBuilder) NodesOutboundConnectivity(value *AzureNodesOutboundConnectivityBuilder) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.nodesOutboundConnectivity = value
 	if value != nil {
-		b.fieldSet_[3] = true
+		b.fieldSet_[4] = true
 	} else {
-		b.fieldSet_[3] = false
+		b.fieldSet_[4] = false
 	}
 	return b
 }
@@ -111,10 +130,10 @@ func (b *AzureBuilder) NodesOutboundConnectivity(value *AzureNodesOutboundConnec
 // OidcIssuerUrl sets the value of the 'oidc_issuer_url' attribute to the given value.
 func (b *AzureBuilder) OidcIssuerUrl(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.oidcIssuerUrl = value
-	b.fieldSet_[4] = true
+	b.fieldSet_[5] = true
 	return b
 }
 
@@ -124,13 +143,13 @@ func (b *AzureBuilder) OidcIssuerUrl(value string) *AzureBuilder {
 // cluster have to authenticate to Azure.
 func (b *AzureBuilder) OperatorsAuthentication(value *AzureOperatorsAuthenticationBuilder) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.operatorsAuthentication = value
 	if value != nil {
-		b.fieldSet_[5] = true
+		b.fieldSet_[6] = true
 	} else {
-		b.fieldSet_[5] = false
+		b.fieldSet_[6] = false
 	}
 	return b
 }
@@ -138,60 +157,60 @@ func (b *AzureBuilder) OperatorsAuthentication(value *AzureOperatorsAuthenticati
 // ResourceGroupName sets the value of the 'resource_group_name' attribute to the given value.
 func (b *AzureBuilder) ResourceGroupName(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.resourceGroupName = value
-	b.fieldSet_[6] = true
+	b.fieldSet_[7] = true
 	return b
 }
 
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureBuilder) ResourceName(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.resourceName = value
-	b.fieldSet_[7] = true
+	b.fieldSet_[8] = true
 	return b
 }
 
 // SubnetResourceID sets the value of the 'subnet_resource_ID' attribute to the given value.
 func (b *AzureBuilder) SubnetResourceID(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.subnetResourceID = value
-	b.fieldSet_[8] = true
+	b.fieldSet_[9] = true
 	return b
 }
 
 // SubscriptionID sets the value of the 'subscription_ID' attribute to the given value.
 func (b *AzureBuilder) SubscriptionID(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.subscriptionID = value
-	b.fieldSet_[9] = true
+	b.fieldSet_[10] = true
 	return b
 }
 
 // TenantID sets the value of the 'tenant_ID' attribute to the given value.
 func (b *AzureBuilder) TenantID(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.tenantID = value
-	b.fieldSet_[10] = true
+	b.fieldSet_[11] = true
 	return b
 }
 
 // VnetIntegrationSubnetResourceID sets the value of the 'vnet_integration_subnet_resource_ID' attribute to the given value.
 func (b *AzureBuilder) VnetIntegrationSubnetResourceID(value string) *AzureBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.vnetIntegrationSubnetResourceID = value
-	b.fieldSet_[11] = true
+	b.fieldSet_[12] = true
 	return b
 }
 
@@ -203,6 +222,11 @@ func (b *AzureBuilder) Copy(object *Azure) *AzureBuilder {
 	if len(object.fieldSet_) > 0 {
 		b.fieldSet_ = make([]bool, len(object.fieldSet_))
 		copy(b.fieldSet_, object.fieldSet_)
+	}
+	if object.containerRegistry != nil {
+		b.containerRegistry = NewAzureContainerRegistry().Copy(object.containerRegistry)
+	} else {
+		b.containerRegistry = nil
 	}
 	if object.etcdEncryption != nil {
 		b.etcdEncryption = NewAzureEtcdEncryption().Copy(object.etcdEncryption)
@@ -237,6 +261,12 @@ func (b *AzureBuilder) Build() (object *Azure, err error) {
 	if len(b.fieldSet_) > 0 {
 		object.fieldSet_ = make([]bool, len(b.fieldSet_))
 		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.containerRegistry != nil {
+		object.containerRegistry, err = b.containerRegistry.Build()
+		if err != nil {
+			return
+		}
 	}
 	if b.etcdEncryption != nil {
 		object.etcdEncryption, err = b.etcdEncryption.Build()

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_builder.go
@@ -1,0 +1,99 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// Azure Container Registry configuration for an ARO HCP Cluster.
+// Configures how Data Plane worker nodes authenticate container image
+// pulls from Azure Container Registry (ACR).
+type AzureContainerRegistryBuilder struct {
+	fieldSet_   []bool
+	credentials *AzureContainerRegistryCredentialsBuilder
+}
+
+// NewAzureContainerRegistry creates a new builder of 'azure_container_registry' objects.
+func NewAzureContainerRegistry() *AzureContainerRegistryBuilder {
+	return &AzureContainerRegistryBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureContainerRegistryBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Credentials sets the value of the 'credentials' attribute to the given value.
+//
+// Azure Container Registry credentials configuration for an ARO HCP Cluster.
+// Configures authentication for container image pulls from Azure Container
+// Registry (ACR) on Data Plane worker nodes.
+func (b *AzureContainerRegistryBuilder) Credentials(value *AzureContainerRegistryCredentialsBuilder) *AzureContainerRegistryBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.credentials = value
+	if value != nil {
+		b.fieldSet_[0] = true
+	} else {
+		b.fieldSet_[0] = false
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureContainerRegistryBuilder) Copy(object *AzureContainerRegistry) *AzureContainerRegistryBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	if object.credentials != nil {
+		b.credentials = NewAzureContainerRegistryCredentials().Copy(object.credentials)
+	} else {
+		b.credentials = nil
+	}
+	return b
+}
+
+// Build creates a 'azure_container_registry' object using the configuration stored in the builder.
+func (b *AzureContainerRegistryBuilder) Build() (object *AzureContainerRegistry, err error) {
+	object = new(AzureContainerRegistry)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.credentials != nil {
+		object.credentials, err = b.credentials.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credential_type_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credential_type_list_type_json.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureContainerRegistryCredentialTypeList writes a list of values of the 'azure_container_registry_credential_type' type to
+// the given writer.
+func MarshalAzureContainerRegistryCredentialTypeList(list []AzureContainerRegistryCredentialType, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureContainerRegistryCredentialTypeList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureContainerRegistryCredentialTypeList writes a list of value of the 'azure_container_registry_credential_type' type to
+// the given stream.
+func WriteAzureContainerRegistryCredentialTypeList(list []AzureContainerRegistryCredentialType, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteString(string(value))
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureContainerRegistryCredentialTypeList reads a list of values of the 'azure_container_registry_credential_type' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureContainerRegistryCredentialTypeList(source interface{}) (items []AzureContainerRegistryCredentialType, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureContainerRegistryCredentialTypeList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureContainerRegistryCredentialTypeList reads list of values of the ”azure_container_registry_credential_type' type from
+// the given iterator.
+func ReadAzureContainerRegistryCredentialTypeList(iterator *jsoniter.Iterator) []AzureContainerRegistryCredentialType {
+	list := []AzureContainerRegistryCredentialType{}
+	for iterator.ReadArray() {
+		text := iterator.ReadString()
+		item := AzureContainerRegistryCredentialType(text)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credential_type_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credential_type_type.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureContainerRegistryCredentialType represents the values of the 'azure_container_registry_credential_type' enumerated type.
+type AzureContainerRegistryCredentialType string
+
+const (
+	// Uses a user-assigned managed identity for ACR authentication.
+	AzureContainerRegistryCredentialTypeManagedIdentity AzureContainerRegistryCredentialType = "ManagedIdentity"
+)

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_builder.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// Azure Container Registry credentials configuration for an ARO HCP Cluster.
+// Configures authentication for container image pulls from Azure Container
+// Registry (ACR) on Data Plane worker nodes.
+type AzureContainerRegistryCredentialsBuilder struct {
+	fieldSet_       []bool
+	managedIdentity *AzureUserAssignedManagedIdentityBuilder
+	type_           AzureContainerRegistryCredentialType
+}
+
+// NewAzureContainerRegistryCredentials creates a new builder of 'azure_container_registry_credentials' objects.
+func NewAzureContainerRegistryCredentials() *AzureContainerRegistryCredentialsBuilder {
+	return &AzureContainerRegistryCredentialsBuilder{
+		fieldSet_: make([]bool, 2),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureContainerRegistryCredentialsBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// ManagedIdentity sets the value of the 'managed_identity' attribute to the given value.
+//
+// Identifies a user-assigned managed identity by its ARM resource ID.
+func (b *AzureContainerRegistryCredentialsBuilder) ManagedIdentity(value *AzureUserAssignedManagedIdentityBuilder) *AzureContainerRegistryCredentialsBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.managedIdentity = value
+	if value != nil {
+		b.fieldSet_[0] = true
+	} else {
+		b.fieldSet_[0] = false
+	}
+	return b
+}
+
+// Type sets the value of the 'type' attribute to the given value.
+//
+// The type of credential used for Azure Container Registry image pulls.
+func (b *AzureContainerRegistryCredentialsBuilder) Type(value AzureContainerRegistryCredentialType) *AzureContainerRegistryCredentialsBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.type_ = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureContainerRegistryCredentialsBuilder) Copy(object *AzureContainerRegistryCredentials) *AzureContainerRegistryCredentialsBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	if object.managedIdentity != nil {
+		b.managedIdentity = NewAzureUserAssignedManagedIdentity().Copy(object.managedIdentity)
+	} else {
+		b.managedIdentity = nil
+	}
+	b.type_ = object.type_
+	return b
+}
+
+// Build creates a 'azure_container_registry_credentials' object using the configuration stored in the builder.
+func (b *AzureContainerRegistryCredentialsBuilder) Build() (object *AzureContainerRegistryCredentials, err error) {
+	object = new(AzureContainerRegistryCredentials)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.managedIdentity != nil {
+		object.managedIdentity, err = b.managedIdentity.Build()
+		if err != nil {
+			return
+		}
+	}
+	object.type_ = b.type_
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureContainerRegistryCredentialsListBuilder contains the data and logic needed to build
+// 'azure_container_registry_credentials' objects.
+type AzureContainerRegistryCredentialsListBuilder struct {
+	items []*AzureContainerRegistryCredentialsBuilder
+}
+
+// NewAzureContainerRegistryCredentialsList creates a new builder of 'azure_container_registry_credentials' objects.
+func NewAzureContainerRegistryCredentialsList() *AzureContainerRegistryCredentialsListBuilder {
+	return new(AzureContainerRegistryCredentialsListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureContainerRegistryCredentialsListBuilder) Items(values ...*AzureContainerRegistryCredentialsBuilder) *AzureContainerRegistryCredentialsListBuilder {
+	b.items = make([]*AzureContainerRegistryCredentialsBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureContainerRegistryCredentialsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureContainerRegistryCredentialsListBuilder) Copy(list *AzureContainerRegistryCredentialsList) *AzureContainerRegistryCredentialsListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureContainerRegistryCredentialsBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureContainerRegistryCredentials().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_container_registry_credentials' objects using the
+// configuration stored in the builder.
+func (b *AzureContainerRegistryCredentialsListBuilder) Build() (list *AzureContainerRegistryCredentialsList, err error) {
+	items := make([]*AzureContainerRegistryCredentials, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureContainerRegistryCredentialsList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureContainerRegistryCredentialsList writes a list of values of the 'azure_container_registry_credentials' type to
+// the given writer.
+func MarshalAzureContainerRegistryCredentialsList(list []*AzureContainerRegistryCredentials, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureContainerRegistryCredentialsList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureContainerRegistryCredentialsList writes a list of value of the 'azure_container_registry_credentials' type to
+// the given stream.
+func WriteAzureContainerRegistryCredentialsList(list []*AzureContainerRegistryCredentials, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureContainerRegistryCredentials(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureContainerRegistryCredentialsList reads a list of values of the 'azure_container_registry_credentials' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureContainerRegistryCredentialsList(source interface{}) (items []*AzureContainerRegistryCredentials, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureContainerRegistryCredentialsList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureContainerRegistryCredentialsList reads list of values of the ”azure_container_registry_credentials' type from
+// the given iterator.
+func ReadAzureContainerRegistryCredentialsList(iterator *jsoniter.Iterator) []*AzureContainerRegistryCredentials {
+	list := []*AzureContainerRegistryCredentials{}
+	for iterator.ReadArray() {
+		item := ReadAzureContainerRegistryCredentials(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_type.go
@@ -1,0 +1,205 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureContainerRegistryCredentials represents the values of the 'azure_container_registry_credentials' type.
+//
+// Azure Container Registry credentials configuration for an ARO HCP Cluster.
+// Configures authentication for container image pulls from Azure Container
+// Registry (ACR) on Data Plane worker nodes.
+type AzureContainerRegistryCredentials struct {
+	fieldSet_       []bool
+	managedIdentity *AzureUserAssignedManagedIdentity
+	type_           AzureContainerRegistryCredentialType
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureContainerRegistryCredentials) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// ManagedIdentity returns the value of the 'managed_identity' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The user-assigned managed identity used for ACR image pulls
+// on Data Plane worker nodes.
+// Required when type is ManagedIdentity.
+func (o *AzureContainerRegistryCredentials) ManagedIdentity() *AzureUserAssignedManagedIdentity {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.managedIdentity
+	}
+	return nil
+}
+
+// GetManagedIdentity returns the value of the 'managed_identity' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The user-assigned managed identity used for ACR image pulls
+// on Data Plane worker nodes.
+// Required when type is ManagedIdentity.
+func (o *AzureContainerRegistryCredentials) GetManagedIdentity() (value *AzureUserAssignedManagedIdentity, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.managedIdentity
+	}
+	return
+}
+
+// Type returns the value of the 'type' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The credential type used for ACR image pulls on Data Plane worker nodes.
+// Required.
+func (o *AzureContainerRegistryCredentials) Type() AzureContainerRegistryCredentialType {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.type_
+	}
+	return AzureContainerRegistryCredentialType("")
+}
+
+// GetType returns the value of the 'type' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The credential type used for ACR image pulls on Data Plane worker nodes.
+// Required.
+func (o *AzureContainerRegistryCredentials) GetType() (value AzureContainerRegistryCredentialType, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.type_
+	}
+	return
+}
+
+// AzureContainerRegistryCredentialsListKind is the name of the type used to represent list of objects of
+// type 'azure_container_registry_credentials'.
+const AzureContainerRegistryCredentialsListKind = "AzureContainerRegistryCredentialsList"
+
+// AzureContainerRegistryCredentialsListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_container_registry_credentials'.
+const AzureContainerRegistryCredentialsListLinkKind = "AzureContainerRegistryCredentialsListLink"
+
+// AzureContainerRegistryCredentialsNilKind is the name of the type used to nil lists of objects of
+// type 'azure_container_registry_credentials'.
+const AzureContainerRegistryCredentialsListNilKind = "AzureContainerRegistryCredentialsListNil"
+
+// AzureContainerRegistryCredentialsList is a list of values of the 'azure_container_registry_credentials' type.
+type AzureContainerRegistryCredentialsList struct {
+	href  string
+	link  bool
+	items []*AzureContainerRegistryCredentials
+}
+
+// Len returns the length of the list.
+func (l *AzureContainerRegistryCredentialsList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureContainerRegistryCredentialsList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureContainerRegistryCredentialsList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureContainerRegistryCredentialsList) SetItems(items []*AzureContainerRegistryCredentials) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureContainerRegistryCredentialsList) Items() []*AzureContainerRegistryCredentials {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureContainerRegistryCredentialsList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureContainerRegistryCredentialsList) Get(i int) *AzureContainerRegistryCredentials {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureContainerRegistryCredentialsList) Slice() []*AzureContainerRegistryCredentials {
+	var slice []*AzureContainerRegistryCredentials
+	if l == nil {
+		slice = make([]*AzureContainerRegistryCredentials, 0)
+	} else {
+		slice = make([]*AzureContainerRegistryCredentials, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureContainerRegistryCredentialsList) Each(f func(item *AzureContainerRegistryCredentials) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureContainerRegistryCredentialsList) Range(f func(index int, item *AzureContainerRegistryCredentials) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_type_json.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureContainerRegistryCredentials writes a value of the 'azure_container_registry_credentials' type to the given writer.
+func MarshalAzureContainerRegistryCredentials(object *AzureContainerRegistryCredentials, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureContainerRegistryCredentials(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureContainerRegistryCredentials writes a value of the 'azure_container_registry_credentials' type to the given stream.
+func WriteAzureContainerRegistryCredentials(object *AzureContainerRegistryCredentials, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.managedIdentity != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("managed_identity")
+		WriteAzureUserAssignedManagedIdentity(object.managedIdentity, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("type")
+		stream.WriteString(string(object.type_))
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureContainerRegistryCredentials reads a value of the 'azure_container_registry_credentials' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureContainerRegistryCredentials(source interface{}) (object *AzureContainerRegistryCredentials, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureContainerRegistryCredentials(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureContainerRegistryCredentials reads a value of the 'azure_container_registry_credentials' type from the given iterator.
+func ReadAzureContainerRegistryCredentials(iterator *jsoniter.Iterator) *AzureContainerRegistryCredentials {
+	object := &AzureContainerRegistryCredentials{
+		fieldSet_: make([]bool, 2),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "managed_identity":
+			value := ReadAzureUserAssignedManagedIdentity(iterator)
+			object.managedIdentity = value
+			object.fieldSet_[0] = true
+		case "type":
+			text := iterator.ReadString()
+			value := AzureContainerRegistryCredentialType(text)
+			object.type_ = value
+			object.fieldSet_[1] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureContainerRegistryListBuilder contains the data and logic needed to build
+// 'azure_container_registry' objects.
+type AzureContainerRegistryListBuilder struct {
+	items []*AzureContainerRegistryBuilder
+}
+
+// NewAzureContainerRegistryList creates a new builder of 'azure_container_registry' objects.
+func NewAzureContainerRegistryList() *AzureContainerRegistryListBuilder {
+	return new(AzureContainerRegistryListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureContainerRegistryListBuilder) Items(values ...*AzureContainerRegistryBuilder) *AzureContainerRegistryListBuilder {
+	b.items = make([]*AzureContainerRegistryBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureContainerRegistryListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureContainerRegistryListBuilder) Copy(list *AzureContainerRegistryList) *AzureContainerRegistryListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureContainerRegistryBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureContainerRegistry().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_container_registry' objects using the
+// configuration stored in the builder.
+func (b *AzureContainerRegistryListBuilder) Build() (list *AzureContainerRegistryList, err error) {
+	items := make([]*AzureContainerRegistry, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureContainerRegistryList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureContainerRegistryList writes a list of values of the 'azure_container_registry' type to
+// the given writer.
+func MarshalAzureContainerRegistryList(list []*AzureContainerRegistry, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureContainerRegistryList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureContainerRegistryList writes a list of value of the 'azure_container_registry' type to
+// the given stream.
+func WriteAzureContainerRegistryList(list []*AzureContainerRegistry, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureContainerRegistry(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureContainerRegistryList reads a list of values of the 'azure_container_registry' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureContainerRegistryList(source interface{}) (items []*AzureContainerRegistry, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureContainerRegistryList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureContainerRegistryList reads list of values of the ”azure_container_registry' type from
+// the given iterator.
+func ReadAzureContainerRegistryList(iterator *jsoniter.Iterator) []*AzureContainerRegistry {
+	list := []*AzureContainerRegistry{}
+	for iterator.ReadArray() {
+		item := ReadAzureContainerRegistry(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_type.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureContainerRegistry represents the values of the 'azure_container_registry' type.
+//
+// Azure Container Registry configuration for an ARO HCP Cluster.
+// Configures how Data Plane worker nodes authenticate container image
+// pulls from Azure Container Registry (ACR).
+type AzureContainerRegistry struct {
+	fieldSet_   []bool
+	credentials *AzureContainerRegistryCredentials
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureContainerRegistry) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Credentials returns the value of the 'credentials' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Credentials for authenticating container image pulls from
+// Azure Container Registry (ACR) on Data Plane worker nodes.
+// Required.
+func (o *AzureContainerRegistry) Credentials() *AzureContainerRegistryCredentials {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.credentials
+	}
+	return nil
+}
+
+// GetCredentials returns the value of the 'credentials' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Credentials for authenticating container image pulls from
+// Azure Container Registry (ACR) on Data Plane worker nodes.
+// Required.
+func (o *AzureContainerRegistry) GetCredentials() (value *AzureContainerRegistryCredentials, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.credentials
+	}
+	return
+}
+
+// AzureContainerRegistryListKind is the name of the type used to represent list of objects of
+// type 'azure_container_registry'.
+const AzureContainerRegistryListKind = "AzureContainerRegistryList"
+
+// AzureContainerRegistryListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_container_registry'.
+const AzureContainerRegistryListLinkKind = "AzureContainerRegistryListLink"
+
+// AzureContainerRegistryNilKind is the name of the type used to nil lists of objects of
+// type 'azure_container_registry'.
+const AzureContainerRegistryListNilKind = "AzureContainerRegistryListNil"
+
+// AzureContainerRegistryList is a list of values of the 'azure_container_registry' type.
+type AzureContainerRegistryList struct {
+	href  string
+	link  bool
+	items []*AzureContainerRegistry
+}
+
+// Len returns the length of the list.
+func (l *AzureContainerRegistryList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureContainerRegistryList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureContainerRegistryList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureContainerRegistryList) SetItems(items []*AzureContainerRegistry) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureContainerRegistryList) Items() []*AzureContainerRegistry {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureContainerRegistryList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureContainerRegistryList) Get(i int) *AzureContainerRegistry {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureContainerRegistryList) Slice() []*AzureContainerRegistry {
+	var slice []*AzureContainerRegistry
+	if l == nil {
+		slice = make([]*AzureContainerRegistry, 0)
+	} else {
+		slice = make([]*AzureContainerRegistry, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureContainerRegistryList) Each(f func(item *AzureContainerRegistry) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureContainerRegistryList) Range(f func(index int, item *AzureContainerRegistry) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_container_registry_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureContainerRegistry writes a value of the 'azure_container_registry' type to the given writer.
+func MarshalAzureContainerRegistry(object *AzureContainerRegistry, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureContainerRegistry(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureContainerRegistry writes a value of the 'azure_container_registry' type to the given stream.
+func WriteAzureContainerRegistry(object *AzureContainerRegistry, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.credentials != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("credentials")
+		WriteAzureContainerRegistryCredentials(object.credentials, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureContainerRegistry reads a value of the 'azure_container_registry' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureContainerRegistry(source interface{}) (object *AzureContainerRegistry, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureContainerRegistry(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureContainerRegistry reads a value of the 'azure_container_registry' type from the given iterator.
+func ReadAzureContainerRegistry(iterator *jsoniter.Iterator) *AzureContainerRegistry {
+	object := &AzureContainerRegistry{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "credentials":
+			value := ReadAzureContainerRegistryCredentials(iterator)
+			object.credentials = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_type.go
@@ -24,6 +24,7 @@ package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v
 // Microsoft Azure settings of a cluster.
 type Azure struct {
 	fieldSet_                       []bool
+	containerRegistry               *AzureContainerRegistry
 	etcdEncryption                  *AzureEtcdEncryption
 	managedResourceGroupName        string
 	networkSecurityGroupResourceID  string
@@ -51,6 +52,73 @@ func (o *Azure) Empty() bool {
 	return true
 }
 
+// ContainerRegistry returns the value of the 'container_registry' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Configures authentication for container image pulls from Azure
+// Container Registry (ACR) on Data Plane worker nodes. Only ACR
+// registries (*.azurecr.io, *.azurecr.cn, *.azurecr.de, *.azurecr.us) are
+// supported; non-ACR registries are not affected by this
+// configuration. The identity is not bound to a specific ACR
+// instance — it authenticates to any ACR the identity has the
+// AcrPull role assigned on. The customer controls which ACR
+// instances the identity can pull from via Azure RBAC.
+// When set, the managed identity is attached to worker virtual
+// machines and its resource ID is written into the worker cloud
+// provider config so kubelet's ACR credential provider can
+// authenticate without image pull secrets.
+// When not set, no managed identity is attached to worker virtual
+// machines for ACR and no identity is written into the worker
+// cloud provider config. The ACR credential provider on worker
+// nodes has no identity to authenticate with, so image pulls from
+// private ACR registries will fail unless the workload provides
+// image pull secrets or another authentication mechanism. Public
+// ACR images (anonymous pull enabled) are not affected.
+// Changing this value will trigger a rollout for all existing
+// NodePools in the cluster.
+// Optional.
+// Mutable.
+func (o *Azure) ContainerRegistry() *AzureContainerRegistry {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.containerRegistry
+	}
+	return nil
+}
+
+// GetContainerRegistry returns the value of the 'container_registry' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Configures authentication for container image pulls from Azure
+// Container Registry (ACR) on Data Plane worker nodes. Only ACR
+// registries (*.azurecr.io, *.azurecr.cn, *.azurecr.de, *.azurecr.us) are
+// supported; non-ACR registries are not affected by this
+// configuration. The identity is not bound to a specific ACR
+// instance — it authenticates to any ACR the identity has the
+// AcrPull role assigned on. The customer controls which ACR
+// instances the identity can pull from via Azure RBAC.
+// When set, the managed identity is attached to worker virtual
+// machines and its resource ID is written into the worker cloud
+// provider config so kubelet's ACR credential provider can
+// authenticate without image pull secrets.
+// When not set, no managed identity is attached to worker virtual
+// machines for ACR and no identity is written into the worker
+// cloud provider config. The ACR credential provider on worker
+// nodes has no identity to authenticate with, so image pulls from
+// private ACR registries will fail unless the workload provides
+// image pull secrets or another authentication mechanism. Public
+// ACR images (anonymous pull enabled) are not affected.
+// Changing this value will trigger a rollout for all existing
+// NodePools in the cluster.
+// Optional.
+// Mutable.
+func (o *Azure) GetContainerRegistry() (value *AzureContainerRegistry, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.containerRegistry
+	}
+	return
+}
+
 // EtcdEncryption returns the value of the 'etcd_encryption' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
@@ -59,7 +127,7 @@ func (o *Azure) Empty() bool {
 // Currently etcd data encryption is only supported with customer managed keys.
 // Creating a cluster with platform managed keys will result in a failure creating the cluster.
 func (o *Azure) EtcdEncryption() *AzureEtcdEncryption {
-	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
 		return o.etcdEncryption
 	}
 	return nil
@@ -73,7 +141,7 @@ func (o *Azure) EtcdEncryption() *AzureEtcdEncryption {
 // Currently etcd data encryption is only supported with customer managed keys.
 // Creating a cluster with platform managed keys will result in a failure creating the cluster.
 func (o *Azure) GetEtcdEncryption() (value *AzureEtcdEncryption, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
 	if ok {
 		value = o.etcdEncryption
 	}
@@ -95,7 +163,7 @@ func (o *Azure) GetEtcdEncryption() (value *AzureEtcdEncryption, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) ManagedResourceGroupName() string {
-	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
 		return o.managedResourceGroupName
 	}
 	return ""
@@ -116,7 +184,7 @@ func (o *Azure) ManagedResourceGroupName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetManagedResourceGroupName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
 	if ok {
 		value = o.managedResourceGroupName
 	}
@@ -148,7 +216,7 @@ func (o *Azure) GetManagedResourceGroupName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) NetworkSecurityGroupResourceID() string {
-	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
 		return o.networkSecurityGroupResourceID
 	}
 	return ""
@@ -179,7 +247,7 @@ func (o *Azure) NetworkSecurityGroupResourceID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetNetworkSecurityGroupResourceID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
 	if ok {
 		value = o.networkSecurityGroupResourceID
 	}
@@ -193,7 +261,7 @@ func (o *Azure) GetNetworkSecurityGroupResourceID() (value string, ok bool) {
 // configuration of the Cluster's Node Pool's Nodes is performed.
 // By default this is configured as Azure Load Balancer. This value is immutable.
 func (o *Azure) NodesOutboundConnectivity() *AzureNodesOutboundConnectivity {
-	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
 		return o.nodesOutboundConnectivity
 	}
 	return nil
@@ -206,7 +274,7 @@ func (o *Azure) NodesOutboundConnectivity() *AzureNodesOutboundConnectivity {
 // configuration of the Cluster's Node Pool's Nodes is performed.
 // By default this is configured as Azure Load Balancer. This value is immutable.
 func (o *Azure) GetNodesOutboundConnectivity() (value *AzureNodesOutboundConnectivity, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
 	if ok {
 		value = o.nodesOutboundConnectivity
 	}
@@ -220,7 +288,7 @@ func (o *Azure) GetNodesOutboundConnectivity() (value *AzureNodesOutboundConnect
 // This URL is used by Azure managed identities to establish trust with cluster.
 // Readonly
 func (o *Azure) OidcIssuerUrl() string {
-	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
+	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
 		return o.oidcIssuerUrl
 	}
 	return ""
@@ -233,7 +301,7 @@ func (o *Azure) OidcIssuerUrl() string {
 // This URL is used by Azure managed identities to establish trust with cluster.
 // Readonly
 func (o *Azure) GetOidcIssuerUrl() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
+	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
 	if ok {
 		value = o.oidcIssuerUrl
 	}
@@ -247,7 +315,7 @@ func (o *Azure) GetOidcIssuerUrl() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) OperatorsAuthentication() *AzureOperatorsAuthentication {
-	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
 		return o.operatorsAuthentication
 	}
 	return nil
@@ -260,7 +328,7 @@ func (o *Azure) OperatorsAuthentication() *AzureOperatorsAuthentication {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetOperatorsAuthentication() (value *AzureOperatorsAuthentication, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
 	if ok {
 		value = o.operatorsAuthentication
 	}
@@ -278,7 +346,7 @@ func (o *Azure) GetOperatorsAuthentication() (value *AzureOperatorsAuthenticatio
 // Required during creation.
 // Immutable.
 func (o *Azure) ResourceGroupName() string {
-	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
 		return o.resourceGroupName
 	}
 	return ""
@@ -295,7 +363,7 @@ func (o *Azure) ResourceGroupName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetResourceGroupName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
 	if ok {
 		value = o.resourceGroupName
 	}
@@ -311,7 +379,7 @@ func (o *Azure) GetResourceGroupName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
 		return o.resourceName
 	}
 	return ""
@@ -326,7 +394,7 @@ func (o *Azure) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
 	if ok {
 		value = o.resourceName
 	}
@@ -353,7 +421,7 @@ func (o *Azure) GetResourceName() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) SubnetResourceID() string {
-	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
+	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
 		return o.subnetResourceID
 	}
 	return ""
@@ -379,7 +447,7 @@ func (o *Azure) SubnetResourceID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetSubnetResourceID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
+	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
 	if ok {
 		value = o.subnetResourceID
 	}
@@ -394,7 +462,7 @@ func (o *Azure) GetSubnetResourceID() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) SubscriptionID() string {
-	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
 		return o.subscriptionID
 	}
 	return ""
@@ -408,7 +476,7 @@ func (o *Azure) SubscriptionID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetSubscriptionID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
 	if ok {
 		value = o.subscriptionID
 	}
@@ -422,7 +490,7 @@ func (o *Azure) GetSubscriptionID() (value string, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *Azure) TenantID() string {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.tenantID
 	}
 	return ""
@@ -435,7 +503,7 @@ func (o *Azure) TenantID() string {
 // Required during creation.
 // Immutable.
 func (o *Azure) GetTenantID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.tenantID
 	}
@@ -456,7 +524,7 @@ func (o *Azure) GetTenantID() (value string, ok bool) {
 // This field is optional - if not specified, SWIFT networking will not be enabled.
 // Immutable.
 func (o *Azure) VnetIntegrationSubnetResourceID() string {
-	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
+	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
 		return o.vnetIntegrationSubnetResourceID
 	}
 	return ""
@@ -476,7 +544,7 @@ func (o *Azure) VnetIntegrationSubnetResourceID() string {
 // This field is optional - if not specified, SWIFT networking will not be enabled.
 // Immutable.
 func (o *Azure) GetVnetIntegrationSubnetResourceID() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
+	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
 	if ok {
 		value = o.vnetIntegrationSubnetResourceID
 	}

--- a/clientapi/arohcp/v1alpha1/azure_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_type_json.go
@@ -42,7 +42,16 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
 	var present_ bool
-	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.etcdEncryption != nil
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.containerRegistry != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("container_registry")
+		WriteAzureContainerRegistry(object.containerRegistry, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.etcdEncryption != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -51,7 +60,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureEtcdEncryption(object.etcdEncryption, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -60,7 +69,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.managedResourceGroupName)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -69,7 +78,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.networkSecurityGroupResourceID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3] && object.nodesOutboundConnectivity != nil
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4] && object.nodesOutboundConnectivity != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -78,7 +87,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureNodesOutboundConnectivity(object.nodesOutboundConnectivity, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
+	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -87,7 +96,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.oidcIssuerUrl)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.operatorsAuthentication != nil
+	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6] && object.operatorsAuthentication != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -96,7 +105,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		WriteAzureOperatorsAuthentication(object.operatorsAuthentication, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
+	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -105,7 +114,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.resourceGroupName)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7]
+	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -114,7 +123,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.resourceName)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8]
+	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -123,7 +132,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.subnetResourceID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9]
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -132,7 +141,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.subscriptionID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10]
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -141,7 +150,7 @@ func WriteAzure(object *Azure, stream *jsoniter.Stream) {
 		stream.WriteString(object.tenantID)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11]
+	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -167,7 +176,7 @@ func UnmarshalAzure(source interface{}) (object *Azure, err error) {
 // ReadAzure reads a value of the 'azure' type from the given iterator.
 func ReadAzure(iterator *jsoniter.Iterator) *Azure {
 	object := &Azure{
-		fieldSet_: make([]bool, 12),
+		fieldSet_: make([]bool, 13),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -175,54 +184,58 @@ func ReadAzure(iterator *jsoniter.Iterator) *Azure {
 			break
 		}
 		switch field {
+		case "container_registry":
+			value := ReadAzureContainerRegistry(iterator)
+			object.containerRegistry = value
+			object.fieldSet_[0] = true
 		case "etcd_encryption":
 			value := ReadAzureEtcdEncryption(iterator)
 			object.etcdEncryption = value
-			object.fieldSet_[0] = true
+			object.fieldSet_[1] = true
 		case "managed_resource_group_name":
 			value := iterator.ReadString()
 			object.managedResourceGroupName = value
-			object.fieldSet_[1] = true
+			object.fieldSet_[2] = true
 		case "network_security_group_resource_id":
 			value := iterator.ReadString()
 			object.networkSecurityGroupResourceID = value
-			object.fieldSet_[2] = true
+			object.fieldSet_[3] = true
 		case "nodes_outbound_connectivity":
 			value := ReadAzureNodesOutboundConnectivity(iterator)
 			object.nodesOutboundConnectivity = value
-			object.fieldSet_[3] = true
+			object.fieldSet_[4] = true
 		case "oidc_issuer_url":
 			value := iterator.ReadString()
 			object.oidcIssuerUrl = value
-			object.fieldSet_[4] = true
+			object.fieldSet_[5] = true
 		case "operators_authentication":
 			value := ReadAzureOperatorsAuthentication(iterator)
 			object.operatorsAuthentication = value
-			object.fieldSet_[5] = true
+			object.fieldSet_[6] = true
 		case "resource_group_name":
 			value := iterator.ReadString()
 			object.resourceGroupName = value
-			object.fieldSet_[6] = true
+			object.fieldSet_[7] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[7] = true
+			object.fieldSet_[8] = true
 		case "subnet_resource_id":
 			value := iterator.ReadString()
 			object.subnetResourceID = value
-			object.fieldSet_[8] = true
+			object.fieldSet_[9] = true
 		case "subscription_id":
 			value := iterator.ReadString()
 			object.subscriptionID = value
-			object.fieldSet_[9] = true
+			object.fieldSet_[10] = true
 		case "tenant_id":
 			value := iterator.ReadString()
 			object.tenantID = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		case "vnet_integration_subnet_resource_id":
 			value := iterator.ReadString()
 			object.vnetIntegrationSubnetResourceID = value
-			object.fieldSet_[11] = true
+			object.fieldSet_[12] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_builder.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// Identifies a user-assigned managed identity by its ARM resource ID.
+type AzureUserAssignedManagedIdentityBuilder struct {
+	fieldSet_  []bool
+	resourceID string
+}
+
+// NewAzureUserAssignedManagedIdentity creates a new builder of 'azure_user_assigned_managed_identity' objects.
+func NewAzureUserAssignedManagedIdentity() *AzureUserAssignedManagedIdentityBuilder {
+	return &AzureUserAssignedManagedIdentityBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureUserAssignedManagedIdentityBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// ResourceID sets the value of the 'resource_ID' attribute to the given value.
+func (b *AzureUserAssignedManagedIdentityBuilder) ResourceID(value string) *AzureUserAssignedManagedIdentityBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.resourceID = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureUserAssignedManagedIdentityBuilder) Copy(object *AzureUserAssignedManagedIdentity) *AzureUserAssignedManagedIdentityBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.resourceID = object.resourceID
+	return b
+}
+
+// Build creates a 'azure_user_assigned_managed_identity' object using the configuration stored in the builder.
+func (b *AzureUserAssignedManagedIdentityBuilder) Build() (object *AzureUserAssignedManagedIdentity, err error) {
+	object = new(AzureUserAssignedManagedIdentity)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.resourceID = b.resourceID
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureUserAssignedManagedIdentityListBuilder contains the data and logic needed to build
+// 'azure_user_assigned_managed_identity' objects.
+type AzureUserAssignedManagedIdentityListBuilder struct {
+	items []*AzureUserAssignedManagedIdentityBuilder
+}
+
+// NewAzureUserAssignedManagedIdentityList creates a new builder of 'azure_user_assigned_managed_identity' objects.
+func NewAzureUserAssignedManagedIdentityList() *AzureUserAssignedManagedIdentityListBuilder {
+	return new(AzureUserAssignedManagedIdentityListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureUserAssignedManagedIdentityListBuilder) Items(values ...*AzureUserAssignedManagedIdentityBuilder) *AzureUserAssignedManagedIdentityListBuilder {
+	b.items = make([]*AzureUserAssignedManagedIdentityBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureUserAssignedManagedIdentityListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureUserAssignedManagedIdentityListBuilder) Copy(list *AzureUserAssignedManagedIdentityList) *AzureUserAssignedManagedIdentityListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureUserAssignedManagedIdentityBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureUserAssignedManagedIdentity().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_user_assigned_managed_identity' objects using the
+// configuration stored in the builder.
+func (b *AzureUserAssignedManagedIdentityListBuilder) Build() (list *AzureUserAssignedManagedIdentityList, err error) {
+	items := make([]*AzureUserAssignedManagedIdentity, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureUserAssignedManagedIdentityList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureUserAssignedManagedIdentityList writes a list of values of the 'azure_user_assigned_managed_identity' type to
+// the given writer.
+func MarshalAzureUserAssignedManagedIdentityList(list []*AzureUserAssignedManagedIdentity, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureUserAssignedManagedIdentityList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureUserAssignedManagedIdentityList writes a list of value of the 'azure_user_assigned_managed_identity' type to
+// the given stream.
+func WriteAzureUserAssignedManagedIdentityList(list []*AzureUserAssignedManagedIdentity, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureUserAssignedManagedIdentity(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureUserAssignedManagedIdentityList reads a list of values of the 'azure_user_assigned_managed_identity' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureUserAssignedManagedIdentityList(source interface{}) (items []*AzureUserAssignedManagedIdentity, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureUserAssignedManagedIdentityList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureUserAssignedManagedIdentityList reads list of values of the ”azure_user_assigned_managed_identity' type from
+// the given iterator.
+func ReadAzureUserAssignedManagedIdentityList(iterator *jsoniter.Iterator) []*AzureUserAssignedManagedIdentity {
+	list := []*AzureUserAssignedManagedIdentity{}
+	for iterator.ReadArray() {
+		item := ReadAzureUserAssignedManagedIdentity(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_type.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureUserAssignedManagedIdentity represents the values of the 'azure_user_assigned_managed_identity' type.
+//
+// Identifies a user-assigned managed identity by its ARM resource ID.
+type AzureUserAssignedManagedIdentity struct {
+	fieldSet_  []bool
+	resourceID string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureUserAssignedManagedIdentity) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// ResourceID returns the value of the 'resource_ID' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The Azure Resource ID of the Azure User-Assigned Managed Identity.
+// The managed identity represented must exist before creating or
+// updating the cluster.
+// The Azure Resource Group Name specified as part of the Resource ID
+// must belong to the Azure Subscription specified in `.azure.subscription_id`,
+// and in the same Azure location as the cluster's region.
+// The Azure Resource Group Name specified as part of the Resource ID
+// must be a different Resource Group Name than the one specified in
+// `.azure.managed_resource_group_name`.
+// The Azure Resource Group Name specified as part of the Resource ID
+// can be the same, or a different one than the one specified in
+// `.azure.resource_group_name`.
+// Required.
+func (o *AzureUserAssignedManagedIdentity) ResourceID() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.resourceID
+	}
+	return ""
+}
+
+// GetResourceID returns the value of the 'resource_ID' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The Azure Resource ID of the Azure User-Assigned Managed Identity.
+// The managed identity represented must exist before creating or
+// updating the cluster.
+// The Azure Resource Group Name specified as part of the Resource ID
+// must belong to the Azure Subscription specified in `.azure.subscription_id`,
+// and in the same Azure location as the cluster's region.
+// The Azure Resource Group Name specified as part of the Resource ID
+// must be a different Resource Group Name than the one specified in
+// `.azure.managed_resource_group_name`.
+// The Azure Resource Group Name specified as part of the Resource ID
+// can be the same, or a different one than the one specified in
+// `.azure.resource_group_name`.
+// Required.
+func (o *AzureUserAssignedManagedIdentity) GetResourceID() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.resourceID
+	}
+	return
+}
+
+// AzureUserAssignedManagedIdentityListKind is the name of the type used to represent list of objects of
+// type 'azure_user_assigned_managed_identity'.
+const AzureUserAssignedManagedIdentityListKind = "AzureUserAssignedManagedIdentityList"
+
+// AzureUserAssignedManagedIdentityListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_user_assigned_managed_identity'.
+const AzureUserAssignedManagedIdentityListLinkKind = "AzureUserAssignedManagedIdentityListLink"
+
+// AzureUserAssignedManagedIdentityNilKind is the name of the type used to nil lists of objects of
+// type 'azure_user_assigned_managed_identity'.
+const AzureUserAssignedManagedIdentityListNilKind = "AzureUserAssignedManagedIdentityListNil"
+
+// AzureUserAssignedManagedIdentityList is a list of values of the 'azure_user_assigned_managed_identity' type.
+type AzureUserAssignedManagedIdentityList struct {
+	href  string
+	link  bool
+	items []*AzureUserAssignedManagedIdentity
+}
+
+// Len returns the length of the list.
+func (l *AzureUserAssignedManagedIdentityList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureUserAssignedManagedIdentityList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureUserAssignedManagedIdentityList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureUserAssignedManagedIdentityList) SetItems(items []*AzureUserAssignedManagedIdentity) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureUserAssignedManagedIdentityList) Items() []*AzureUserAssignedManagedIdentity {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureUserAssignedManagedIdentityList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureUserAssignedManagedIdentityList) Get(i int) *AzureUserAssignedManagedIdentity {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureUserAssignedManagedIdentityList) Slice() []*AzureUserAssignedManagedIdentity {
+	var slice []*AzureUserAssignedManagedIdentity
+	if l == nil {
+		slice = make([]*AzureUserAssignedManagedIdentity, 0)
+	} else {
+		slice = make([]*AzureUserAssignedManagedIdentity, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureUserAssignedManagedIdentityList) Each(f func(item *AzureUserAssignedManagedIdentity) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureUserAssignedManagedIdentityList) Range(f func(index int, item *AzureUserAssignedManagedIdentity) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureUserAssignedManagedIdentity writes a value of the 'azure_user_assigned_managed_identity' type to the given writer.
+func MarshalAzureUserAssignedManagedIdentity(object *AzureUserAssignedManagedIdentity, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureUserAssignedManagedIdentity(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureUserAssignedManagedIdentity writes a value of the 'azure_user_assigned_managed_identity' type to the given stream.
+func WriteAzureUserAssignedManagedIdentity(object *AzureUserAssignedManagedIdentity, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("resource_id")
+		stream.WriteString(object.resourceID)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureUserAssignedManagedIdentity reads a value of the 'azure_user_assigned_managed_identity' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureUserAssignedManagedIdentity(source interface{}) (object *AzureUserAssignedManagedIdentity, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureUserAssignedManagedIdentity(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureUserAssignedManagedIdentity reads a value of the 'azure_user_assigned_managed_identity' type from the given iterator.
+func ReadAzureUserAssignedManagedIdentity(iterator *jsoniter.Iterator) *AzureUserAssignedManagedIdentity {
+	object := &AzureUserAssignedManagedIdentity{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "resource_id":
+			value := iterator.ReadString()
+			object.resourceID = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/model/aro_hcp/v1alpha1/azure_container_registry_credential_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_credential_type.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The type of credential used for Azure Container Registry image pulls.
+enum AzureContainerRegistryCredentialType {
+	// Uses a user-assigned managed identity for ACR authentication.
+	@json(name = "ManagedIdentity")
+	ManagedIdentity
+}

--- a/model/aro_hcp/v1alpha1/azure_container_registry_credentials_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_credentials_type.model
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Azure Container Registry credentials configuration for an ARO HCP Cluster.
+// Configures authentication for container image pulls from Azure Container
+// Registry (ACR) on Data Plane worker nodes.
+struct AzureContainerRegistryCredentials {
+	// The credential type used for ACR image pulls on Data Plane worker nodes.
+	// Required.
+	Type AzureContainerRegistryCredentialType
+
+	// The user-assigned managed identity used for ACR image pulls
+	// on Data Plane worker nodes.
+	// Required when type is ManagedIdentity.
+	ManagedIdentity AzureUserAssignedManagedIdentity
+}

--- a/model/aro_hcp/v1alpha1/azure_container_registry_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_type.model
@@ -1,0 +1,25 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Azure Container Registry configuration for an ARO HCP Cluster.
+// Configures how Data Plane worker nodes authenticate container image
+// pulls from Azure Container Registry (ACR).
+struct AzureContainerRegistry {
+	// Credentials for authenticating container image pulls from
+	// Azure Container Registry (ACR) on Data Plane worker nodes.
+	// Required.
+	Credentials AzureContainerRegistryCredentials
+}

--- a/model/aro_hcp/v1alpha1/azure_type.model
+++ b/model/aro_hcp/v1alpha1/azure_type.model
@@ -118,6 +118,31 @@ struct Azure {
 	// Readonly
 	OidcIssuerUrl String
 
+	// Configures authentication for container image pulls from Azure
+	// Container Registry (ACR) on Data Plane worker nodes. Only ACR
+	// registries (*.azurecr.io, *.azurecr.cn, *.azurecr.de, *.azurecr.us) are
+	// supported; non-ACR registries are not affected by this
+	// configuration. The identity is not bound to a specific ACR
+	// instance — it authenticates to any ACR the identity has the
+	// AcrPull role assigned on. The customer controls which ACR
+	// instances the identity can pull from via Azure RBAC.
+	// When set, the managed identity is attached to worker virtual
+	// machines and its resource ID is written into the worker cloud
+	// provider config so kubelet's ACR credential provider can
+	// authenticate without image pull secrets.
+	// When not set, no managed identity is attached to worker virtual
+	// machines for ACR and no identity is written into the worker
+	// cloud provider config. The ACR credential provider on worker
+	// nodes has no identity to authenticate with, so image pulls from
+	// private ACR registries will fail unless the workload provides
+	// image pull secrets or another authentication mechanism. Public
+	// ACR images (anonymous pull enabled) are not affected.
+	// Changing this value will trigger a rollout for all existing
+	// NodePools in the cluster.
+	// Optional.
+	// Mutable.
+	ContainerRegistry AzureContainerRegistry
+
     // Vnet Integration Subnet Resource ID is the Azure Resource ID of a pre-existing Azure
     // Subnet used for SWIFT networking (Azure Container Networking Interface).
     // This subnet is delegated to Microsoft.RedHatOpenShift/hcpOpenShiftClusters

--- a/model/aro_hcp/v1alpha1/azure_user_assigned_managed_identity_type.model
+++ b/model/aro_hcp/v1alpha1/azure_user_assigned_managed_identity_type.model
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Identifies a user-assigned managed identity by its ARM resource ID.
+struct AzureUserAssignedManagedIdentity {
+	// The Azure Resource ID of the Azure User-Assigned Managed Identity.
+	// The managed identity represented must exist before creating or
+	// updating the cluster.
+	// The Azure Resource Group Name specified as part of the Resource ID
+	// must belong to the Azure Subscription specified in `.azure.subscription_id`,
+	// and in the same Azure location as the cluster's region.
+	// The Azure Resource Group Name specified as part of the Resource ID
+	// must be a different Resource Group Name than the one specified in
+	// `.azure.managed_resource_group_name`.
+	// The Azure Resource Group Name specified as part of the Resource ID
+	// can be the same, or a different one than the one specified in
+	// `.azure.resource_group_name`.
+	// Required.
+	ResourceID String
+}

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -4026,6 +4026,10 @@
       "Azure": {
         "description": "Microsoft Azure settings of a cluster.",
         "properties": {
+          "container_registry": {
+            "description": "Configures authentication for container image pulls from Azure\nContainer Registry (ACR) on Data Plane worker nodes. Only ACR\nregistries (*.azurecr.io, *.azurecr.cn, *.azurecr.de, *.azurecr.us) are\nsupported; non-ACR registries are not affected by this\nconfiguration. The identity is not bound to a specific ACR\ninstance — it authenticates to any ACR the identity has the\nAcrPull role assigned on. The customer controls which ACR\ninstances the identity can pull from via Azure RBAC.\nWhen set, the managed identity is attached to worker virtual\nmachines and its resource ID is written into the worker cloud\nprovider config so kubelet's ACR credential provider can\nauthenticate without image pull secrets.\nWhen not set, no managed identity is attached to worker virtual\nmachines for ACR and no identity is written into the worker\ncloud provider config. The ACR credential provider on worker\nnodes has no identity to authenticate with, so image pulls from\nprivate ACR registries will fail unless the workload provides\nimage pull secrets or another authentication mechanism. Public\nACR images (anonymous pull enabled) are not affected.\nChanging this value will trigger a rollout for all existing\nNodePools in the cluster.\nOptional.\nMutable.",
+            "$ref": "#/components/schemas/AzureContainerRegistry"
+          },
           "etcd_encryption": {
             "description": "Etcd encryption configuration.\nIf not specified, etcd data is encrypted with platform managed keys.\nCurrently etcd data encryption is only supported with customer managed keys.\nCreating a cluster with platform managed keys will result in a failure creating the cluster.",
             "$ref": "#/components/schemas/AzureEtcdEncryption"
@@ -4073,6 +4077,35 @@
           "vnet_integration_subnet_resource_id": {
             "description": "Vnet Integration Subnet Resource ID is the Azure Resource ID of a pre-existing Azure\nSubnet used for SWIFT networking (Azure Container Networking Interface).\nThis subnet is delegated to Microsoft.RedHatOpenShift/hcpOpenShiftClusters\nvia a Service Association Link and is used for pod networking in the cluster.\nVnet Integration Subnet Resource ID must be located in the same Azure location as the\ncluster's region and in the same VNet as Subnet Resource ID.\nThe Azure Subscription specified as part of the Vnet Integration Subnet Resource ID must\nbe located in the same Azure Subscription as Subscription ID.\nThis field is optional - if not specified, SWIFT networking will not be enabled.\nImmutable.",
             "type": "string"
+          }
+        }
+      },
+      "AzureContainerRegistry": {
+        "description": "Azure Container Registry configuration for an ARO HCP Cluster.\nConfigures how Data Plane worker nodes authenticate container image\npulls from Azure Container Registry (ACR).",
+        "properties": {
+          "credentials": {
+            "description": "Credentials for authenticating container image pulls from\nAzure Container Registry (ACR) on Data Plane worker nodes.\nRequired.",
+            "$ref": "#/components/schemas/AzureContainerRegistryCredentials"
+          }
+        }
+      },
+      "AzureContainerRegistryCredentialType": {
+        "description": "The type of credential used for Azure Container Registry image pulls.",
+        "type": "string",
+        "enum": [
+          "ManagedIdentity"
+        ]
+      },
+      "AzureContainerRegistryCredentials": {
+        "description": "Azure Container Registry credentials configuration for an ARO HCP Cluster.\nConfigures authentication for container image pulls from Azure Container\nRegistry (ACR) on Data Plane worker nodes.",
+        "properties": {
+          "managed_identity": {
+            "description": "The user-assigned managed identity used for ACR image pulls\non Data Plane worker nodes.\nRequired when type is ManagedIdentity.",
+            "$ref": "#/components/schemas/AzureUserAssignedManagedIdentity"
+          },
+          "type": {
+            "description": "The credential type used for ACR image pulls on Data Plane worker nodes.\nRequired.",
+            "$ref": "#/components/schemas/AzureContainerRegistryCredentialType"
           }
         }
       },
@@ -4310,6 +4343,15 @@
           },
           "public_dns_zone_resource_id": {
             "description": "The Azure Public DNS Zone associated to the provision shard.\nIt is the Azure Resource ID of a pre-existing Public DNS Zone.\n`public_dns_zone_resource_id` must be located in the same\nAzure Tenant as the Clusters Service's Azure infrastructure\nThe Azure Resource Group Name specified as part of `public_dns_zone_resource_id`\nmust be in the same Azure location to where Clusters Service is deployed.\nRequired during creation.\nImmutable.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureUserAssignedManagedIdentity": {
+        "description": "Identifies a user-assigned managed identity by its ARM resource ID.",
+        "properties": {
+          "resource_id": {
+            "description": "The Azure Resource ID of the Azure User-Assigned Managed Identity.\nThe managed identity represented must exist before creating or\nupdating the cluster.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust belong to the Azure Subscription specified in `.azure.subscription_id`,\nand in the same Azure location as the cluster's region.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust be a different Resource Group Name than the one specified in\n`.azure.managed_resource_group_name`.\nThe Azure Resource Group Name specified as part of the Resource ID\ncan be the same, or a different one than the one specified in\n`.azure.resource_group_name`.\nRequired.",
             "type": "string"
           }
         }


### PR DESCRIPTION
## Description

Required for the ACR Pull with MI feature to be plumbed.

Data flow:

1. RP receives acrPullIdentity (ARM resource ID of a user-assigned managed identity)
2. RP converts to Azure.ImageRegistryCredentials.ManagedIdentityResourceId via OCM SDK
3. CS stores it and sets it on the HyperShift HostedCluster CR
4. HyperShift attaches the MI to worker VMSS and writes it into worker cloud.conf
5. Kubelet's ACR credential provider uses the MI to authenticate image pulls from ACR

Why a new type: No existing OCM model type carries a managed identity resource ID for image registry authentication.

Feature https://redhat.atlassian.net/browse/ARO-24037
Implementation https://redhat.atlassian.net/browse/ARO-25891

<!-- Briefly describe what model or tooling changes this PR introduces and why. -->
<!-- For model changes, reference the Jira ticket (e.g., OCM-XXXXX). -->

## Type of Change

- [x] Model change (new or modified types, resources, methods, or parameters)
- [x] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [ ] CI/CD or tooling change

## Verification

- [x] `make check` passes (model syntax validation)
- [x] `make verify` passes (generated code matches model)
- [x] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)
