### PR TITLE
ROSAENG-61032 | task: ocm-api/sdk changes to support SpotMarketOptions for ROSA HCP

### DIFF
--- a/clientapi/clustersmgmt/v1/aws_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_builder.go
@@ -40,9 +40,9 @@ type AWSBuilder struct {
 	privateHostedZoneRoleARN               string
 	privateLinkConfiguration               *PrivateLinkClusterConfigurationBuilder
 	secretAccessKey                        string
-	spotTerminationHandlerQueueUrl         string
 	subnetIDs                              []string
 	tags                                   map[string]string
+	terminationHandlerQueueUrl             string
 	vpcEndpointRoleArn                     string
 	zeroEgress                             *ZeroEgressBuilder
 	privateLink                            bool
@@ -294,16 +294,6 @@ func (b *AWSBuilder) SecretAccessKey(value string) *AWSBuilder {
 	return b
 }
 
-// SpotTerminationHandlerQueueUrl sets the value of the 'spot_termination_handler_queue_url' attribute to the given value.
-func (b *AWSBuilder) SpotTerminationHandlerQueueUrl(value string) *AWSBuilder {
-	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 24)
-	}
-	b.spotTerminationHandlerQueueUrl = value
-	b.fieldSet_[19] = true
-	return b
-}
-
 // SubnetIDs sets the value of the 'subnet_IDs' attribute to the given values.
 func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
@@ -311,7 +301,7 @@ func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 	}
 	b.subnetIDs = make([]string, len(values))
 	copy(b.subnetIDs, values)
-	b.fieldSet_[20] = true
+	b.fieldSet_[19] = true
 	return b
 }
 
@@ -322,10 +312,20 @@ func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 	}
 	b.tags = value
 	if value != nil {
-		b.fieldSet_[21] = true
+		b.fieldSet_[20] = true
 	} else {
-		b.fieldSet_[21] = false
+		b.fieldSet_[20] = false
 	}
+	return b
+}
+
+// TerminationHandlerQueueUrl sets the value of the 'termination_handler_queue_url' attribute to the given value.
+func (b *AWSBuilder) TerminationHandlerQueueUrl(value string) *AWSBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 24)
+	}
+	b.terminationHandlerQueueUrl = value
+	b.fieldSet_[21] = true
 	return b
 }
 
@@ -423,7 +423,6 @@ func (b *AWSBuilder) Copy(object *AWS) *AWSBuilder {
 		b.privateLinkConfiguration = nil
 	}
 	b.secretAccessKey = object.secretAccessKey
-	b.spotTerminationHandlerQueueUrl = object.spotTerminationHandlerQueueUrl
 	if object.subnetIDs != nil {
 		b.subnetIDs = make([]string, len(object.subnetIDs))
 		copy(b.subnetIDs, object.subnetIDs)
@@ -438,6 +437,7 @@ func (b *AWSBuilder) Copy(object *AWS) *AWSBuilder {
 	} else {
 		b.tags = nil
 	}
+	b.terminationHandlerQueueUrl = object.terminationHandlerQueueUrl
 	b.vpcEndpointRoleArn = object.vpcEndpointRoleArn
 	if object.zeroEgress != nil {
 		b.zeroEgress = NewZeroEgress().Copy(object.zeroEgress)
@@ -510,7 +510,6 @@ func (b *AWSBuilder) Build() (object *AWS, err error) {
 		}
 	}
 	object.secretAccessKey = b.secretAccessKey
-	object.spotTerminationHandlerQueueUrl = b.spotTerminationHandlerQueueUrl
 	if b.subnetIDs != nil {
 		object.subnetIDs = make([]string, len(b.subnetIDs))
 		copy(object.subnetIDs, b.subnetIDs)
@@ -521,6 +520,7 @@ func (b *AWSBuilder) Build() (object *AWS, err error) {
 			object.tags[k] = v
 		}
 	}
+	object.terminationHandlerQueueUrl = b.terminationHandlerQueueUrl
 	object.vpcEndpointRoleArn = b.vpcEndpointRoleArn
 	if b.zeroEgress != nil {
 		object.zeroEgress, err = b.zeroEgress.Build()

--- a/clientapi/clustersmgmt/v1/aws_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_builder.go
@@ -40,6 +40,7 @@ type AWSBuilder struct {
 	privateHostedZoneRoleARN               string
 	privateLinkConfiguration               *PrivateLinkClusterConfigurationBuilder
 	secretAccessKey                        string
+	spotTerminationHandlerQueueUrl         string
 	subnetIDs                              []string
 	tags                                   map[string]string
 	vpcEndpointRoleArn                     string
@@ -50,7 +51,7 @@ type AWSBuilder struct {
 // NewAWS creates a new builder of 'AWS' objects.
 func NewAWS() *AWSBuilder {
 	return &AWSBuilder{
-		fieldSet_: make([]bool, 23),
+		fieldSet_: make([]bool, 24),
 	}
 }
 
@@ -70,7 +71,7 @@ func (b *AWSBuilder) Empty() bool {
 // KMSKeyArn sets the value of the 'KMS_key_arn' attribute to the given value.
 func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.kmsKeyArn = value
 	b.fieldSet_[0] = true
@@ -82,7 +83,7 @@ func (b *AWSBuilder) KMSKeyArn(value string) *AWSBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.sts = value
 	if value != nil {
@@ -96,7 +97,7 @@ func (b *AWSBuilder) STS(value *STSBuilder) *AWSBuilder {
 // AccessKeyID sets the value of the 'access_key_ID' attribute to the given value.
 func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.accessKeyID = value
 	b.fieldSet_[2] = true
@@ -106,7 +107,7 @@ func (b *AWSBuilder) AccessKeyID(value string) *AWSBuilder {
 // AccountID sets the value of the 'account_ID' attribute to the given value.
 func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.accountID = value
 	b.fieldSet_[3] = true
@@ -116,7 +117,7 @@ func (b *AWSBuilder) AccountID(value string) *AWSBuilder {
 // AdditionalAllowedPrincipals sets the value of the 'additional_allowed_principals' attribute to the given values.
 func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.additionalAllowedPrincipals = make([]string, len(values))
 	copy(b.additionalAllowedPrincipals, values)
@@ -127,7 +128,7 @@ func (b *AWSBuilder) AdditionalAllowedPrincipals(values ...string) *AWSBuilder {
 // AdditionalComputeSecurityGroupIds sets the value of the 'additional_compute_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.additionalComputeSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalComputeSecurityGroupIds, values)
@@ -138,7 +139,7 @@ func (b *AWSBuilder) AdditionalComputeSecurityGroupIds(values ...string) *AWSBui
 // AdditionalControlPlaneSecurityGroupIds sets the value of the 'additional_control_plane_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.additionalControlPlaneSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalControlPlaneSecurityGroupIds, values)
@@ -149,7 +150,7 @@ func (b *AWSBuilder) AdditionalControlPlaneSecurityGroupIds(values ...string) *A
 // AdditionalInfraSecurityGroupIds sets the value of the 'additional_infra_security_group_ids' attribute to the given values.
 func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.additionalInfraSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalInfraSecurityGroupIds, values)
@@ -162,7 +163,7 @@ func (b *AWSBuilder) AdditionalInfraSecurityGroupIds(values ...string) *AWSBuild
 // Contains the necessary attributes to support audit log forwarding
 func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.auditLog = value
 	if value != nil {
@@ -178,7 +179,7 @@ func (b *AWSBuilder) AuditLog(value *AuditLogBuilder) *AWSBuilder {
 // AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
 func (b *AWSBuilder) AutoNode(value *AwsAutoNodeBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.autoNode = value
 	if value != nil {
@@ -192,7 +193,7 @@ func (b *AWSBuilder) AutoNode(value *AwsAutoNodeBuilder) *AWSBuilder {
 // BillingAccountID sets the value of the 'billing_account_ID' attribute to the given value.
 func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.billingAccountID = value
 	b.fieldSet_[10] = true
@@ -204,7 +205,7 @@ func (b *AWSBuilder) BillingAccountID(value string) *AWSBuilder {
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.ec2MetadataHttpTokens = value
 	b.fieldSet_[11] = true
@@ -216,7 +217,7 @@ func (b *AWSBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSBuil
 // Contains the necessary attributes to support etcd encryption for AWS based clusters.
 func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.etcdEncryption = value
 	if value != nil {
@@ -230,7 +231,7 @@ func (b *AWSBuilder) EtcdEncryption(value *AwsEtcdEncryptionBuilder) *AWSBuilder
 // HcpInternalCommunicationHostedZoneId sets the value of the 'hcp_internal_communication_hosted_zone_id' attribute to the given value.
 func (b *AWSBuilder) HcpInternalCommunicationHostedZoneId(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.hcpInternalCommunicationHostedZoneId = value
 	b.fieldSet_[13] = true
@@ -240,7 +241,7 @@ func (b *AWSBuilder) HcpInternalCommunicationHostedZoneId(value string) *AWSBuil
 // PrivateHostedZoneID sets the value of the 'private_hosted_zone_ID' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneID(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.privateHostedZoneID = value
 	b.fieldSet_[14] = true
@@ -250,7 +251,7 @@ func (b *AWSBuilder) PrivateHostedZoneID(value string) *AWSBuilder {
 // PrivateHostedZoneRoleARN sets the value of the 'private_hosted_zone_role_ARN' attribute to the given value.
 func (b *AWSBuilder) PrivateHostedZoneRoleARN(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.privateHostedZoneRoleARN = value
 	b.fieldSet_[15] = true
@@ -260,7 +261,7 @@ func (b *AWSBuilder) PrivateHostedZoneRoleARN(value string) *AWSBuilder {
 // PrivateLink sets the value of the 'private_link' attribute to the given value.
 func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.privateLink = value
 	b.fieldSet_[16] = true
@@ -272,7 +273,7 @@ func (b *AWSBuilder) PrivateLink(value bool) *AWSBuilder {
 // Manages the configuration for the Private Links.
 func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigurationBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.privateLinkConfiguration = value
 	if value != nil {
@@ -286,34 +287,44 @@ func (b *AWSBuilder) PrivateLinkConfiguration(value *PrivateLinkClusterConfigura
 // SecretAccessKey sets the value of the 'secret_access_key' attribute to the given value.
 func (b *AWSBuilder) SecretAccessKey(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.secretAccessKey = value
 	b.fieldSet_[18] = true
 	return b
 }
 
+// SpotTerminationHandlerQueueUrl sets the value of the 'spot_termination_handler_queue_url' attribute to the given value.
+func (b *AWSBuilder) SpotTerminationHandlerQueueUrl(value string) *AWSBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 24)
+	}
+	b.spotTerminationHandlerQueueUrl = value
+	b.fieldSet_[19] = true
+	return b
+}
+
 // SubnetIDs sets the value of the 'subnet_IDs' attribute to the given values.
 func (b *AWSBuilder) SubnetIDs(values ...string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.subnetIDs = make([]string, len(values))
 	copy(b.subnetIDs, values)
-	b.fieldSet_[19] = true
+	b.fieldSet_[20] = true
 	return b
 }
 
 // Tags sets the value of the 'tags' attribute to the given value.
 func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.tags = value
 	if value != nil {
-		b.fieldSet_[20] = true
+		b.fieldSet_[21] = true
 	} else {
-		b.fieldSet_[20] = false
+		b.fieldSet_[21] = false
 	}
 	return b
 }
@@ -321,10 +332,10 @@ func (b *AWSBuilder) Tags(value map[string]string) *AWSBuilder {
 // VpcEndpointRoleArn sets the value of the 'vpc_endpoint_role_arn' attribute to the given value.
 func (b *AWSBuilder) VpcEndpointRoleArn(value string) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.vpcEndpointRoleArn = value
-	b.fieldSet_[21] = true
+	b.fieldSet_[22] = true
 	return b
 }
 
@@ -333,13 +344,13 @@ func (b *AWSBuilder) VpcEndpointRoleArn(value string) *AWSBuilder {
 // Zero egress configuration.
 func (b *AWSBuilder) ZeroEgress(value *ZeroEgressBuilder) *AWSBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 23)
+		b.fieldSet_ = make([]bool, 24)
 	}
 	b.zeroEgress = value
 	if value != nil {
-		b.fieldSet_[22] = true
+		b.fieldSet_[23] = true
 	} else {
-		b.fieldSet_[22] = false
+		b.fieldSet_[23] = false
 	}
 	return b
 }
@@ -412,6 +423,7 @@ func (b *AWSBuilder) Copy(object *AWS) *AWSBuilder {
 		b.privateLinkConfiguration = nil
 	}
 	b.secretAccessKey = object.secretAccessKey
+	b.spotTerminationHandlerQueueUrl = object.spotTerminationHandlerQueueUrl
 	if object.subnetIDs != nil {
 		b.subnetIDs = make([]string, len(object.subnetIDs))
 		copy(b.subnetIDs, object.subnetIDs)
@@ -498,6 +510,7 @@ func (b *AWSBuilder) Build() (object *AWS, err error) {
 		}
 	}
 	object.secretAccessKey = b.secretAccessKey
+	object.spotTerminationHandlerQueueUrl = b.spotTerminationHandlerQueueUrl
 	if b.subnetIDs != nil {
 		object.subnetIDs = make([]string, len(b.subnetIDs))
 		copy(object.subnetIDs, b.subnetIDs)

--- a/clientapi/clustersmgmt/v1/aws_node_pool_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_builder.go
@@ -31,7 +31,7 @@ type AWSNodePoolBuilder struct {
 	instanceProfile            string
 	instanceType               string
 	rootVolume                 *AWSVolumeBuilder
-	spotMarketOptions          *AWSSpotMarketOptionsBuilder
+	spotMarketOptions          *AwsNodePoolSpotMarketOptionsBuilder
 	subnetOutposts             map[string]string
 	tags                       map[string]string
 }
@@ -177,8 +177,8 @@ func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBui
 
 // SpotMarketOptions sets the value of the 'spot_market_options' attribute to the given value.
 //
-// Spot market options for AWS machine pool.
-func (b *AWSNodePoolBuilder) SpotMarketOptions(value *AWSSpotMarketOptionsBuilder) *AWSNodePoolBuilder {
+// Spot market options for AWS node pool.
+func (b *AWSNodePoolBuilder) SpotMarketOptions(value *AwsNodePoolSpotMarketOptionsBuilder) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
 		b.fieldSet_ = make([]bool, 13)
 	}
@@ -258,7 +258,7 @@ func (b *AWSNodePoolBuilder) Copy(object *AWSNodePool) *AWSNodePoolBuilder {
 		b.rootVolume = nil
 	}
 	if object.spotMarketOptions != nil {
-		b.spotMarketOptions = NewAWSSpotMarketOptions().Copy(object.spotMarketOptions)
+		b.spotMarketOptions = NewAwsNodePoolSpotMarketOptions().Copy(object.spotMarketOptions)
 	} else {
 		b.spotMarketOptions = nil
 	}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_builder.go
@@ -31,6 +31,7 @@ type AWSNodePoolBuilder struct {
 	instanceProfile            string
 	instanceType               string
 	rootVolume                 *AWSVolumeBuilder
+	spotMarketOptions          *AWSSpotMarketOptionsBuilder
 	subnetOutposts             map[string]string
 	tags                       map[string]string
 }
@@ -38,14 +39,14 @@ type AWSNodePoolBuilder struct {
 // NewAWSNodePool creates a new builder of 'AWS_node_pool' objects.
 func NewAWSNodePool() *AWSNodePoolBuilder {
 	return &AWSNodePoolBuilder{
-		fieldSet_: make([]bool, 12),
+		fieldSet_: make([]bool, 13),
 	}
 }
 
 // Link sets the flag that indicates if this is a link.
 func (b *AWSNodePoolBuilder) Link(value bool) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.fieldSet_[0] = true
 	return b
@@ -54,7 +55,7 @@ func (b *AWSNodePoolBuilder) Link(value bool) *AWSNodePoolBuilder {
 // ID sets the identifier of the object.
 func (b *AWSNodePoolBuilder) ID(value string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.id = value
 	b.fieldSet_[1] = true
@@ -64,7 +65,7 @@ func (b *AWSNodePoolBuilder) ID(value string) *AWSNodePoolBuilder {
 // HREF sets the link to the object.
 func (b *AWSNodePoolBuilder) HREF(value string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.href = value
 	b.fieldSet_[2] = true
@@ -88,7 +89,7 @@ func (b *AWSNodePoolBuilder) Empty() bool {
 // AdditionalSecurityGroupIds sets the value of the 'additional_security_group_ids' attribute to the given values.
 func (b *AWSNodePoolBuilder) AdditionalSecurityGroupIds(values ...string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.additionalSecurityGroupIds = make([]string, len(values))
 	copy(b.additionalSecurityGroupIds, values)
@@ -99,7 +100,7 @@ func (b *AWSNodePoolBuilder) AdditionalSecurityGroupIds(values ...string) *AWSNo
 // AvailabilityZoneTypes sets the value of the 'availability_zone_types' attribute to the given value.
 func (b *AWSNodePoolBuilder) AvailabilityZoneTypes(value map[string]string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.availabilityZoneTypes = value
 	if value != nil {
@@ -115,7 +116,7 @@ func (b *AWSNodePoolBuilder) AvailabilityZoneTypes(value map[string]string) *AWS
 // AWS Capacity Reservation specification.
 func (b *AWSNodePoolBuilder) CapacityReservation(value *AWSCapacityReservationBuilder) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.capacityReservation = value
 	if value != nil {
@@ -131,7 +132,7 @@ func (b *AWSNodePoolBuilder) CapacityReservation(value *AWSCapacityReservationBu
 // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
 func (b *AWSNodePoolBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.ec2MetadataHttpTokens = value
 	b.fieldSet_[6] = true
@@ -141,7 +142,7 @@ func (b *AWSNodePoolBuilder) Ec2MetadataHttpTokens(value Ec2MetadataHttpTokens) 
 // InstanceProfile sets the value of the 'instance_profile' attribute to the given value.
 func (b *AWSNodePoolBuilder) InstanceProfile(value string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.instanceProfile = value
 	b.fieldSet_[7] = true
@@ -151,7 +152,7 @@ func (b *AWSNodePoolBuilder) InstanceProfile(value string) *AWSNodePoolBuilder {
 // InstanceType sets the value of the 'instance_type' attribute to the given value.
 func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.instanceType = value
 	b.fieldSet_[8] = true
@@ -163,7 +164,7 @@ func (b *AWSNodePoolBuilder) InstanceType(value string) *AWSNodePoolBuilder {
 // Holds settings for an AWS storage volume.
 func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
 	b.rootVolume = value
 	if value != nil {
@@ -174,12 +175,14 @@ func (b *AWSNodePoolBuilder) RootVolume(value *AWSVolumeBuilder) *AWSNodePoolBui
 	return b
 }
 
-// SubnetOutposts sets the value of the 'subnet_outposts' attribute to the given value.
-func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoolBuilder {
+// SpotMarketOptions sets the value of the 'spot_market_options' attribute to the given value.
+//
+// Spot market options for AWS machine pool.
+func (b *AWSNodePoolBuilder) SpotMarketOptions(value *AWSSpotMarketOptionsBuilder) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
-	b.subnetOutposts = value
+	b.spotMarketOptions = value
 	if value != nil {
 		b.fieldSet_[10] = true
 	} else {
@@ -188,16 +191,30 @@ func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoo
 	return b
 }
 
-// Tags sets the value of the 'tags' attribute to the given value.
-func (b *AWSNodePoolBuilder) Tags(value map[string]string) *AWSNodePoolBuilder {
+// SubnetOutposts sets the value of the 'subnet_outposts' attribute to the given value.
+func (b *AWSNodePoolBuilder) SubnetOutposts(value map[string]string) *AWSNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 12)
+		b.fieldSet_ = make([]bool, 13)
 	}
-	b.tags = value
+	b.subnetOutposts = value
 	if value != nil {
 		b.fieldSet_[11] = true
 	} else {
 		b.fieldSet_[11] = false
+	}
+	return b
+}
+
+// Tags sets the value of the 'tags' attribute to the given value.
+func (b *AWSNodePoolBuilder) Tags(value map[string]string) *AWSNodePoolBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 13)
+	}
+	b.tags = value
+	if value != nil {
+		b.fieldSet_[12] = true
+	} else {
+		b.fieldSet_[12] = false
 	}
 	return b
 }
@@ -239,6 +256,11 @@ func (b *AWSNodePoolBuilder) Copy(object *AWSNodePool) *AWSNodePoolBuilder {
 		b.rootVolume = NewAWSVolume().Copy(object.rootVolume)
 	} else {
 		b.rootVolume = nil
+	}
+	if object.spotMarketOptions != nil {
+		b.spotMarketOptions = NewAWSSpotMarketOptions().Copy(object.spotMarketOptions)
+	} else {
+		b.spotMarketOptions = nil
 	}
 	if len(object.subnetOutposts) > 0 {
 		b.subnetOutposts = map[string]string{}
@@ -289,6 +311,12 @@ func (b *AWSNodePoolBuilder) Build() (object *AWSNodePool, err error) {
 	object.instanceType = b.instanceType
 	if b.rootVolume != nil {
 		object.rootVolume, err = b.rootVolume.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.spotMarketOptions != nil {
+		object.spotMarketOptions, err = b.spotMarketOptions.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_builder.go
@@ -1,0 +1,116 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Spot market options for AWS node pool.
+type AwsNodePoolSpotMarketOptionsBuilder struct {
+	fieldSet_ []bool
+	id        string
+	href      string
+	maxPrice  string
+}
+
+// NewAwsNodePoolSpotMarketOptions creates a new builder of 'aws_node_pool_spot_market_options' objects.
+func NewAwsNodePoolSpotMarketOptions() *AwsNodePoolSpotMarketOptionsBuilder {
+	return &AwsNodePoolSpotMarketOptionsBuilder{
+		fieldSet_: make([]bool, 4),
+	}
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) Link(value bool) *AwsNodePoolSpotMarketOptionsBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.fieldSet_[0] = true
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) ID(value string) *AwsNodePoolSpotMarketOptionsBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.id = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) HREF(value string) *AwsNodePoolSpotMarketOptionsBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.href = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(b.fieldSet_); i++ {
+		if b.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// MaxPrice sets the value of the 'max_price' attribute to the given value.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) MaxPrice(value string) *AwsNodePoolSpotMarketOptionsBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.maxPrice = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) Copy(object *AwsNodePoolSpotMarketOptions) *AwsNodePoolSpotMarketOptionsBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.id = object.id
+	b.href = object.href
+	b.maxPrice = object.maxPrice
+	return b
+}
+
+// Build creates a 'aws_node_pool_spot_market_options' object using the configuration stored in the builder.
+func (b *AwsNodePoolSpotMarketOptionsBuilder) Build() (object *AwsNodePoolSpotMarketOptions, err error) {
+	object = new(AwsNodePoolSpotMarketOptions)
+	object.id = b.id
+	object.href = b.href
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.maxPrice = b.maxPrice
+	return
+}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_list_builder.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AwsNodePoolSpotMarketOptionsListBuilder contains the data and logic needed to build
+// 'aws_node_pool_spot_market_options' objects.
+type AwsNodePoolSpotMarketOptionsListBuilder struct {
+	items []*AwsNodePoolSpotMarketOptionsBuilder
+}
+
+// NewAwsNodePoolSpotMarketOptionsList creates a new builder of 'aws_node_pool_spot_market_options' objects.
+func NewAwsNodePoolSpotMarketOptionsList() *AwsNodePoolSpotMarketOptionsListBuilder {
+	return new(AwsNodePoolSpotMarketOptionsListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AwsNodePoolSpotMarketOptionsListBuilder) Items(values ...*AwsNodePoolSpotMarketOptionsBuilder) *AwsNodePoolSpotMarketOptionsListBuilder {
+	b.items = make([]*AwsNodePoolSpotMarketOptionsBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AwsNodePoolSpotMarketOptionsListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AwsNodePoolSpotMarketOptionsListBuilder) Copy(list *AwsNodePoolSpotMarketOptionsList) *AwsNodePoolSpotMarketOptionsListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AwsNodePoolSpotMarketOptionsBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAwsNodePoolSpotMarketOptions().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'aws_node_pool_spot_market_options' objects using the
+// configuration stored in the builder.
+func (b *AwsNodePoolSpotMarketOptionsListBuilder) Build() (list *AwsNodePoolSpotMarketOptionsList, err error) {
+	items := make([]*AwsNodePoolSpotMarketOptions, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AwsNodePoolSpotMarketOptionsList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAwsNodePoolSpotMarketOptionsList writes a list of values of the 'aws_node_pool_spot_market_options' type to
+// the given writer.
+func MarshalAwsNodePoolSpotMarketOptionsList(list []*AwsNodePoolSpotMarketOptions, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAwsNodePoolSpotMarketOptionsList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAwsNodePoolSpotMarketOptionsList writes a list of value of the 'aws_node_pool_spot_market_options' type to
+// the given stream.
+func WriteAwsNodePoolSpotMarketOptionsList(list []*AwsNodePoolSpotMarketOptions, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAwsNodePoolSpotMarketOptions(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAwsNodePoolSpotMarketOptionsList reads a list of values of the 'aws_node_pool_spot_market_options' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAwsNodePoolSpotMarketOptionsList(source interface{}) (items []*AwsNodePoolSpotMarketOptions, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAwsNodePoolSpotMarketOptionsList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAwsNodePoolSpotMarketOptionsList reads list of values of the ”aws_node_pool_spot_market_options' type from
+// the given iterator.
+func ReadAwsNodePoolSpotMarketOptionsList(iterator *jsoniter.Iterator) []*AwsNodePoolSpotMarketOptions {
+	list := []*AwsNodePoolSpotMarketOptions{}
+	for iterator.ReadArray() {
+		item := ReadAwsNodePoolSpotMarketOptions(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_type.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_type.go
@@ -1,0 +1,277 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AwsNodePoolSpotMarketOptionsKind is the name of the type used to represent objects
+// of type 'aws_node_pool_spot_market_options'.
+const AwsNodePoolSpotMarketOptionsKind = "AwsNodePoolSpotMarketOptions"
+
+// AwsNodePoolSpotMarketOptionsLinkKind is the name of the type used to represent links
+// to objects of type 'aws_node_pool_spot_market_options'.
+const AwsNodePoolSpotMarketOptionsLinkKind = "AwsNodePoolSpotMarketOptionsLink"
+
+// AwsNodePoolSpotMarketOptionsNilKind is the name of the type used to nil references
+// to objects of type 'aws_node_pool_spot_market_options'.
+const AwsNodePoolSpotMarketOptionsNilKind = "AwsNodePoolSpotMarketOptionsNil"
+
+// AwsNodePoolSpotMarketOptions represents the values of the 'aws_node_pool_spot_market_options' type.
+//
+// Spot market options for AWS node pool.
+type AwsNodePoolSpotMarketOptions struct {
+	fieldSet_ []bool
+	id        string
+	href      string
+	maxPrice  string
+}
+
+// Kind returns the name of the type of the object.
+func (o *AwsNodePoolSpotMarketOptions) Kind() string {
+	if o == nil {
+		return AwsNodePoolSpotMarketOptionsNilKind
+	}
+	if len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return AwsNodePoolSpotMarketOptionsLinkKind
+	}
+	return AwsNodePoolSpotMarketOptionsKind
+}
+
+// Link returns true if this is a link.
+func (o *AwsNodePoolSpotMarketOptions) Link() bool {
+	return o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+}
+
+// ID returns the identifier of the object.
+func (o *AwsNodePoolSpotMarketOptions) ID() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *AwsNodePoolSpotMarketOptions) GetID() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *AwsNodePoolSpotMarketOptions) HREF() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *AwsNodePoolSpotMarketOptions) GetHREF() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AwsNodePoolSpotMarketOptions) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(o.fieldSet_); i++ {
+		if o.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// MaxPrice returns the value of the 'max_price' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The max price for spot instance. Optional.
+// If not set, use the on-demand price.
+func (o *AwsNodePoolSpotMarketOptions) MaxPrice() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.maxPrice
+	}
+	return ""
+}
+
+// GetMaxPrice returns the value of the 'max_price' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The max price for spot instance. Optional.
+// If not set, use the on-demand price.
+func (o *AwsNodePoolSpotMarketOptions) GetMaxPrice() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.maxPrice
+	}
+	return
+}
+
+// AwsNodePoolSpotMarketOptionsListKind is the name of the type used to represent list of objects of
+// type 'aws_node_pool_spot_market_options'.
+const AwsNodePoolSpotMarketOptionsListKind = "AwsNodePoolSpotMarketOptionsList"
+
+// AwsNodePoolSpotMarketOptionsListLinkKind is the name of the type used to represent links to list
+// of objects of type 'aws_node_pool_spot_market_options'.
+const AwsNodePoolSpotMarketOptionsListLinkKind = "AwsNodePoolSpotMarketOptionsListLink"
+
+// AwsNodePoolSpotMarketOptionsNilKind is the name of the type used to nil lists of objects of
+// type 'aws_node_pool_spot_market_options'.
+const AwsNodePoolSpotMarketOptionsListNilKind = "AwsNodePoolSpotMarketOptionsListNil"
+
+// AwsNodePoolSpotMarketOptionsList is a list of values of the 'aws_node_pool_spot_market_options' type.
+type AwsNodePoolSpotMarketOptionsList struct {
+	href  string
+	link  bool
+	items []*AwsNodePoolSpotMarketOptions
+}
+
+// Kind returns the name of the type of the object.
+func (l *AwsNodePoolSpotMarketOptionsList) Kind() string {
+	if l == nil {
+		return AwsNodePoolSpotMarketOptionsListNilKind
+	}
+	if l.link {
+		return AwsNodePoolSpotMarketOptionsListLinkKind
+	}
+	return AwsNodePoolSpotMarketOptionsListKind
+}
+
+// Link returns true iif this is a link.
+func (l *AwsNodePoolSpotMarketOptionsList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *AwsNodePoolSpotMarketOptionsList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *AwsNodePoolSpotMarketOptionsList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *AwsNodePoolSpotMarketOptionsList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AwsNodePoolSpotMarketOptionsList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AwsNodePoolSpotMarketOptionsList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AwsNodePoolSpotMarketOptionsList) SetItems(items []*AwsNodePoolSpotMarketOptions) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AwsNodePoolSpotMarketOptionsList) Items() []*AwsNodePoolSpotMarketOptions {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AwsNodePoolSpotMarketOptionsList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AwsNodePoolSpotMarketOptionsList) Get(i int) *AwsNodePoolSpotMarketOptions {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AwsNodePoolSpotMarketOptionsList) Slice() []*AwsNodePoolSpotMarketOptions {
+	var slice []*AwsNodePoolSpotMarketOptions
+	if l == nil {
+		slice = make([]*AwsNodePoolSpotMarketOptions, 0)
+	} else {
+		slice = make([]*AwsNodePoolSpotMarketOptions, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AwsNodePoolSpotMarketOptionsList) Each(f func(item *AwsNodePoolSpotMarketOptions) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AwsNodePoolSpotMarketOptionsList) Range(f func(index int, item *AwsNodePoolSpotMarketOptions) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_spot_market_options_type_json.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAwsNodePoolSpotMarketOptions writes a value of the 'aws_node_pool_spot_market_options' type to the given writer.
+func MarshalAwsNodePoolSpotMarketOptions(object *AwsNodePoolSpotMarketOptions, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAwsNodePoolSpotMarketOptions(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAwsNodePoolSpotMarketOptions writes a value of the 'aws_node_pool_spot_market_options' type to the given stream.
+func WriteAwsNodePoolSpotMarketOptions(object *AwsNodePoolSpotMarketOptions, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	stream.WriteObjectField("kind")
+	if len(object.fieldSet_) > 0 && object.fieldSet_[0] {
+		stream.WriteString(AwsNodePoolSpotMarketOptionsLinkKind)
+	} else {
+		stream.WriteString(AwsNodePoolSpotMarketOptionsKind)
+	}
+	count++
+	if len(object.fieldSet_) > 1 && object.fieldSet_[1] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	if len(object.fieldSet_) > 2 && object.fieldSet_[2] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
+	var present_ bool
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("max_price")
+		stream.WriteString(object.maxPrice)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAwsNodePoolSpotMarketOptions reads a value of the 'aws_node_pool_spot_market_options' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAwsNodePoolSpotMarketOptions(source interface{}) (object *AwsNodePoolSpotMarketOptions, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAwsNodePoolSpotMarketOptions(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAwsNodePoolSpotMarketOptions reads a value of the 'aws_node_pool_spot_market_options' type from the given iterator.
+func ReadAwsNodePoolSpotMarketOptions(iterator *jsoniter.Iterator) *AwsNodePoolSpotMarketOptions {
+	object := &AwsNodePoolSpotMarketOptions{
+		fieldSet_: make([]bool, 4),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "kind":
+			value := iterator.ReadString()
+			if value == AwsNodePoolSpotMarketOptionsLinkKind {
+				object.fieldSet_[0] = true
+			}
+		case "id":
+			object.id = iterator.ReadString()
+			object.fieldSet_[1] = true
+		case "href":
+			object.href = iterator.ReadString()
+			object.fieldSet_[2] = true
+		case "max_price":
+			value := iterator.ReadString()
+			object.maxPrice = value
+			object.fieldSet_[3] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_type.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_type.go
@@ -45,7 +45,7 @@ type AWSNodePool struct {
 	instanceProfile            string
 	instanceType               string
 	rootVolume                 *AWSVolume
-	spotMarketOptions          *AWSSpotMarketOptions
+	spotMarketOptions          *AwsNodePoolSpotMarketOptions
 	subnetOutposts             map[string]string
 	tags                       map[string]string
 }
@@ -282,7 +282,7 @@ func (o *AWSNodePool) GetRootVolume() (value *AWSVolume, ok bool) {
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Use spot instances on this node pool to reduce cost.
-func (o *AWSNodePool) SpotMarketOptions() *AWSSpotMarketOptions {
+func (o *AWSNodePool) SpotMarketOptions() *AwsNodePoolSpotMarketOptions {
 	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
 		return o.spotMarketOptions
 	}
@@ -293,7 +293,7 @@ func (o *AWSNodePool) SpotMarketOptions() *AWSSpotMarketOptions {
 // a flag indicating if the attribute has a value.
 //
 // Use spot instances on this node pool to reduce cost.
-func (o *AWSNodePool) GetSpotMarketOptions() (value *AWSSpotMarketOptions, ok bool) {
+func (o *AWSNodePool) GetSpotMarketOptions() (value *AwsNodePoolSpotMarketOptions, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
 	if ok {
 		value = o.spotMarketOptions

--- a/clientapi/clustersmgmt/v1/aws_node_pool_type.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_type.go
@@ -45,6 +45,7 @@ type AWSNodePool struct {
 	instanceProfile            string
 	instanceType               string
 	rootVolume                 *AWSVolume
+	spotMarketOptions          *AWSSpotMarketOptions
 	subnetOutposts             map[string]string
 	tags                       map[string]string
 }
@@ -277,12 +278,35 @@ func (o *AWSNodePool) GetRootVolume() (value *AWSVolume, ok bool) {
 	return
 }
 
+// SpotMarketOptions returns the value of the 'spot_market_options' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Use spot instances on this node pool to reduce cost.
+func (o *AWSNodePool) SpotMarketOptions() *AWSSpotMarketOptions {
+	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+		return o.spotMarketOptions
+	}
+	return nil
+}
+
+// GetSpotMarketOptions returns the value of the 'spot_market_options' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Use spot instances on this node pool to reduce cost.
+func (o *AWSNodePool) GetSpotMarketOptions() (value *AWSSpotMarketOptions, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	if ok {
+		value = o.spotMarketOptions
+	}
+	return
+}
+
 // SubnetOutposts returns the value of the 'subnet_outposts' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Associates nodepool subnets with AWS Outposts.
 func (o *AWSNodePool) SubnetOutposts() map[string]string {
-	if o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10] {
+	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
 		return o.subnetOutposts
 	}
 	return nil
@@ -293,7 +317,7 @@ func (o *AWSNodePool) SubnetOutposts() map[string]string {
 //
 // Associates nodepool subnets with AWS Outposts.
 func (o *AWSNodePool) GetSubnetOutposts() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 10 && o.fieldSet_[10]
+	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
 	if ok {
 		value = o.subnetOutposts
 	}
@@ -312,7 +336,7 @@ func (o *AWSNodePool) GetSubnetOutposts() (value map[string]string, ok bool) {
 // - Tag values may be between 0 and 256 characters in length
 // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
 func (o *AWSNodePool) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11] {
+	if o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12] {
 		return o.tags
 	}
 	return nil
@@ -330,7 +354,7 @@ func (o *AWSNodePool) Tags() map[string]string {
 // - Tag values may be between 0 and 256 characters in length
 // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
 func (o *AWSNodePool) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 11 && o.fieldSet_[11]
+	ok = o != nil && len(o.fieldSet_) > 12 && o.fieldSet_[12]
 	if ok {
 		value = o.tags
 	}

--- a/clientapi/clustersmgmt/v1/aws_node_pool_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_type_json.go
@@ -155,7 +155,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 			stream.WriteMore()
 		}
 		stream.WriteObjectField("spot_market_options")
-		WriteAWSSpotMarketOptions(object.spotMarketOptions, stream)
+		WriteAwsNodePoolSpotMarketOptions(object.spotMarketOptions, stream)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.subnetOutposts != nil
@@ -290,7 +290,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 			object.rootVolume = value
 			object.fieldSet_[9] = true
 		case "spot_market_options":
-			value := ReadAWSSpotMarketOptions(iterator)
+			value := ReadAwsNodePoolSpotMarketOptions(iterator)
 			object.spotMarketOptions = value
 			object.fieldSet_[10] = true
 		case "subnet_outposts":

--- a/clientapi/clustersmgmt/v1/aws_node_pool_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_node_pool_type_json.go
@@ -149,7 +149,16 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		WriteAWSVolume(object.rootVolume, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.subnetOutposts != nil
+	present_ = len(object.fieldSet_) > 10 && object.fieldSet_[10] && object.spotMarketOptions != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("spot_market_options")
+		WriteAWSSpotMarketOptions(object.spotMarketOptions, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.subnetOutposts != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -178,7 +187,7 @@ func WriteAWSNodePool(object *AWSNodePool, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 11 && object.fieldSet_[11] && object.tags != nil
+	present_ = len(object.fieldSet_) > 12 && object.fieldSet_[12] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -224,7 +233,7 @@ func UnmarshalAWSNodePool(source interface{}) (object *AWSNodePool, err error) {
 // ReadAWSNodePool reads a value of the 'AWS_node_pool' type from the given iterator.
 func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 	object := &AWSNodePool{
-		fieldSet_: make([]bool, 12),
+		fieldSet_: make([]bool, 13),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -280,6 +289,10 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 			value := ReadAWSVolume(iterator)
 			object.rootVolume = value
 			object.fieldSet_[9] = true
+		case "spot_market_options":
+			value := ReadAWSSpotMarketOptions(iterator)
+			object.spotMarketOptions = value
+			object.fieldSet_[10] = true
 		case "subnet_outposts":
 			value := map[string]string{}
 			for {
@@ -291,7 +304,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 				value[key] = item
 			}
 			object.subnetOutposts = value
-			object.fieldSet_[10] = true
+			object.fieldSet_[11] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -303,7 +316,7 @@ func ReadAWSNodePool(iterator *jsoniter.Iterator) *AWSNodePool {
 				value[key] = item
 			}
 			object.tags = value
-			object.fieldSet_[11] = true
+			object.fieldSet_[12] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/aws_type.go
+++ b/clientapi/clustersmgmt/v1/aws_type.go
@@ -42,9 +42,9 @@ type AWS struct {
 	privateHostedZoneRoleARN               string
 	privateLinkConfiguration               *PrivateLinkClusterConfiguration
 	secretAccessKey                        string
-	spotTerminationHandlerQueueUrl         string
 	subnetIDs                              []string
 	tags                                   map[string]string
+	terminationHandlerQueueUrl             string
 	vpcEndpointRoleArn                     string
 	zeroEgress                             *ZeroEgress
 	privateLink                            bool
@@ -500,39 +500,12 @@ func (o *AWS) GetSecretAccessKey() (value string, ok bool) {
 	return
 }
 
-// SpotTerminationHandlerQueueUrl returns the value of the 'spot_termination_handler_queue_url' attribute, or
-// the zero value of the type if the attribute doesn't have a value.
-//
-// URL of the SQS queue used for graceful Spot instance interruption handling.
-// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
-// control plane. Queue must be in the same region as the cluster.
-func (o *AWS) SpotTerminationHandlerQueueUrl() string {
-	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
-		return o.spotTerminationHandlerQueueUrl
-	}
-	return ""
-}
-
-// GetSpotTerminationHandlerQueueUrl returns the value of the 'spot_termination_handler_queue_url' attribute and
-// a flag indicating if the attribute has a value.
-//
-// URL of the SQS queue used for graceful Spot instance interruption handling.
-// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
-// control plane. Queue must be in the same region as the cluster.
-func (o *AWS) GetSpotTerminationHandlerQueueUrl() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
-	if ok {
-		value = o.spotTerminationHandlerQueueUrl
-	}
-	return
-}
-
 // SubnetIDs returns the value of the 'subnet_IDs' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) SubnetIDs() []string {
-	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
+	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
 		return o.subnetIDs
 	}
 	return nil
@@ -543,7 +516,7 @@ func (o *AWS) SubnetIDs() []string {
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
+	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
 	if ok {
 		value = o.subnetIDs
 	}
@@ -555,7 +528,7 @@ func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
+	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
 		return o.tags
 	}
 	return nil
@@ -566,9 +539,36 @@ func (o *AWS) Tags() map[string]string {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
+	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
 	if ok {
 		value = o.tags
+	}
+	return
+}
+
+// TerminationHandlerQueueUrl returns the value of the 'termination_handler_queue_url' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// URL of the SQS queue used for graceful Spot instance interruption handling.
+// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
+// control plane. Queue must be in the same region as the cluster.
+func (o *AWS) TerminationHandlerQueueUrl() string {
+	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
+		return o.terminationHandlerQueueUrl
+	}
+	return ""
+}
+
+// GetTerminationHandlerQueueUrl returns the value of the 'termination_handler_queue_url' attribute and
+// a flag indicating if the attribute has a value.
+//
+// URL of the SQS queue used for graceful Spot instance interruption handling.
+// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
+// control plane. Queue must be in the same region as the cluster.
+func (o *AWS) GetTerminationHandlerQueueUrl() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
+	if ok {
+		value = o.terminationHandlerQueueUrl
 	}
 	return
 }

--- a/clientapi/clustersmgmt/v1/aws_type.go
+++ b/clientapi/clustersmgmt/v1/aws_type.go
@@ -42,6 +42,7 @@ type AWS struct {
 	privateHostedZoneRoleARN               string
 	privateLinkConfiguration               *PrivateLinkClusterConfiguration
 	secretAccessKey                        string
+	spotTerminationHandlerQueueUrl         string
 	subnetIDs                              []string
 	tags                                   map[string]string
 	vpcEndpointRoleArn                     string
@@ -499,12 +500,39 @@ func (o *AWS) GetSecretAccessKey() (value string, ok bool) {
 	return
 }
 
+// SpotTerminationHandlerQueueUrl returns the value of the 'spot_termination_handler_queue_url' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// URL of the SQS queue used for graceful Spot instance interruption handling.
+// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
+// control plane. Queue must be in the same region as the cluster.
+func (o *AWS) SpotTerminationHandlerQueueUrl() string {
+	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
+		return o.spotTerminationHandlerQueueUrl
+	}
+	return ""
+}
+
+// GetSpotTerminationHandlerQueueUrl returns the value of the 'spot_termination_handler_queue_url' attribute and
+// a flag indicating if the attribute has a value.
+//
+// URL of the SQS queue used for graceful Spot instance interruption handling.
+// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
+// control plane. Queue must be in the same region as the cluster.
+func (o *AWS) GetSpotTerminationHandlerQueueUrl() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
+	if ok {
+		value = o.spotTerminationHandlerQueueUrl
+	}
+	return
+}
+
 // SubnetIDs returns the value of the 'subnet_IDs' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) SubnetIDs() []string {
-	if o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19] {
+	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
 		return o.subnetIDs
 	}
 	return nil
@@ -515,7 +543,7 @@ func (o *AWS) SubnetIDs() []string {
 //
 // The subnet ids to be used when installing the cluster.
 func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 19 && o.fieldSet_[19]
+	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
 	if ok {
 		value = o.subnetIDs
 	}
@@ -527,7 +555,7 @@ func (o *AWS) GetSubnetIDs() (value []string, ok bool) {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) Tags() map[string]string {
-	if o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20] {
+	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
 		return o.tags
 	}
 	return nil
@@ -538,7 +566,7 @@ func (o *AWS) Tags() map[string]string {
 //
 // Optional keys and values that the installer will add as tags to all AWS resources it creates
 func (o *AWS) GetTags() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 20 && o.fieldSet_[20]
+	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
 	if ok {
 		value = o.tags
 	}
@@ -550,7 +578,7 @@ func (o *AWS) GetTags() (value map[string]string, ok bool) {
 //
 // Role ARN for VPC Endpoint Service cross account role.
 func (o *AWS) VpcEndpointRoleArn() string {
-	if o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21] {
+	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
 		return o.vpcEndpointRoleArn
 	}
 	return ""
@@ -561,7 +589,7 @@ func (o *AWS) VpcEndpointRoleArn() string {
 //
 // Role ARN for VPC Endpoint Service cross account role.
 func (o *AWS) GetVpcEndpointRoleArn() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 21 && o.fieldSet_[21]
+	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
 	if ok {
 		value = o.vpcEndpointRoleArn
 	}
@@ -573,7 +601,7 @@ func (o *AWS) GetVpcEndpointRoleArn() (value string, ok bool) {
 //
 // Zero egress configuration.
 func (o *AWS) ZeroEgress() *ZeroEgress {
-	if o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22] {
+	if o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23] {
 		return o.zeroEgress
 	}
 	return nil
@@ -584,7 +612,7 @@ func (o *AWS) ZeroEgress() *ZeroEgress {
 //
 // Zero egress configuration.
 func (o *AWS) GetZeroEgress() (value *ZeroEgress, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 22 && o.fieldSet_[22]
+	ok = o != nil && len(o.fieldSet_) > 23 && o.fieldSet_[23]
 	if ok {
 		value = o.zeroEgress
 	}

--- a/clientapi/clustersmgmt/v1/aws_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_type_json.go
@@ -214,16 +214,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.secretAccessKey)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("spot_termination_handler_queue_url")
-		stream.WriteString(object.spotTerminationHandlerQueueUrl)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.subnetIDs != nil
+	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.subnetIDs != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -232,7 +223,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteStringList(object.subnetIDs, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21] && object.tags != nil
+	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -259,6 +250,15 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		} else {
 			stream.WriteNil()
 		}
+		count++
+	}
+	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("termination_handler_queue_url")
+		stream.WriteString(object.terminationHandlerQueueUrl)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22]
@@ -381,14 +381,10 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 			value := iterator.ReadString()
 			object.secretAccessKey = value
 			object.fieldSet_[18] = true
-		case "spot_termination_handler_queue_url":
-			value := iterator.ReadString()
-			object.spotTerminationHandlerQueueUrl = value
-			object.fieldSet_[19] = true
 		case "subnet_ids":
 			value := ReadStringList(iterator)
 			object.subnetIDs = value
-			object.fieldSet_[20] = true
+			object.fieldSet_[19] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -400,6 +396,10 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 				value[key] = item
 			}
 			object.tags = value
+			object.fieldSet_[20] = true
+		case "termination_handler_queue_url":
+			value := iterator.ReadString()
+			object.terminationHandlerQueueUrl = value
 			object.fieldSet_[21] = true
 		case "vpc_endpoint_role_arn":
 			value := iterator.ReadString()

--- a/clientapi/clustersmgmt/v1/aws_type_json.go
+++ b/clientapi/clustersmgmt/v1/aws_type_json.go
@@ -214,7 +214,16 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.secretAccessKey)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19] && object.subnetIDs != nil
+	present_ = len(object.fieldSet_) > 19 && object.fieldSet_[19]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("spot_termination_handler_queue_url")
+		stream.WriteString(object.spotTerminationHandlerQueueUrl)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.subnetIDs != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -223,7 +232,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		WriteStringList(object.subnetIDs, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 20 && object.fieldSet_[20] && object.tags != nil
+	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21] && object.tags != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -252,7 +261,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 21 && object.fieldSet_[21]
+	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -261,7 +270,7 @@ func WriteAWS(object *AWS, stream *jsoniter.Stream) {
 		stream.WriteString(object.vpcEndpointRoleArn)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 22 && object.fieldSet_[22] && object.zeroEgress != nil
+	present_ = len(object.fieldSet_) > 23 && object.fieldSet_[23] && object.zeroEgress != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -287,7 +296,7 @@ func UnmarshalAWS(source interface{}) (object *AWS, err error) {
 // ReadAWS reads a value of the 'AWS' type from the given iterator.
 func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 	object := &AWS{
-		fieldSet_: make([]bool, 23),
+		fieldSet_: make([]bool, 24),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -372,10 +381,14 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 			value := iterator.ReadString()
 			object.secretAccessKey = value
 			object.fieldSet_[18] = true
+		case "spot_termination_handler_queue_url":
+			value := iterator.ReadString()
+			object.spotTerminationHandlerQueueUrl = value
+			object.fieldSet_[19] = true
 		case "subnet_ids":
 			value := ReadStringList(iterator)
 			object.subnetIDs = value
-			object.fieldSet_[19] = true
+			object.fieldSet_[20] = true
 		case "tags":
 			value := map[string]string{}
 			for {
@@ -387,15 +400,15 @@ func ReadAWS(iterator *jsoniter.Iterator) *AWS {
 				value[key] = item
 			}
 			object.tags = value
-			object.fieldSet_[20] = true
+			object.fieldSet_[21] = true
 		case "vpc_endpoint_role_arn":
 			value := iterator.ReadString()
 			object.vpcEndpointRoleArn = value
-			object.fieldSet_[21] = true
+			object.fieldSet_[22] = true
 		case "zero_egress":
 			value := ReadZeroEgress(iterator)
 			object.zeroEgress = value
-			object.fieldSet_[22] = true
+			object.fieldSet_[23] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/clusters_mgmt/v1/aws_node_pool_spot_market_options_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_spot_market_options_type.model
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Spot market options for AWS node pool.
+class AwsNodePoolSpotMarketOptions {
+    // The max price for spot instance. Optional.
+    // If not set, use the on-demand price.
+    MaxPrice String
+}

--- a/model/clusters_mgmt/v1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_type.model
@@ -54,5 +54,5 @@ class AWSNodePool {
 
     // Use spot instances on this node pool to reduce cost.
     @json(name = "spot_market_options")
-    SpotMarketOptions AWSSpotMarketOptions
+    SpotMarketOptions AwsNodePoolSpotMarketOptions
 }

--- a/model/clusters_mgmt/v1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_type.model
@@ -51,4 +51,8 @@ class AWSNodePool {
     // If present it defines the AWS Capacity Reservation used for this NodePool
     @json(name = "capacity_reservation")
     CapacityReservation AWSCapacityReservation
+
+    // Use spot instances on this node pool to reduce cost.
+    @json(name = "spot_market_options")
+    SpotMarketOptions AWSSpotMarketOptions
 }

--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -89,6 +89,6 @@ struct AWS {
 	// URL of the SQS queue used for graceful Spot instance interruption handling.
 	// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
 	// control plane. Queue must be in the same region as the cluster.
-	@json(name = "spot_termination_handler_queue_url")
-	SpotTerminationHandlerQueueUrl String
+	@json(name = "termination_handler_queue_url")
+	TerminationHandlerQueueUrl String
 }

--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -85,4 +85,10 @@ struct AWS {
 
 	// Zero egress configuration.
 	ZeroEgress ZeroEgress
+
+	// URL of the SQS queue used for graceful Spot instance interruption handling.
+	// When set, HyperShift deploys the AWS Node Termination Handler in the hosted
+	// control plane. Queue must be in the same region as the cluster.
+	@json(name = "spot_termination_handler_queue_url")
+	SpotTerminationHandlerQueueUrl String
 }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -14215,10 +14215,6 @@
             "description": "AWS secret access key.",
             "type": "string"
           },
-          "spot_termination_handler_queue_url": {
-            "description": "URL of the SQS queue used for graceful Spot instance interruption handling.\nWhen set, HyperShift deploys the AWS Node Termination Handler in the hosted\ncontrol plane. Queue must be in the same region as the cluster.",
-            "type": "string"
-          },
           "subnet_ids": {
             "description": "The subnet ids to be used when installing the cluster.",
             "type": "array",
@@ -14232,6 +14228,10 @@
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "termination_handler_queue_url": {
+            "description": "URL of the SQS queue used for graceful Spot instance interruption handling.\nWhen set, HyperShift deploys the AWS Node Termination Handler in the hosted\ncontrol plane. Queue must be in the same region as the cluster.",
+            "type": "string"
           },
           "vpc_endpoint_role_arn": {
             "description": "Role ARN for VPC Endpoint Service cross account role.",

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -14504,7 +14504,7 @@
           },
           "spot_market_options": {
             "description": "Use spot instances on this node pool to reduce cost.",
-            "$ref": "#/components/schemas/AWSSpotMarketOptions"
+            "$ref": "#/components/schemas/AwsNodePoolSpotMarketOptions"
           },
           "subnet_outposts": {
             "description": "Associates nodepool subnets with AWS Outposts.",
@@ -15987,6 +15987,27 @@
         "properties": {
           "kms_key_arn": {
             "description": "ARN of the KMS to be used for the etcd encryption",
+            "type": "string"
+          }
+        }
+      },
+      "AwsNodePoolSpotMarketOptions": {
+        "description": "Spot market options for AWS node pool.",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'AwsNodePoolSpotMarketOptions' if this is a complete object or 'AwsNodePoolSpotMarketOptionsLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "max_price": {
+            "description": "The max price for spot instance. Optional.\nIf not set, use the on-demand price.",
             "type": "string"
           }
         }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -14215,6 +14215,10 @@
             "description": "AWS secret access key.",
             "type": "string"
           },
+          "spot_termination_handler_queue_url": {
+            "description": "URL of the SQS queue used for graceful Spot instance interruption handling.\nWhen set, HyperShift deploys the AWS Node Termination Handler in the hosted\ncontrol plane. Queue must be in the same region as the cluster.",
+            "type": "string"
+          },
           "subnet_ids": {
             "description": "The subnet ids to be used when installing the cluster.",
             "type": "array",
@@ -14497,6 +14501,10 @@
           "root_volume": {
             "description": "AWS Volume specification to be used to set custom worker disk size",
             "$ref": "#/components/schemas/AWSVolume"
+          },
+          "spot_market_options": {
+            "description": "Use spot instances on this node pool to reduce cost.",
+            "$ref": "#/components/schemas/AWSSpotMarketOptions"
           },
           "subnet_outposts": {
             "description": "Associates nodepool subnets with AWS Outposts.",


### PR DESCRIPTION
Related to change suggestions identified in:
https://github.com/gdbranco/rosa-enhancements/blob/8fc56cb5c2bf65f39a2418388cef0e7a619c872b/enhancements/aws-spot-instances-rosa-hcp.md

Supporting Spot instances for ROSA HCP

## Description

<!-- Briefly describe what model or tooling changes this PR introduces and why. -->
<!-- For model changes, reference the Jira ticket (e.g., OCM-XXXXX). -->

## Type of Change

- [ ] Model change (new or modified types, resources, methods, or parameters)
- [ ] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [ ] CI/CD or tooling change

## Verification

- [ ] `make check` passes (model syntax validation)
- [ ] `make verify` passes (generated code matches model)
- [ ] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `termination_handler_queue_url` to configure the SQS queue for graceful Spot interruption handling on AWS clusters.
  * Added `spot_market_options` to configure AWS Spot settings for node pools (including optional `max_price`).
  * Included support across the configuration model, API responses, and JSON serialization/deserialization.
* **Bug Fixes**
  * Updated serialization/deserialization so existing optional node-pool and AWS fields remain correctly set/unset and mapped alongside the new properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->