### PR TITLE
ci: add automated release pipeline

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -1,0 +1,138 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Auto-tag on merge
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'model/**'
+      - 'clientapi/**'
+      - 'metamodel_generator/**'
+
+concurrency:
+  group: auto-tag-main
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    name: Create release tags
+    runs-on: ubuntu-latest
+    # Skip if the commit is a release commit (avoid infinite loop)
+    if: "!startsWith(github.event.head_commit.message, 'Release v')"
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Use PAT instead of GITHUB_TOKEN so that tag pushes trigger
+          # downstream workflows (publish-release, sync-sdk).
+          # GITHUB_TOKEN events don't trigger other workflows by design.
+          token: ${{ secrets.OCM_SDK_SYNC_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine next version
+        id: version
+        run: |
+          # Get the latest root tag
+          LATEST=$(git tag -l 'v0.0.*' --sort=-version:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "next=v0.0.1" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Extract patch number and bump
+          PATCH=$(echo "$LATEST" | sed 's/v0\.0\.//')
+          NEXT=$((PATCH + 1))
+          echo "next=v0.0.${NEXT}" >> "$GITHUB_OUTPUT"
+          echo "Latest tag: ${LATEST}, next: v0.0.${NEXT}"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Regenerate clientapi and openapi
+        run: make update
+
+      - name: Update CHANGES.md
+        env:
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          VERSION_NUM="${VERSION#v}"
+          DATE=$(date '+%b %d %Y')
+
+          # Collect commit messages since last tag
+          LATEST_TAG=$(git tag -l 'v0.0.*' --sort=-version:refname | head -1)
+          CHANGES_FILE=$(mktemp)
+          if [ -n "$LATEST_TAG" ]; then
+            git log "${LATEST_TAG}..HEAD" --pretty=format:"- %s" \
+              --no-merges > "$CHANGES_FILE"
+          fi
+          if [ ! -s "$CHANGES_FILE" ]; then
+            git log -1 --format="- %s" > "$CHANGES_FILE"
+          fi
+
+          # Build new CHANGES.md with the entry inserted after the header
+          {
+            echo "# Changes"
+            echo ""
+            echo "This document describes the relevant changes between releases of the API model."
+            echo ""
+            echo "## ${VERSION_NUM} ${DATE}"
+            cat "$CHANGES_FILE"
+            echo ""
+            # Append everything after the original header block
+            tail -n +4 CHANGES.md
+          } > CHANGES.md.new
+          mv CHANGES.md.new CHANGES.md
+          rm -f "$CHANGES_FILE"
+
+      - name: Commit and tag
+        env:
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGES.md clientapi/ openapi/
+          git commit -m "Release ${VERSION}" || echo "No changes to commit"
+
+          # Create all 4 tags on this commit (Go multi-module convention)
+          git tag "${VERSION}"
+          git tag "clientapi/${VERSION}"
+          git tag "model/${VERSION}"
+          git tag "metamodel_generator/${VERSION}"
+
+          git push --atomic origin main --tags
+
+      - name: Create release
+        env:
+          VERSION: ${{ steps.version.outputs.next }}
+          GH_TOKEN: ${{ secrets.OCM_SDK_SYNC_TOKEN }}
+        run: |
+          VERSION_NUM="${VERSION#v}"
+
+          # Extract changelog for this version from CHANGES.md
+          NOTES=$(sed -n "/^## ${VERSION_NUM} /,/^## /{ /^## ${VERSION_NUM} /d; /^## /d; p; }" CHANGES.md)
+
+          gh release create "${VERSION}" \
+            --title "Release ${VERSION_NUM}" \
+            --notes "${NOTES}" \
+            --target main

--- a/.github/workflows/sync-sdk.yaml
+++ b/.github/workflows/sync-sdk.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Notify SDK
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  notify-sdk:
+    name: Trigger SDK update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository dispatch to ocm-sdk-go
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.OCM_SDK_SYNC_TOKEN }}
+          repository: openshift-online/ocm-sdk-go
+          event-type: model-updated
+          client-payload: >-
+            {
+              "version": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}"
+            }

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ clientapi: metamodel goimports-install
 		--generators=types,builders,json \
 		--base=github.com/openshift-online/ocm-api-model/clientapi \
 		--output=clientapi
-	pushd clientapi; go mod tidy; popd
+	cd clientapi && go mod tidy
 
 verify-clientapi: metamodel goimports-install
 	$(eval TMPDIR := $(shell mktemp -d))

--- a/README.md
+++ b/README.md
@@ -56,17 +56,23 @@ also known as the _model_.
 
 ## Releasing a new OCM API Model version
 
-To use any updates to the [ocm-api-model](https://github.com/openshift-online/ocm-api-model), the version
-must be incremented for consumption in ocm-sdk-go generation. The version is defined by the release.
+### Automated (recommended)
 
-Once all changes to the OCM API Model have been defined and reviewed, the client types for the model need to be generated via the `make update` target
-in the `ocm-api-model` project.
+When model changes merge to main, the release pipeline runs automatically:
 
-Once all changes to the OCM API Model have been committed to the main branch, you will need to create a git tag for the changes in the ocm-api-model.
+1. **Auto-tag** — bumps the patch version, regenerates `clientapi/` and `openapi/`, updates `CHANGES.md`, creates all sub-module tags, and publishes a GitHub Release.
+2. **SDK sync** — the release triggers a PR in [ocm-sdk-go](https://github.com/openshift-online/ocm-sdk-go) with the bumped dependency and regenerated SDK code.
 
-To do that you can use a dedicated make target:
+No manual steps required beyond merging the model change PR.
 
-```
+### Manual
+
+If the automation is not available, follow these steps:
+
+1. Generate the client types: `make update`
+2. Create and push release tags:
+
+```shell
 make release VERSION=<vX.Y.Z>
 ```
 


### PR DESCRIPTION
- auto-tag.yaml: bumps patch version, updates CHANGES.md, pushes all 4 sub-module tags, and creates a GitHub Release on merge to main when model/ changes. Uses PAT for tag push and release creation to trigger downstream workflows.

- sync-sdk.yaml: sends repository_dispatch to ocm-sdk-go on release, triggering SDK regeneration. Auto-detects forks.

## Description

<!-- Briefly describe what model or tooling changes this PR introduces and why. -->
<!-- For model changes, reference the Jira ticket (e.g., OCM-XXXXX). -->

## Type of Change

- [ ] Model change (new or modified types, resources, methods, or parameters)
- [ ] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [x] CI/CD or tooling change

## Verification

- [x] `make check` passes (model syntax validation)
- [x] `make verify` passes (generated code matches model)
- [x] `make lint` passes (indentation enforcement)

## Checklist

- [x] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [x] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)
