### PR TITLE
ARO-HCP: Add Resources subresource to Cluster resource

### DIFF
--- a/model/aro_hcp/v1alpha1/cluster_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_resource.model
@@ -74,4 +74,9 @@ resource Cluster {
 	locator ControlPlaneUpgradePolicies {
 		target ControlPlaneUpgradePolicies
 	}
+
+	// Reference to cluster resources.
+	locator Resources {
+	    target Resources
+	}
 }

--- a/model/aro_hcp/v1alpha1/resources_resource.model
+++ b/model/aro_hcp/v1alpha1/resources_resource.model
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages a collection of resources for a cluster
+resource Resources {
+    // Retrieves a list of resources for a cluster in error state
+    method Get {
+        // List of cluster resources
+        out Body ClusterResources
+    }
+}

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -1705,6 +1705,43 @@
         }
       }
     },
+    "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/resources": {
+      "get": {
+        "description": "Retrieves a list of resources for a cluster in error state",
+        "parameters": [
+          {
+            "name": "cluster_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClusterResources"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/aro_hcp/v1alpha1/clusters/{cluster_id}/status": {
       "get": {
         "parameters": [


### PR DESCRIPTION
## Description

JIRA: https://redhat.atlassian.net/browse/ARO-27920

## Type of Change

- [x] Model change (new or modified types, resources, methods, or parameters)
- [x] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [x] Documentation update
- [ ] CI/CD or tooling change

## Verification

- [ ] `make check` passes (model syntax validation)
- [x] `make verify` passes (generated code matches model)
- [x] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new API endpoint to retrieve a list of cluster resources currently in an error state
* New Resources subresource now available, providing explicit management capabilities for cluster resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->