### PR TITLE
OCM-24824 | feat: Expose the number of nodes managed by AutoNode in t…

### DIFF
--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_builder.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_builder.go
@@ -23,12 +23,13 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 type ClusterAutoNodeStatusBuilder struct {
 	fieldSet_ []bool
 	message   string
+	nodeCount int
 }
 
 // NewClusterAutoNodeStatus creates a new builder of 'cluster_auto_node_status' objects.
 func NewClusterAutoNodeStatus() *ClusterAutoNodeStatusBuilder {
 	return &ClusterAutoNodeStatusBuilder{
-		fieldSet_: make([]bool, 1),
+		fieldSet_: make([]bool, 2),
 	}
 }
 
@@ -48,10 +49,20 @@ func (b *ClusterAutoNodeStatusBuilder) Empty() bool {
 // Message sets the value of the 'message' attribute to the given value.
 func (b *ClusterAutoNodeStatusBuilder) Message(value string) *ClusterAutoNodeStatusBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 1)
+		b.fieldSet_ = make([]bool, 2)
 	}
 	b.message = value
 	b.fieldSet_[0] = true
+	return b
+}
+
+// NodeCount sets the value of the 'node_count' attribute to the given value.
+func (b *ClusterAutoNodeStatusBuilder) NodeCount(value int) *ClusterAutoNodeStatusBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.nodeCount = value
+	b.fieldSet_[1] = true
 	return b
 }
 
@@ -65,6 +76,7 @@ func (b *ClusterAutoNodeStatusBuilder) Copy(object *ClusterAutoNodeStatus) *Clus
 		copy(b.fieldSet_, object.fieldSet_)
 	}
 	b.message = object.message
+	b.nodeCount = object.nodeCount
 	return b
 }
 
@@ -76,5 +88,6 @@ func (b *ClusterAutoNodeStatusBuilder) Build() (object *ClusterAutoNodeStatus, e
 		copy(object.fieldSet_, b.fieldSet_)
 	}
 	object.message = b.message
+	object.nodeCount = b.nodeCount
 	return
 }

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_type.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_type.go
@@ -25,6 +25,7 @@ package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v
 type ClusterAutoNodeStatus struct {
 	fieldSet_ []bool
 	message   string
+	nodeCount int
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -59,6 +60,29 @@ func (o *ClusterAutoNodeStatus) GetMessage() (value string, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
 	if ok {
 		value = o.message
+	}
+	return
+}
+
+// NodeCount returns the value of the 'node_count' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The number of Nodes AutoNode has provisioned in the cluster
+func (o *ClusterAutoNodeStatus) NodeCount() int {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.nodeCount
+	}
+	return 0
+}
+
+// GetNodeCount returns the value of the 'node_count' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The number of Nodes AutoNode has provisioned in the cluster
+func (o *ClusterAutoNodeStatus) GetNodeCount() (value int, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.nodeCount
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/cluster_auto_node_status_type_json.go
+++ b/clientapi/clustersmgmt/v1/cluster_auto_node_status_type_json.go
@@ -49,6 +49,15 @@ func WriteClusterAutoNodeStatus(object *ClusterAutoNodeStatus, stream *jsoniter.
 		}
 		stream.WriteObjectField("message")
 		stream.WriteString(object.message)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("node_count")
+		stream.WriteInt(object.nodeCount)
 	}
 	stream.WriteObjectEnd()
 }
@@ -68,7 +77,7 @@ func UnmarshalClusterAutoNodeStatus(source interface{}) (object *ClusterAutoNode
 // ReadClusterAutoNodeStatus reads a value of the 'cluster_auto_node_status' type from the given iterator.
 func ReadClusterAutoNodeStatus(iterator *jsoniter.Iterator) *ClusterAutoNodeStatus {
 	object := &ClusterAutoNodeStatus{
-		fieldSet_: make([]bool, 1),
+		fieldSet_: make([]bool, 2),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -80,6 +89,10 @@ func ReadClusterAutoNodeStatus(iterator *jsoniter.Iterator) *ClusterAutoNodeStat
 			value := iterator.ReadString()
 			object.message = value
 			object.fieldSet_[0] = true
+		case "node_count":
+			value := iterator.ReadInt()
+			object.nodeCount = value
+			object.fieldSet_[1] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/cluster_autonode_type.model
+++ b/model/clusters_mgmt/v1/cluster_autonode_type.model
@@ -26,4 +26,6 @@ struct ClusterAutoNode {
 struct ClusterAutoNodeStatus {
     // Messages relating to the status of the AutoNode installation on this Cluster
     Message String
+    // The number of Nodes AutoNode has provisioned in the cluster
+    NodeCount Integer
 }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16884,6 +16884,11 @@
           "message": {
             "description": "Messages relating to the status of the AutoNode installation on this Cluster",
             "type": "string"
+          },
+          "node_count": {
+            "description": "The number of Nodes AutoNode has provisioned in the cluster",
+            "type": "integer",
+            "format": "int32"
           }
         }
       },


### PR DESCRIPTION
…he cluster

## Description

This MR adds a single addition field into the `cluster.auto_node.status` object that exposes the number of nodes that are currently managed in the cluster by AutoNode (karpenter). This provides additional information to users of AutoNode as to the state of their usage, particularly when browsing via console.redhat.com

## Type of Change

- [X] Model change (new or modified types, resources, methods, or parameters)
- [X] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [ ] CI/CD or tooling change

## Verification

- [ ] `make check` passes (model syntax validation)
- [ ] `make verify` passes (generated code matches model)
- [ ] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)
