### PR TITLE
fix: relax subscription and location constraints on ACR pull managed identity

### DIFF
--- a/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_container_registry_credentials_type.go
@@ -48,6 +48,13 @@ func (o *AzureContainerRegistryCredentials) Empty() bool {
 //
 // The user-assigned managed identity used for ACR image pulls
 // on Data Plane worker nodes.
+// The managed identity must be in the same Microsoft Entra tenant
+// as the cluster's Azure Subscription.
+// The managed identity can be in any Azure Subscription or location
+// within the tenant.
+// The Azure Resource Group Name specified as part of the Resource ID
+// must be a different Resource Group Name than the one specified in
+// `.azure.managed_resource_group_name`.
 // Required when type is ManagedIdentity.
 func (o *AzureContainerRegistryCredentials) ManagedIdentity() *AzureUserAssignedManagedIdentity {
 	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
@@ -61,6 +68,13 @@ func (o *AzureContainerRegistryCredentials) ManagedIdentity() *AzureUserAssigned
 //
 // The user-assigned managed identity used for ACR image pulls
 // on Data Plane worker nodes.
+// The managed identity must be in the same Microsoft Entra tenant
+// as the cluster's Azure Subscription.
+// The managed identity can be in any Azure Subscription or location
+// within the tenant.
+// The Azure Resource Group Name specified as part of the Resource ID
+// must be a different Resource Group Name than the one specified in
+// `.azure.managed_resource_group_name`.
 // Required when type is ManagedIdentity.
 func (o *AzureContainerRegistryCredentials) GetManagedIdentity() (value *AzureUserAssignedManagedIdentity, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]

--- a/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_user_assigned_managed_identity_type.go
@@ -46,15 +46,6 @@ func (o *AzureUserAssignedManagedIdentity) Empty() bool {
 // The Azure Resource ID of the Azure User-Assigned Managed Identity.
 // The managed identity represented must exist before creating or
 // updating the cluster.
-// The Azure Resource Group Name specified as part of the Resource ID
-// must belong to the Azure Subscription specified in `.azure.subscription_id`,
-// and in the same Azure location as the cluster's region.
-// The Azure Resource Group Name specified as part of the Resource ID
-// must be a different Resource Group Name than the one specified in
-// `.azure.managed_resource_group_name`.
-// The Azure Resource Group Name specified as part of the Resource ID
-// can be the same, or a different one than the one specified in
-// `.azure.resource_group_name`.
 // Required.
 func (o *AzureUserAssignedManagedIdentity) ResourceID() string {
 	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
@@ -69,15 +60,6 @@ func (o *AzureUserAssignedManagedIdentity) ResourceID() string {
 // The Azure Resource ID of the Azure User-Assigned Managed Identity.
 // The managed identity represented must exist before creating or
 // updating the cluster.
-// The Azure Resource Group Name specified as part of the Resource ID
-// must belong to the Azure Subscription specified in `.azure.subscription_id`,
-// and in the same Azure location as the cluster's region.
-// The Azure Resource Group Name specified as part of the Resource ID
-// must be a different Resource Group Name than the one specified in
-// `.azure.managed_resource_group_name`.
-// The Azure Resource Group Name specified as part of the Resource ID
-// can be the same, or a different one than the one specified in
-// `.azure.resource_group_name`.
 // Required.
 func (o *AzureUserAssignedManagedIdentity) GetResourceID() (value string, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]

--- a/model/aro_hcp/v1alpha1/azure_container_registry_credentials_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_credentials_type.model
@@ -24,6 +24,13 @@ struct AzureContainerRegistryCredentials {
 
 	// The user-assigned managed identity used for ACR image pulls
 	// on Data Plane worker nodes.
+	// The managed identity must be in the same Microsoft Entra tenant
+	// as the cluster's Azure Subscription.
+	// The managed identity can be in any Azure Subscription or location
+	// within the tenant.
+	// The Azure Resource Group Name specified as part of the Resource ID
+	// must be a different Resource Group Name than the one specified in
+	// `.azure.managed_resource_group_name`.
 	// Required when type is ManagedIdentity.
 	ManagedIdentity AzureUserAssignedManagedIdentity
 }

--- a/model/aro_hcp/v1alpha1/azure_user_assigned_managed_identity_type.model
+++ b/model/aro_hcp/v1alpha1/azure_user_assigned_managed_identity_type.model
@@ -19,15 +19,6 @@ struct AzureUserAssignedManagedIdentity {
 	// The Azure Resource ID of the Azure User-Assigned Managed Identity.
 	// The managed identity represented must exist before creating or
 	// updating the cluster.
-	// The Azure Resource Group Name specified as part of the Resource ID
-	// must belong to the Azure Subscription specified in `.azure.subscription_id`,
-	// and in the same Azure location as the cluster's region.
-	// The Azure Resource Group Name specified as part of the Resource ID
-	// must be a different Resource Group Name than the one specified in
-	// `.azure.managed_resource_group_name`.
-	// The Azure Resource Group Name specified as part of the Resource ID
-	// can be the same, or a different one than the one specified in
-	// `.azure.resource_group_name`.
 	// Required.
 	ResourceID String
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -4100,7 +4100,7 @@
         "description": "Azure Container Registry credentials configuration for an ARO HCP Cluster.\nConfigures authentication for container image pulls from Azure Container\nRegistry (ACR) on Data Plane worker nodes.",
         "properties": {
           "managed_identity": {
-            "description": "The user-assigned managed identity used for ACR image pulls\non Data Plane worker nodes.\nRequired when type is ManagedIdentity.",
+            "description": "The user-assigned managed identity used for ACR image pulls\non Data Plane worker nodes.\nThe managed identity must be in the same Microsoft Entra tenant\nas the cluster's Azure Subscription.\nThe managed identity can be in any Azure Subscription or location\nwithin the tenant.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust be a different Resource Group Name than the one specified in\n`.azure.managed_resource_group_name`.\nRequired when type is ManagedIdentity.",
             "$ref": "#/components/schemas/AzureUserAssignedManagedIdentity"
           },
           "type": {
@@ -4351,7 +4351,7 @@
         "description": "Identifies a user-assigned managed identity by its ARM resource ID.",
         "properties": {
           "resource_id": {
-            "description": "The Azure Resource ID of the Azure User-Assigned Managed Identity.\nThe managed identity represented must exist before creating or\nupdating the cluster.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust belong to the Azure Subscription specified in `.azure.subscription_id`,\nand in the same Azure location as the cluster's region.\nThe Azure Resource Group Name specified as part of the Resource ID\nmust be a different Resource Group Name than the one specified in\n`.azure.managed_resource_group_name`.\nThe Azure Resource Group Name specified as part of the Resource ID\ncan be the same, or a different one than the one specified in\n`.azure.resource_group_name`.\nRequired.",
+            "description": "The Azure Resource ID of the Azure User-Assigned Managed Identity.\nThe managed identity represented must exist before creating or\nupdating the cluster.\nRequired.",
             "type": "string"
           }
         }


### PR DESCRIPTION
The managed identity for ACR pulls is customer-owned and passed through to CAPZ. Azure enforces regional isolation via the MI's isolationScope property, and cross-subscription attachment is supported within the same tenant. Remove same-subscription and same-location constraints from the model, keeping only same-tenant and different-MRG requirements.

Feature https://redhat.atlassian.net/browse/ARO-24037
Implementation https://redhat.atlassian.net/browse/ARO-25891

## Type of Change

- [X] Documentation update

## Verification

- [X] `make check` passes (model syntax validation)
- [X] `make verify` passes (generated code matches model)
- [X] `make lint` passes (indentation enforcement)

## Checklist

- [X] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [X] Documentation comments use Markdown format
- [X] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)