### PR TITLE
Fix linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ metamodel:
 
 # Enforce indentation by tabs. License contains 2 spaces, so reject 3+.
 lint:
-	find -name '*.model' -print0 | xargs -0 sh -c '! egrep --with-filename --line-number "^(   |\t+ )" "$$@"'
+	find . -name '*.model' -print0 | xargs -0 sh -c '! egrep --with-filename --line-number "^(   |\t+ )" "$$@"'
 
 .PHONY: clean
 clean:

--- a/clientapi/arohcp/v1alpha1/cluster_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_builder.go
@@ -106,6 +106,7 @@ type ClusterBuilder struct {
 	managedService                    *ManagedServiceBuilder
 	name                              string
 	network                           *NetworkBuilder
+	nodeSSHPublicKey                  string
 	nodeDrainGracePeriod              *ValueBuilder
 	nodePools                         *NodePoolListBuilder
 	nodes                             *ClusterNodesBuilder
@@ -131,14 +132,14 @@ type ClusterBuilder struct {
 // NewCluster creates a new builder of 'cluster' objects.
 func NewCluster() *ClusterBuilder {
 	return &ClusterBuilder{
-		fieldSet_: make([]bool, 63),
+		fieldSet_: make([]bool, 64),
 	}
 }
 
 // Link sets the flag that indicates if this is a link.
 func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.fieldSet_[0] = true
 	return b
@@ -147,7 +148,7 @@ func (b *ClusterBuilder) Link(value bool) *ClusterBuilder {
 // ID sets the identifier of the object.
 func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.id = value
 	b.fieldSet_[1] = true
@@ -157,7 +158,7 @@ func (b *ClusterBuilder) ID(value string) *ClusterBuilder {
 // HREF sets the link to the object.
 func (b *ClusterBuilder) HREF(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.href = value
 	b.fieldSet_[2] = true
@@ -184,7 +185,7 @@ func (b *ClusterBuilder) Empty() bool {
 // Information about the API of a cluster.
 func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.api = value
 	if value != nil {
@@ -200,7 +201,7 @@ func (b *ClusterBuilder) API(value *ClusterAPIBuilder) *ClusterBuilder {
 // _Amazon Web Services_ specific settings of a cluster.
 func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.aws = value
 	if value != nil {
@@ -214,7 +215,7 @@ func (b *ClusterBuilder) AWS(value *AWSBuilder) *ClusterBuilder {
 // AWSInfrastructureAccessRoleGrants sets the value of the 'AWS_infrastructure_access_role_grants' attribute to the given values.
 func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *AWSInfrastructureAccessRoleGrantListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.awsInfrastructureAccessRoleGrants = value
 	b.fieldSet_[5] = true
@@ -224,7 +225,7 @@ func (b *ClusterBuilder) AWSInfrastructureAccessRoleGrants(value *AWSInfrastruct
 // CCS sets the value of the 'CCS' attribute to the given value.
 func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.ccs = value
 	if value != nil {
@@ -240,7 +241,7 @@ func (b *ClusterBuilder) CCS(value *CCSBuilder) *ClusterBuilder {
 // DNS settings of the cluster.
 func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.dns = value
 	if value != nil {
@@ -254,7 +255,7 @@ func (b *ClusterBuilder) DNS(value *DNSBuilder) *ClusterBuilder {
 // FIPS sets the value of the 'FIPS' attribute to the given value.
 func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.fips = value
 	b.fieldSet_[8] = true
@@ -266,7 +267,7 @@ func (b *ClusterBuilder) FIPS(value bool) *ClusterBuilder {
 // Google cloud platform settings of a cluster.
 func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcp = value
 	if value != nil {
@@ -282,7 +283,7 @@ func (b *ClusterBuilder) GCP(value *GCPBuilder) *ClusterBuilder {
 // GCP Encryption Key for CCS clusters.
 func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcpEncryptionKey = value
 	if value != nil {
@@ -298,7 +299,7 @@ func (b *ClusterBuilder) GCPEncryptionKey(value *GCPEncryptionKeyBuilder) *Clust
 // GCP Network configuration of a cluster.
 func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.gcpNetwork = value
 	if value != nil {
@@ -312,7 +313,7 @@ func (b *ClusterBuilder) GCPNetwork(value *GCPNetworkBuilder) *ClusterBuilder {
 // AdditionalTrustBundle sets the value of the 'additional_trust_bundle' attribute to the given value.
 func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.additionalTrustBundle = value
 	b.fieldSet_[12] = true
@@ -322,7 +323,7 @@ func (b *ClusterBuilder) AdditionalTrustBundle(value string) *ClusterBuilder {
 // Addons sets the value of the 'addons' attribute to the given values.
 func (b *ClusterBuilder) Addons(value *AddOnInstallationListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.addons = value
 	b.fieldSet_[13] = true
@@ -334,7 +335,7 @@ func (b *ClusterBuilder) Addons(value *AddOnInstallationListBuilder) *ClusterBui
 // The AutoNode configuration for the Cluster.
 func (b *ClusterBuilder) AutoNode(value *ClusterAutoNodeBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.autoNode = value
 	if value != nil {
@@ -350,7 +351,7 @@ func (b *ClusterBuilder) AutoNode(value *ClusterAutoNodeBuilder) *ClusterBuilder
 // Cluster-wide autoscaling configuration.
 func (b *ClusterBuilder) Autoscaler(value *ClusterAutoscalerBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.autoscaler = value
 	if value != nil {
@@ -366,7 +367,7 @@ func (b *ClusterBuilder) Autoscaler(value *ClusterAutoscalerBuilder) *ClusterBui
 // Microsoft Azure settings of a cluster.
 func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.azure = value
 	if value != nil {
@@ -382,7 +383,7 @@ func (b *ClusterBuilder) Azure(value *AzureBuilder) *ClusterBuilder {
 // Billing model for cluster resources.
 func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.billingModel = value
 	b.fieldSet_[17] = true
@@ -394,7 +395,7 @@ func (b *ClusterBuilder) BillingModel(value BillingModel) *ClusterBuilder {
 // ByoOidc configuration.
 func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.byoOidc = value
 	if value != nil {
@@ -410,7 +411,7 @@ func (b *ClusterBuilder) ByoOidc(value *ByoOidcBuilder) *ClusterBuilder {
 // Cloud provider.
 func (b *ClusterBuilder) CloudProvider(value *CloudProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.cloudProvider = value
 	if value != nil {
@@ -426,7 +427,7 @@ func (b *ClusterBuilder) CloudProvider(value *CloudProviderBuilder) *ClusterBuil
 // Information about the console of a cluster.
 func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.console = value
 	if value != nil {
@@ -440,7 +441,7 @@ func (b *ClusterBuilder) Console(value *ClusterConsoleBuilder) *ClusterBuilder {
 // CreationTimestamp sets the value of the 'creation_timestamp' attribute to the given value.
 func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.creationTimestamp = value
 	b.fieldSet_[21] = true
@@ -452,7 +453,7 @@ func (b *ClusterBuilder) CreationTimestamp(value time.Time) *ClusterBuilder {
 // DeleteProtection configuration.
 func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.deleteProtection = value
 	if value != nil {
@@ -466,7 +467,7 @@ func (b *ClusterBuilder) DeleteProtection(value *DeleteProtectionBuilder) *Clust
 // DomainPrefix sets the value of the 'domain_prefix' attribute to the given value.
 func (b *ClusterBuilder) DomainPrefix(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.domainPrefix = value
 	b.fieldSet_[23] = true
@@ -476,7 +477,7 @@ func (b *ClusterBuilder) DomainPrefix(value string) *ClusterBuilder {
 // EtcdEncryption sets the value of the 'etcd_encryption' attribute to the given value.
 func (b *ClusterBuilder) EtcdEncryption(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.etcdEncryption = value
 	b.fieldSet_[24] = true
@@ -486,7 +487,7 @@ func (b *ClusterBuilder) EtcdEncryption(value bool) *ClusterBuilder {
 // ExpirationTimestamp sets the value of the 'expiration_timestamp' attribute to the given value.
 func (b *ClusterBuilder) ExpirationTimestamp(value time.Time) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.expirationTimestamp = value
 	b.fieldSet_[25] = true
@@ -496,7 +497,7 @@ func (b *ClusterBuilder) ExpirationTimestamp(value time.Time) *ClusterBuilder {
 // ExternalID sets the value of the 'external_ID' attribute to the given value.
 func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalID = value
 	b.fieldSet_[26] = true
@@ -508,7 +509,7 @@ func (b *ClusterBuilder) ExternalID(value string) *ClusterBuilder {
 // Represents an external authentication configuration
 func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalAuthConfig = value
 	if value != nil {
@@ -524,7 +525,7 @@ func (b *ClusterBuilder) ExternalAuthConfig(value *ExternalAuthConfigBuilder) *C
 // Representation of cluster external configuration.
 func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.externalConfiguration = value
 	if value != nil {
@@ -541,7 +542,7 @@ func (b *ClusterBuilder) ExternalConfiguration(value *ExternalConfigurationBuild
 // with 10 infra nodes and 1000 compute nodes.
 func (b *ClusterBuilder) Flavour(value *FlavourBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.flavour = value
 	if value != nil {
@@ -555,7 +556,7 @@ func (b *ClusterBuilder) Flavour(value *FlavourBuilder) *ClusterBuilder {
 // Groups sets the value of the 'groups' attribute to the given values.
 func (b *ClusterBuilder) Groups(value *GroupListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.groups = value
 	b.fieldSet_[30] = true
@@ -567,7 +568,7 @@ func (b *ClusterBuilder) Groups(value *GroupListBuilder) *ClusterBuilder {
 // ClusterHealthState indicates the health of a cluster.
 func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.healthState = value
 	b.fieldSet_[31] = true
@@ -579,7 +580,7 @@ func (b *ClusterBuilder) HealthState(value ClusterHealthState) *ClusterBuilder {
 // Details for `htpasswd` identity providers.
 func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.htpasswd = value
 	if value != nil {
@@ -595,7 +596,7 @@ func (b *ClusterBuilder) Htpasswd(value *HTPasswdIdentityProviderBuilder) *Clust
 // Hypershift configuration.
 func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.hypershift = value
 	if value != nil {
@@ -609,7 +610,7 @@ func (b *ClusterBuilder) Hypershift(value *HypershiftBuilder) *ClusterBuilder {
 // IdentityProviders sets the value of the 'identity_providers' attribute to the given values.
 func (b *ClusterBuilder) IdentityProviders(value *IdentityProviderListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.identityProviders = value
 	b.fieldSet_[34] = true
@@ -621,7 +622,7 @@ func (b *ClusterBuilder) IdentityProviders(value *IdentityProviderListBuilder) *
 // ClusterImageRegistry represents the configuration for the cluster's internal image registry.
 func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.imageRegistry = value
 	if value != nil {
@@ -635,7 +636,7 @@ func (b *ClusterBuilder) ImageRegistry(value *ClusterImageRegistryBuilder) *Clus
 // InflightChecks sets the value of the 'inflight_checks' attribute to the given values.
 func (b *ClusterBuilder) InflightChecks(value *InflightCheckListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.inflightChecks = value
 	b.fieldSet_[36] = true
@@ -645,7 +646,7 @@ func (b *ClusterBuilder) InflightChecks(value *InflightCheckListBuilder) *Cluste
 // InfraID sets the value of the 'infra_ID' attribute to the given value.
 func (b *ClusterBuilder) InfraID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.infraID = value
 	b.fieldSet_[37] = true
@@ -655,7 +656,7 @@ func (b *ClusterBuilder) InfraID(value string) *ClusterBuilder {
 // Ingresses sets the value of the 'ingresses' attribute to the given values.
 func (b *ClusterBuilder) Ingresses(value *IngressListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.ingresses = value
 	b.fieldSet_[38] = true
@@ -668,7 +669,7 @@ func (b *ClusterBuilder) Ingresses(value *IngressListBuilder) *ClusterBuilder {
 // KubeletConfig that can be managed by users
 func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.kubeletConfig = value
 	if value != nil {
@@ -682,7 +683,7 @@ func (b *ClusterBuilder) KubeletConfig(value *KubeletConfigBuilder) *ClusterBuil
 // LoadBalancerQuota sets the value of the 'load_balancer_quota' attribute to the given value.
 func (b *ClusterBuilder) LoadBalancerQuota(value int) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.loadBalancerQuota = value
 	b.fieldSet_[40] = true
@@ -692,7 +693,7 @@ func (b *ClusterBuilder) LoadBalancerQuota(value int) *ClusterBuilder {
 // MachinePools sets the value of the 'machine_pools' attribute to the given values.
 func (b *ClusterBuilder) MachinePools(value *MachinePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.machinePools = value
 	b.fieldSet_[41] = true
@@ -702,7 +703,7 @@ func (b *ClusterBuilder) MachinePools(value *MachinePoolListBuilder) *ClusterBui
 // Managed sets the value of the 'managed' attribute to the given value.
 func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.managed = value
 	b.fieldSet_[42] = true
@@ -714,7 +715,7 @@ func (b *ClusterBuilder) Managed(value bool) *ClusterBuilder {
 // Contains the necessary attributes to support role-based authentication on AWS.
 func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.managedService = value
 	if value != nil {
@@ -728,7 +729,7 @@ func (b *ClusterBuilder) ManagedService(value *ManagedServiceBuilder) *ClusterBu
 // MultiAZ sets the value of the 'multi_AZ' attribute to the given value.
 func (b *ClusterBuilder) MultiAZ(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.multiAZ = value
 	b.fieldSet_[44] = true
@@ -738,7 +739,7 @@ func (b *ClusterBuilder) MultiAZ(value bool) *ClusterBuilder {
 // MultiArchEnabled sets the value of the 'multi_arch_enabled' attribute to the given value.
 func (b *ClusterBuilder) MultiArchEnabled(value bool) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.multiArchEnabled = value
 	b.fieldSet_[45] = true
@@ -748,7 +749,7 @@ func (b *ClusterBuilder) MultiArchEnabled(value bool) *ClusterBuilder {
 // Name sets the value of the 'name' attribute to the given value.
 func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.name = value
 	b.fieldSet_[46] = true
@@ -760,7 +761,7 @@ func (b *ClusterBuilder) Name(value string) *ClusterBuilder {
 // Network configuration of a cluster.
 func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.network = value
 	if value != nil {
@@ -768,6 +769,16 @@ func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 	} else {
 		b.fieldSet_[47] = false
 	}
+	return b
+}
+
+// NodeSSHPublicKey sets the value of the 'node_SSH_public_key' attribute to the given value.
+func (b *ClusterBuilder) NodeSSHPublicKey(value string) *ClusterBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 64)
+	}
+	b.nodeSSHPublicKey = value
+	b.fieldSet_[48] = true
 	return b
 }
 
@@ -793,13 +804,13 @@ func (b *ClusterBuilder) Network(value *NetworkBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodeDrainGracePeriod = value
 	if value != nil {
-		b.fieldSet_[48] = true
+		b.fieldSet_[49] = true
 	} else {
-		b.fieldSet_[48] = false
+		b.fieldSet_[49] = false
 	}
 	return b
 }
@@ -807,10 +818,10 @@ func (b *ClusterBuilder) NodeDrainGracePeriod(value *ValueBuilder) *ClusterBuild
 // NodePools sets the value of the 'node_pools' attribute to the given values.
 func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodePools = value
-	b.fieldSet_[49] = true
+	b.fieldSet_[50] = true
 	return b
 }
 
@@ -819,13 +830,13 @@ func (b *ClusterBuilder) NodePools(value *NodePoolListBuilder) *ClusterBuilder {
 // Counts of different classes of nodes inside a cluster.
 func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.nodes = value
 	if value != nil {
-		b.fieldSet_[50] = true
+		b.fieldSet_[51] = true
 	} else {
-		b.fieldSet_[50] = false
+		b.fieldSet_[51] = false
 	}
 	return b
 }
@@ -833,10 +844,10 @@ func (b *ClusterBuilder) Nodes(value *ClusterNodesBuilder) *ClusterBuilder {
 // OpenshiftVersion sets the value of the 'openshift_version' attribute to the given value.
 func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.openshiftVersion = value
-	b.fieldSet_[51] = true
+	b.fieldSet_[52] = true
 	return b
 }
 
@@ -845,13 +856,13 @@ func (b *ClusterBuilder) OpenshiftVersion(value string) *ClusterBuilder {
 // Representation of an product that can be selected as a cluster type.
 func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.product = value
 	if value != nil {
-		b.fieldSet_[52] = true
+		b.fieldSet_[53] = true
 	} else {
-		b.fieldSet_[52] = false
+		b.fieldSet_[53] = false
 	}
 	return b
 }
@@ -859,13 +870,13 @@ func (b *ClusterBuilder) Product(value *ProductBuilder) *ClusterBuilder {
 // Properties sets the value of the 'properties' attribute to the given value.
 func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.properties = value
 	if value != nil {
-		b.fieldSet_[53] = true
+		b.fieldSet_[54] = true
 	} else {
-		b.fieldSet_[53] = false
+		b.fieldSet_[54] = false
 	}
 	return b
 }
@@ -875,13 +886,13 @@ func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 // Contains the properties of the provision shard
 func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.provisionShard = value
 	if value != nil {
-		b.fieldSet_[54] = true
+		b.fieldSet_[55] = true
 	} else {
-		b.fieldSet_[54] = false
+		b.fieldSet_[55] = false
 	}
 	return b
 }
@@ -891,13 +902,13 @@ func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBu
 // Proxy configuration of a cluster.
 func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.proxy = value
 	if value != nil {
-		b.fieldSet_[55] = true
+		b.fieldSet_[56] = true
 	} else {
-		b.fieldSet_[55] = false
+		b.fieldSet_[56] = false
 	}
 	return b
 }
@@ -907,13 +918,13 @@ func (b *ClusterBuilder) Proxy(value *ProxyBuilder) *ClusterBuilder {
 // Description of a region of a cloud provider.
 func (b *ClusterBuilder) Region(value *CloudRegionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.region = value
 	if value != nil {
-		b.fieldSet_[56] = true
+		b.fieldSet_[57] = true
 	} else {
-		b.fieldSet_[56] = false
+		b.fieldSet_[57] = false
 	}
 	return b
 }
@@ -939,13 +950,13 @@ func (b *ClusterBuilder) Region(value *CloudRegionBuilder) *ClusterBuilder {
 // ```
 func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.registryConfig = value
 	if value != nil {
-		b.fieldSet_[57] = true
+		b.fieldSet_[58] = true
 	} else {
-		b.fieldSet_[57] = false
+		b.fieldSet_[58] = false
 	}
 	return b
 }
@@ -955,10 +966,10 @@ func (b *ClusterBuilder) RegistryConfig(value *ClusterRegistryConfigBuilder) *Cl
 // Overall state of a cluster.
 func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.state = value
-	b.fieldSet_[58] = true
+	b.fieldSet_[59] = true
 	return b
 }
 
@@ -967,13 +978,13 @@ func (b *ClusterBuilder) State(value ClusterState) *ClusterBuilder {
 // Detailed status of a cluster.
 func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.status = value
 	if value != nil {
-		b.fieldSet_[59] = true
+		b.fieldSet_[60] = true
 	} else {
-		b.fieldSet_[59] = false
+		b.fieldSet_[60] = false
 	}
 	return b
 }
@@ -1000,13 +1011,13 @@ func (b *ClusterBuilder) Status(value *ClusterStatusBuilder) *ClusterBuilder {
 // - 1 PiB = 2^50 bytes
 func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.storageQuota = value
 	if value != nil {
-		b.fieldSet_[60] = true
+		b.fieldSet_[61] = true
 	} else {
-		b.fieldSet_[60] = false
+		b.fieldSet_[61] = false
 	}
 	return b
 }
@@ -1016,13 +1027,13 @@ func (b *ClusterBuilder) StorageQuota(value *ValueBuilder) *ClusterBuilder {
 // Definition of a subscription.
 func (b *ClusterBuilder) Subscription(value *SubscriptionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.subscription = value
 	if value != nil {
-		b.fieldSet_[61] = true
+		b.fieldSet_[62] = true
 	} else {
-		b.fieldSet_[61] = false
+		b.fieldSet_[62] = false
 	}
 	return b
 }
@@ -1032,13 +1043,13 @@ func (b *ClusterBuilder) Subscription(value *SubscriptionBuilder) *ClusterBuilde
 // Representation of an _OpenShift_ version.
 func (b *ClusterBuilder) Version(value *VersionBuilder) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 63)
+		b.fieldSet_ = make([]bool, 64)
 	}
 	b.version = value
 	if value != nil {
-		b.fieldSet_[62] = true
+		b.fieldSet_[63] = true
 	} else {
-		b.fieldSet_[62] = false
+		b.fieldSet_[63] = false
 	}
 	return b
 }
@@ -1219,6 +1230,7 @@ func (b *ClusterBuilder) Copy(object *Cluster) *ClusterBuilder {
 	} else {
 		b.network = nil
 	}
+	b.nodeSSHPublicKey = object.nodeSSHPublicKey
 	if object.nodeDrainGracePeriod != nil {
 		b.nodeDrainGracePeriod = NewValue().Copy(object.nodeDrainGracePeriod)
 	} else {
@@ -1496,6 +1508,7 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 			return
 		}
 	}
+	object.nodeSSHPublicKey = b.nodeSSHPublicKey
 	if b.nodeDrainGracePeriod != nil {
 		object.nodeDrainGracePeriod, err = b.nodeDrainGracePeriod.Build()
 		if err != nil {

--- a/clientapi/arohcp/v1alpha1/cluster_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type.go
@@ -120,6 +120,7 @@ type Cluster struct {
 	managedService                    *ManagedService
 	name                              string
 	network                           *Network
+	nodeSSHPublicKey                  string
 	nodeDrainGracePeriod              *Value
 	nodePools                         *NodePoolList
 	nodes                             *ClusterNodes
@@ -1286,12 +1287,41 @@ func (o *Cluster) GetNetwork() (value *Network, ok bool) {
 	return
 }
 
+// NodeSSHPublicKey returns the value of the 'node_SSH_public_key' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// The SSH public key used for secure access to cluster nodes. When set, this key
+// is distributed to all nodes, enabling SSH access for debugging
+// and maintenance purposes.
+// This is currently only supported for ARO HCP
+func (o *Cluster) NodeSSHPublicKey() string {
+	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
+		return o.nodeSSHPublicKey
+	}
+	return ""
+}
+
+// GetNodeSSHPublicKey returns the value of the 'node_SSH_public_key' attribute and
+// a flag indicating if the attribute has a value.
+//
+// The SSH public key used for secure access to cluster nodes. When set, this key
+// is distributed to all nodes, enabling SSH access for debugging
+// and maintenance purposes.
+// This is currently only supported for ARO HCP
+func (o *Cluster) GetNodeSSHPublicKey() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
+	if ok {
+		value = o.nodeSSHPublicKey
+	}
+	return
+}
+
 // NodeDrainGracePeriod returns the value of the 'node_drain_grace_period' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // Node drain grace period.
 func (o *Cluster) NodeDrainGracePeriod() *Value {
-	if o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48] {
+	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
 		return o.nodeDrainGracePeriod
 	}
 	return nil
@@ -1302,7 +1332,7 @@ func (o *Cluster) NodeDrainGracePeriod() *Value {
 //
 // Node drain grace period.
 func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 48 && o.fieldSet_[48]
+	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
 	if ok {
 		value = o.nodeDrainGracePeriod
 	}
@@ -1315,7 +1345,7 @@ func (o *Cluster) GetNodeDrainGracePeriod() (value *Value, ok bool) {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) NodePools() *NodePoolList {
-	if o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49] {
+	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
 		return o.nodePools
 	}
 	return nil
@@ -1327,7 +1357,7 @@ func (o *Cluster) NodePools() *NodePoolList {
 // List of node pools on this cluster.
 // NodePool is a scalable set of worker nodes attached to a hosted cluster.
 func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 49 && o.fieldSet_[49]
+	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
 	if ok {
 		value = o.nodePools
 	}
@@ -1339,7 +1369,7 @@ func (o *Cluster) GetNodePools() (value *NodePoolList, ok bool) {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) Nodes() *ClusterNodes {
-	if o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50] {
+	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
 		return o.nodes
 	}
 	return nil
@@ -1350,7 +1380,7 @@ func (o *Cluster) Nodes() *ClusterNodes {
 //
 // Information about the nodes of the cluster.
 func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 50 && o.fieldSet_[50]
+	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
 	if ok {
 		value = o.nodes
 	}
@@ -1367,7 +1397,7 @@ func (o *Cluster) GetNodes() (value *ClusterNodes, ok bool) {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) OpenshiftVersion() string {
-	if o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51] {
+	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
 		return o.openshiftVersion
 	}
 	return ""
@@ -1383,7 +1413,7 @@ func (o *Cluster) OpenshiftVersion() string {
 // When provisioning a cluster this will be ignored, as the version to
 // deploy will be determined internally.
 func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 51 && o.fieldSet_[51]
+	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
 	if ok {
 		value = o.openshiftVersion
 	}
@@ -1395,7 +1425,7 @@ func (o *Cluster) GetOpenshiftVersion() (value string, ok bool) {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) Product() *Product {
-	if o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52] {
+	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
 		return o.product
 	}
 	return nil
@@ -1406,7 +1436,7 @@ func (o *Cluster) Product() *Product {
 //
 // Link to the product type of this cluster.
 func (o *Cluster) GetProduct() (value *Product, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 52 && o.fieldSet_[52]
+	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
 	if ok {
 		value = o.product
 	}
@@ -1418,7 +1448,7 @@ func (o *Cluster) GetProduct() (value *Product, ok bool) {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) Properties() map[string]string {
-	if o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53] {
+	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
 		return o.properties
 	}
 	return nil
@@ -1429,7 +1459,7 @@ func (o *Cluster) Properties() map[string]string {
 //
 // User defined properties for tagging and querying.
 func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 53 && o.fieldSet_[53]
+	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
 	if ok {
 		value = o.properties
 	}
@@ -1441,7 +1471,7 @@ func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) ProvisionShard() *ProvisionShard {
-	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
+	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
 		return o.provisionShard
 	}
 	return nil
@@ -1452,7 +1482,7 @@ func (o *Cluster) ProvisionShard() *ProvisionShard {
 //
 // ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
 func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
+	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
 	if ok {
 		value = o.provisionShard
 	}
@@ -1464,7 +1494,7 @@ func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
 //
 // Proxy.
 func (o *Cluster) Proxy() *Proxy {
-	if o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55] {
+	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
 		return o.proxy
 	}
 	return nil
@@ -1475,7 +1505,7 @@ func (o *Cluster) Proxy() *Proxy {
 //
 // Proxy.
 func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 55 && o.fieldSet_[55]
+	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
 	if ok {
 		value = o.proxy
 	}
@@ -1487,7 +1517,7 @@ func (o *Cluster) GetProxy() (value *Proxy, ok bool) {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) Region() *CloudRegion {
-	if o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56] {
+	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
 		return o.region
 	}
 	return nil
@@ -1498,7 +1528,7 @@ func (o *Cluster) Region() *CloudRegion {
 //
 // Link to the cloud provider region where the cluster is installed.
 func (o *Cluster) GetRegion() (value *CloudRegion, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 56 && o.fieldSet_[56]
+	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
 	if ok {
 		value = o.region
 	}
@@ -1510,7 +1540,7 @@ func (o *Cluster) GetRegion() (value *CloudRegion, ok bool) {
 //
 // External registry configuration for the cluster
 func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
-	if o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57] {
+	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
 		return o.registryConfig
 	}
 	return nil
@@ -1521,7 +1551,7 @@ func (o *Cluster) RegistryConfig() *ClusterRegistryConfig {
 //
 // External registry configuration for the cluster
 func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 57 && o.fieldSet_[57]
+	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
 	if ok {
 		value = o.registryConfig
 	}
@@ -1533,7 +1563,7 @@ func (o *Cluster) GetRegistryConfig() (value *ClusterRegistryConfig, ok bool) {
 //
 // Overall state of the cluster.
 func (o *Cluster) State() ClusterState {
-	if o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58] {
+	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
 		return o.state
 	}
 	return ClusterState("")
@@ -1544,7 +1574,7 @@ func (o *Cluster) State() ClusterState {
 //
 // Overall state of the cluster.
 func (o *Cluster) GetState() (value ClusterState, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 58 && o.fieldSet_[58]
+	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
 	if ok {
 		value = o.state
 	}
@@ -1556,7 +1586,7 @@ func (o *Cluster) GetState() (value ClusterState, ok bool) {
 //
 // Status of cluster
 func (o *Cluster) Status() *ClusterStatus {
-	if o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59] {
+	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
 		return o.status
 	}
 	return nil
@@ -1567,7 +1597,7 @@ func (o *Cluster) Status() *ClusterStatus {
 //
 // Status of cluster
 func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 59 && o.fieldSet_[59]
+	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
 	if ok {
 		value = o.status
 	}
@@ -1579,7 +1609,7 @@ func (o *Cluster) GetStatus() (value *ClusterStatus, ok bool) {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) StorageQuota() *Value {
-	if o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60] {
+	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
 		return o.storageQuota
 	}
 	return nil
@@ -1590,7 +1620,7 @@ func (o *Cluster) StorageQuota() *Value {
 //
 // Storage quota to be assigned to the cluster.
 func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 60 && o.fieldSet_[60]
+	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
 	if ok {
 		value = o.storageQuota
 	}
@@ -1603,7 +1633,7 @@ func (o *Cluster) GetStorageQuota() (value *Value, ok bool) {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) Subscription() *Subscription {
-	if o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61] {
+	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
 		return o.subscription
 	}
 	return nil
@@ -1615,7 +1645,7 @@ func (o *Cluster) Subscription() *Subscription {
 // Link to the subscription that comes from the account management service when the cluster
 // is registered.
 func (o *Cluster) GetSubscription() (value *Subscription, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 61 && o.fieldSet_[61]
+	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
 	if ok {
 		value = o.subscription
 	}
@@ -1627,7 +1657,7 @@ func (o *Cluster) GetSubscription() (value *Subscription, ok bool) {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) Version() *Version {
-	if o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62] {
+	if o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63] {
 		return o.version
 	}
 	return nil
@@ -1638,7 +1668,7 @@ func (o *Cluster) Version() *Version {
 //
 // Link to the version of _OpenShift_ that will be used to install the cluster.
 func (o *Cluster) GetVersion() (value *Version, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 62 && o.fieldSet_[62]
+	ok = o != nil && len(o.fieldSet_) > 63 && o.fieldSet_[63]
 	if ok {
 		value = o.version
 	}

--- a/clientapi/arohcp/v1alpha1/cluster_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type_json.go
@@ -493,7 +493,16 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteNetwork(object.network, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48] && object.nodeDrainGracePeriod != nil
+	present_ = len(object.fieldSet_) > 48 && object.fieldSet_[48]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("node_ssh_public_key")
+		stream.WriteString(object.nodeSSHPublicKey)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49] && object.nodeDrainGracePeriod != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -502,7 +511,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.nodeDrainGracePeriod, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 49 && object.fieldSet_[49] && object.nodePools != nil
+	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.nodePools != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -514,7 +523,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteObjectEnd()
 		count++
 	}
-	present_ = len(object.fieldSet_) > 50 && object.fieldSet_[50] && object.nodes != nil
+	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51] && object.nodes != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -523,7 +532,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterNodes(object.nodes, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 51 && object.fieldSet_[51]
+	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -532,7 +541,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(object.openshiftVersion)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 52 && object.fieldSet_[52] && object.product != nil
+	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.product != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -541,7 +550,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProduct(object.product, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 53 && object.fieldSet_[53] && object.properties != nil
+	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.properties != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -570,7 +579,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.provisionShard != nil
+	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.provisionShard != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -579,7 +588,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProvisionShard(object.provisionShard, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.proxy != nil
+	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.proxy != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -588,7 +597,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteProxy(object.proxy, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 56 && object.fieldSet_[56] && object.region != nil
+	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.region != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -597,7 +606,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteCloudRegion(object.region, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 57 && object.fieldSet_[57] && object.registryConfig != nil
+	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58] && object.registryConfig != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -606,7 +615,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterRegistryConfig(object.registryConfig, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 58 && object.fieldSet_[58]
+	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -615,7 +624,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		stream.WriteString(string(object.state))
 		count++
 	}
-	present_ = len(object.fieldSet_) > 59 && object.fieldSet_[59] && object.status != nil
+	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.status != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -624,7 +633,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteClusterStatus(object.status, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 60 && object.fieldSet_[60] && object.storageQuota != nil
+	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.storageQuota != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -633,7 +642,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteValue(object.storageQuota, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 61 && object.fieldSet_[61] && object.subscription != nil
+	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.subscription != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -642,7 +651,7 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		WriteSubscription(object.subscription, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 62 && object.fieldSet_[62] && object.version != nil
+	present_ = len(object.fieldSet_) > 63 && object.fieldSet_[63] && object.version != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -668,7 +677,7 @@ func UnmarshalCluster(source interface{}) (object *Cluster, err error) {
 // ReadCluster reads a value of the 'cluster' type from the given iterator.
 func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 	object := &Cluster{
-		fieldSet_: make([]bool, 63),
+		fieldSet_: make([]bool, 64),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -996,10 +1005,14 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 			value := ReadNetwork(iterator)
 			object.network = value
 			object.fieldSet_[47] = true
+		case "node_ssh_public_key":
+			value := iterator.ReadString()
+			object.nodeSSHPublicKey = value
+			object.fieldSet_[48] = true
 		case "node_drain_grace_period":
 			value := ReadValue(iterator)
 			object.nodeDrainGracePeriod = value
-			object.fieldSet_[48] = true
+			object.fieldSet_[49] = true
 		case "node_pools":
 			value := &NodePoolList{}
 			for {
@@ -1020,19 +1033,19 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				}
 			}
 			object.nodePools = value
-			object.fieldSet_[49] = true
+			object.fieldSet_[50] = true
 		case "nodes":
 			value := ReadClusterNodes(iterator)
 			object.nodes = value
-			object.fieldSet_[50] = true
+			object.fieldSet_[51] = true
 		case "openshift_version":
 			value := iterator.ReadString()
 			object.openshiftVersion = value
-			object.fieldSet_[51] = true
+			object.fieldSet_[52] = true
 		case "product":
 			value := ReadProduct(iterator)
 			object.product = value
-			object.fieldSet_[52] = true
+			object.fieldSet_[53] = true
 		case "properties":
 			value := map[string]string{}
 			for {
@@ -1044,44 +1057,44 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 				value[key] = item
 			}
 			object.properties = value
-			object.fieldSet_[53] = true
+			object.fieldSet_[54] = true
 		case "provision_shard":
 			value := ReadProvisionShard(iterator)
 			object.provisionShard = value
-			object.fieldSet_[54] = true
+			object.fieldSet_[55] = true
 		case "proxy":
 			value := ReadProxy(iterator)
 			object.proxy = value
-			object.fieldSet_[55] = true
+			object.fieldSet_[56] = true
 		case "region":
 			value := ReadCloudRegion(iterator)
 			object.region = value
-			object.fieldSet_[56] = true
+			object.fieldSet_[57] = true
 		case "registry_config":
 			value := ReadClusterRegistryConfig(iterator)
 			object.registryConfig = value
-			object.fieldSet_[57] = true
+			object.fieldSet_[58] = true
 		case "state":
 			text := iterator.ReadString()
 			value := ClusterState(text)
 			object.state = value
-			object.fieldSet_[58] = true
+			object.fieldSet_[59] = true
 		case "status":
 			value := ReadClusterStatus(iterator)
 			object.status = value
-			object.fieldSet_[59] = true
+			object.fieldSet_[60] = true
 		case "storage_quota":
 			value := ReadValue(iterator)
 			object.storageQuota = value
-			object.fieldSet_[60] = true
+			object.fieldSet_[61] = true
 		case "subscription":
 			value := ReadSubscription(iterator)
 			object.subscription = value
-			object.fieldSet_[61] = true
+			object.fieldSet_[62] = true
 		case "version":
 			value := ReadVersion(iterator)
 			object.version = value
-			object.fieldSet_[62] = true
+			object.fieldSet_[63] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/access_transparency/v1/access_protection_resource.model
+++ b/model/access_transparency/v1/access_protection_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/access_protection_type.model
+++ b/model/access_transparency/v1/access_protection_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,5 +16,5 @@ limitations under the License.
 
 // Representation of an access protection.
 struct AccessProtection {
-  Enabled boolean
+	Enabled boolean
 }

--- a/model/access_transparency/v1/access_request_post_request_type.model
+++ b/model/access_transparency/v1/access_request_post_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/access_request_resource.model
+++ b/model/access_transparency/v1/access_request_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/access_request_state.model
+++ b/model/access_transparency/v1/access_request_state.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Possible states to an access request status.
 enum AccessRequestState {
-    @json(name = "Pending")
-    Pending
+	@json(name = "Pending")
+	Pending
 
-    @json(name = "Approved")
-    Approved
+	@json(name = "Approved")
+	Approved
 
-    @json(name = "Expired")
-    Expired
+	@json(name = "Expired")
+	Expired
 
-    @json(name = "Denied")
-    Denied
+	@json(name = "Denied")
+	Denied
 }

--- a/model/access_transparency/v1/access_request_status_type.model
+++ b/model/access_transparency/v1/access_request_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Representation of an access request status.
 struct AccessRequestStatus {
-  // Current state of the Access Request.
-  State AccessRequestState
+	// Current state of the Access Request.
+	State AccessRequestState
 
-  // Date and time when the access request will expire, using the
-  // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
-  ExpiresAt Date
+	// Date and time when the access request will expire, using the
+	// format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
+	ExpiresAt Date
 }

--- a/model/access_transparency/v1/access_request_type.model
+++ b/model/access_transparency/v1/access_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/access_requests_resource.model
+++ b/model/access_transparency/v1/access_requests_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/decision_decision_type.model
+++ b/model/access_transparency/v1/decision_decision_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Possible decisions to a decision status.
 enum DecisionDecision {
-    @json(name = "Approved")
-    Approved
+	@json(name = "Approved")
+	Approved
 
-    @json(name = "Expired")
-    Expired
+	@json(name = "Expired")
+	Expired
 
-    @json(name = "Denied")
-    Denied
+	@json(name = "Denied")
+	Denied
 }

--- a/model/access_transparency/v1/decision_resource.model
+++ b/model/access_transparency/v1/decision_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/decision_type.model
+++ b/model/access_transparency/v1/decision_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/decisions_resource.model
+++ b/model/access_transparency/v1/decisions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/access_transparency/v1/root_resource.model
+++ b/model/access_transparency/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Root of the tree of resources of the Access Transparency Management.
 resource Root {
-    // Reference to the resource that manages the Access Protection resource.
-    locator AccessProtection {
-        target AccessProtection
-    }
+	// Reference to the resource that manages the Access Protection resource.
+	locator AccessProtection {
+		target AccessProtection
+	}
 
-    // Reference to the resource that manages the collection of Access Requests.
-    locator AccessRequests {
-        target AccessRequests
-    }
+	// Reference to the resource that manages the collection of Access Requests.
+	locator AccessRequests {
+		target AccessRequests
+	}
 
 }

--- a/model/accounts_mgmt/v1/access_token_auth_type.model
+++ b/model/accounts_mgmt/v1/access_token_auth_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/access_token_resource.model
+++ b/model/accounts_mgmt/v1/access_token_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/access_token_type.model
+++ b/model/accounts_mgmt/v1/access_token_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/account_group_assignment_managed_by_type.model
+++ b/model/accounts_mgmt/v1/account_group_assignment_managed_by_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 enum AccountGroupAssignmentManagedBy {
-  // Assignment managed by remote RBAC service, synchronized by job
-  RBAC
+	// Assignment managed by remote RBAC service, synchronized by job
+	RBAC
 
-  // Assignment managed by OCM's API directly
-  OCM
+	// Assignment managed by OCM's API directly
+	OCM
 }

--- a/model/accounts_mgmt/v1/account_group_assignment_resource.model
+++ b/model/accounts_mgmt/v1/account_group_assignment_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/account_group_assignment_type.model
+++ b/model/accounts_mgmt/v1/account_group_assignment_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 class AccountGroupAssignment {
-  CreatedAt Date
-  UpdatedAt Date
-  AccountID String
-  AccountGroupID String
-  AccountGroup AccountGroup
+	CreatedAt Date
+	UpdatedAt Date
+	AccountID String
+	AccountGroupID String
+	AccountGroup AccountGroup
 
-  // Indicates which system manages this account group assignment
-  // Can be either:
-  // RBAC - Assignment managed by remote RBAC service, synchronized by job
-  // OCM - Assignment managed by OCM's APIs directly
-  ManagedBy AccountGroupAssignmentManagedBy
+	// Indicates which system manages this account group assignment
+	// Can be either:
+	// RBAC - Assignment managed by remote RBAC service, synchronized by job
+	// OCM - Assignment managed by OCM's APIs directly
+	ManagedBy AccountGroupAssignmentManagedBy
 }

--- a/model/accounts_mgmt/v1/account_group_assignments_resource.model
+++ b/model/accounts_mgmt/v1/account_group_assignments_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/account_group_managed_by_type.model
+++ b/model/accounts_mgmt/v1/account_group_managed_by_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 enum AccountGroupManagedBy {
-  // Group managed by remote RBAC service, synchronized by job
-  RBAC
+	// Group managed by remote RBAC service, synchronized by job
+	RBAC
 
-  // Group managed by OCM's API directly
-  OCM
+	// Group managed by OCM's API directly
+	OCM
 }

--- a/model/accounts_mgmt/v1/account_group_resource.model
+++ b/model/accounts_mgmt/v1/account_group_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/account_group_type.model
+++ b/model/accounts_mgmt/v1/account_group_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,21 +15,21 @@ limitations under the License.
 */
 
 class AccountGroup {
-  CreatedAt Date
-  UpdatedAt Date
+	CreatedAt Date
+	UpdatedAt Date
 
-  // An optional field for the Platform RBAC's identifier for this account group.
-  // Used when the group is managed by an external RBAC service to track the
-  // corresponding ID in that system.
-  ExternalID String
+	// An optional field for the Platform RBAC's identifier for this account group.
+	// Used when the group is managed by an external RBAC service to track the
+	// corresponding ID in that system.
+	ExternalID String
 
-  Name String
-  Description String
-  OrganizationID String
+	Name String
+	Description String
+	OrganizationID String
 
-  // Indicates which system manages this account group
-  // Can be either:
-  // RBAC - Group managed by remote RBAC service, synchronized by job
-  // OCM - Group managed by OCM's APIs directly
-  ManagedBy AccountGroupManagedBy
+	// Indicates which system manages this account group
+	// Can be either:
+	// RBAC - Group managed by remote RBAC service, synchronized by job
+	// OCM - Group managed by OCM's APIs directly
+	ManagedBy AccountGroupManagedBy
 }

--- a/model/accounts_mgmt/v1/account_groups_resource.model
+++ b/model/accounts_mgmt/v1/account_groups_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/account_resource.model
+++ b/model/accounts_mgmt/v1/account_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,8 +27,8 @@ resource Account {
 	}
 
 	method Delete {
-	    @json(name = "deleteAssociatedResources")
-	    in DeleteAssociatedResources Boolean = false
+		@json(name = "deleteAssociatedResources")
+		in DeleteAssociatedResources Boolean = false
 	}
 
 	// Reference to the list of labels of a specific account.

--- a/model/accounts_mgmt/v1/account_type.model
+++ b/model/accounts_mgmt/v1/account_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,7 +27,7 @@ class Account {
 	ServiceAccount Boolean
 	Organization Organization
 	Labels []Label
-        // RhitAccountID will be deprecated in favor of RhitWebUserId
+		// RhitAccountID will be deprecated in favor of RhitWebUserId
 	RhitAccountID string
 	RhitWebUserId string
 	Capabilities []Capability

--- a/model/accounts_mgmt/v1/accounts_resource.model
+++ b/model/accounts_mgmt/v1/accounts_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/action_type.model
+++ b/model/accounts_mgmt/v1/action_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/billing_model_item_type.model
+++ b/model/accounts_mgmt/v1/billing_model_item_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/billing_model_type.model
+++ b/model/accounts_mgmt/v1/billing_model_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,19 +22,19 @@ enum BillingModel {
 	// BillingModelMarketplace Legacy Marketplace billing model. Currently only used for tests. Use cloud-provider specific billing models instead.
 	Marketplace
 
-    // AWS Marketplace billing model.
-    @json(name = "marketplace-aws")
-    MarketplaceAWS
+	// AWS Marketplace billing model.
+	@json(name = "marketplace-aws")
+	MarketplaceAWS
 
-    // Azure Marketplace billing model.
-    @json(name = "marketplace-azure")
-    MarketplaceAzure
+	// Azure Marketplace billing model.
+	@json(name = "marketplace-azure")
+	MarketplaceAzure
 
-    // RH Marketplace billing model.
-    @json(name = "marketplace-rhm")
-    MarketplaceRHM
+	// RH Marketplace billing model.
+	@json(name = "marketplace-rhm")
+	MarketplaceRHM
 
-    // GCP Marketplace billing model.
-    @json(name = "marketplace-gcp")
-    MarketplaceGCP
+	// GCP Marketplace billing model.
+	@json(name = "marketplace-gcp")
+	MarketplaceGCP
 }

--- a/model/accounts_mgmt/v1/capabilities_resource.model
+++ b/model/accounts_mgmt/v1/capabilities_resource.model
@@ -1,5 +1,5 @@
 resource Capabilities{
-    // Retrieves a list of Capabilities.
+	// Retrieves a list of Capabilities.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
 		in out Page Integer = 1
@@ -16,7 +16,7 @@ resource Capabilities{
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the organization
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve organizations with name starting with my:
+			// retrieve organizations with name starting with my:
 		//
 		// ```sql
 		// name like 'my%'

--- a/model/accounts_mgmt/v1/capability_type.model
+++ b/model/accounts_mgmt/v1/capability_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cloud_account_type.model
+++ b/model/accounts_mgmt/v1/cloud_account_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cloud_resource.model
+++ b/model/accounts_mgmt/v1/cloud_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cloud_resource_type.model
+++ b/model/accounts_mgmt/v1/cloud_resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cloud_resources.model
+++ b/model/accounts_mgmt/v1/cloud_resources.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,15 +42,15 @@ resource CloudResources {
 		out Items []CloudResource
 	}
 
-    // Creates a new cloud resource
-    method Add {
-        in out Body CloudResource
-    }
+	// Creates a new cloud resource
+	method Add {
+		in out Body CloudResource
+	}
 
-    // Reference to the service that manages a specific cloud resource.
-    locator CloudResource {
-        target CloudResource
-        variable ID
-    }
+	// Reference to the service that manages a specific cloud resource.
+	locator CloudResource {
+		target CloudResource
+		variable ID
+	}
 
 }

--- a/model/accounts_mgmt/v1/cluster_authorization_request_type.model
+++ b/model/accounts_mgmt/v1/cluster_authorization_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cluster_authorization_response_type.model
+++ b/model/accounts_mgmt/v1/cluster_authorization_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cluster_authorizations_resource.model
+++ b/model/accounts_mgmt/v1/cluster_authorizations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cluster_metrics_nodes_type.model
+++ b/model/accounts_mgmt/v1/cluster_metrics_nodes_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 struct ClusterMetricsNodes {
-    Total Float
-    Master Float
-    Infra Float
-    Compute Float
+	Total Float
+	Master Float
+	Infra Float
+	Compute Float
 }

--- a/model/accounts_mgmt/v1/cluster_registration_request_type.model
+++ b/model/accounts_mgmt/v1/cluster_registration_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cluster_registration_response_type.model
+++ b/model/accounts_mgmt/v1/cluster_registration_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cluster_registrations_resource.model
+++ b/model/accounts_mgmt/v1/cluster_registrations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/cluster_resource_type.model
+++ b/model/accounts_mgmt/v1/cluster_resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 
 struct ClusterResource {
-    UpdatedTimestamp Date
-    Used ValueUnit
-    Total ValueUnit
+	UpdatedTimestamp Date
+	Used ValueUnit
+	Total ValueUnit
 }

--- a/model/accounts_mgmt/v1/cluster_upgrade_type.model
+++ b/model/accounts_mgmt/v1/cluster_upgrade_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 struct ClusterUpgrade {
-    UpdatedTimestamp Date
-    Available Boolean
-    State String
-    Version String
+	UpdatedTimestamp Date
+	Available Boolean
+	State String
+	Version String
 }

--- a/model/accounts_mgmt/v1/contract_dimension_type.model
+++ b/model/accounts_mgmt/v1/contract_dimension_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/contract_type.model
+++ b/model/accounts_mgmt/v1/contract_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/current_access_resource.model
+++ b/model/accounts_mgmt/v1/current_access_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/current_account_resource.model
+++ b/model/accounts_mgmt/v1/current_account_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/default_capabilities_resource.model
+++ b/model/accounts_mgmt/v1/default_capabilities_resource.model
@@ -1,5 +1,5 @@
 resource DefaultCapabilities{
-    // Retrieves a list of Dedfault Capabilities.
+	// Retrieves a list of Dedfault Capabilities.
 	method List {
 		// Index of the requested page, where one corresponds to the first page.
 		in out Page Integer = 1
@@ -16,7 +16,7 @@ resource DefaultCapabilities{
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the organization
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve organizations with name starting with my:
+			// retrieve organizations with name starting with my:
 		//
 		// ```sql
 		// name like 'my%'
@@ -30,7 +30,7 @@ resource DefaultCapabilities{
 		out Items []DefaultCapability
 	}
 
-    // Creates a new default capability.
+	// Creates a new default capability.
 	method Add {
 		// Default capability data.
 		in out Body DefaultCapability

--- a/model/accounts_mgmt/v1/default_capability_resource.model
+++ b/model/accounts_mgmt/v1/default_capability_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/default_capability_type.model
+++ b/model/accounts_mgmt/v1/default_capability_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 struct DefaultCapability {
-    // Name of the default capability (the key).
+	// Name of the default capability (the key).
 	Name String
-    // Value of the default capability.
+	// Value of the default capability.
 	Value String
 }

--- a/model/accounts_mgmt/v1/deleted_subscription_type.model
+++ b/model/accounts_mgmt/v1/deleted_subscription_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/deleted_subscriptions_resource.model
+++ b/model/accounts_mgmt/v1/deleted_subscriptions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/feature_toggle_query_request_type.model
+++ b/model/accounts_mgmt/v1/feature_toggle_query_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/feature_toggle_query_resource.model
+++ b/model/accounts_mgmt/v1/feature_toggle_query_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/feature_toggle_resource.model
+++ b/model/accounts_mgmt/v1/feature_toggle_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/feature_toggle_type.model
+++ b/model/accounts_mgmt/v1/feature_toggle_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/features_toggle_resource.model
+++ b/model/accounts_mgmt/v1/features_toggle_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/generic_label_resource.model
+++ b/model/accounts_mgmt/v1/generic_label_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/generic_labels_resource.model
+++ b/model/accounts_mgmt/v1/generic_labels_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/generic_notify_details_response_type.model
+++ b/model/accounts_mgmt/v1/generic_notify_details_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/label_type.model
+++ b/model/accounts_mgmt/v1/label_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 class Label {
-    Key String
-    Value String
-    Internal Boolean
-    Type String
-    ManagedBy String
-    AccountID String
-    SubscriptionID String
-    OrganizationID String
-    CreatedAt Date
-    UpdatedAt Date
+	Key String
+	Value String
+	Internal Boolean
+	Type String
+	ManagedBy String
+	AccountID String
+	SubscriptionID String
+	OrganizationID String
+	CreatedAt Date
+	UpdatedAt Date
 }

--- a/model/accounts_mgmt/v1/labels_resource.model
+++ b/model/accounts_mgmt/v1/labels_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ resource Labels {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the organization
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve labels with name starting with my:
+			// retrieve labels with name starting with my:
 		//
 		// ```sql
 		// name like 'my%'

--- a/model/accounts_mgmt/v1/notify_details_request_type.model
+++ b/model/accounts_mgmt/v1/notify_details_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/notify_details_resource.model
+++ b/model/accounts_mgmt/v1/notify_details_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/notify_details_response_type.model
+++ b/model/accounts_mgmt/v1/notify_details_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/organization_resource.model
+++ b/model/accounts_mgmt/v1/organization_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -48,13 +48,13 @@ resource Organization {
 		target QuotaCost
 	}
 
-  // Reference to the service that manages the account groups for this organization.
-  locator AccountGroups {
-    target AccountGroups
-  }
+	// Reference to the service that manages the account groups for this organization.
+	locator AccountGroups {
+	target AccountGroups
+	}
 
-  // Reference to the service that manages the account group assignments for this organization.
-  locator AccountGroupAssignments {
-    target AccountGroupAssignments 
-  }
+	// Reference to the service that manages the account group assignments for this organization.
+	locator AccountGroupAssignments {
+	target AccountGroupAssignments 
+	}
 }

--- a/model/accounts_mgmt/v1/organization_type.model
+++ b/model/accounts_mgmt/v1/organization_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/organizations_resource.model
+++ b/model/accounts_mgmt/v1/organizations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ resource Organizations {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the organization
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve organizations with name starting with my:
+			// retrieve organizations with name starting with my:
 		//
 		// ```sql
 		// name like 'my%'
@@ -43,7 +43,7 @@ resource Organizations {
 		// items that the user has permission to see will be returned.
 		in Search String
 
- 		// Projection
+			// Projection
 		// This field contains a comma-separated list of fields you'd like to get in
 		// a result. No new fields can be added, only existing ones can be filtered.
 		// To specify a field 'id' of a structure 'plan' use 'plan.id'.

--- a/model/accounts_mgmt/v1/permission_resource.model
+++ b/model/accounts_mgmt/v1/permission_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/permission_type.model
+++ b/model/accounts_mgmt/v1/permission_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/permissions_resource.model
+++ b/model/accounts_mgmt/v1/permissions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/plan_type.model
+++ b/model/accounts_mgmt/v1/plan_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 class Plan {
-    Name String
-    Type String
-    Category String
+	Name String
+	Type String
+	Category String
 }

--- a/model/accounts_mgmt/v1/pull_secret_resource.model
+++ b/model/accounts_mgmt/v1/pull_secret_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/pull_secrets_request_type.model
+++ b/model/accounts_mgmt/v1/pull_secrets_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/pull_secrets_resource.model
+++ b/model/accounts_mgmt/v1/pull_secrets_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_authorization_request_type.model
+++ b/model/accounts_mgmt/v1/quota_authorization_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_authorization_response_type.model
+++ b/model/accounts_mgmt/v1/quota_authorization_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_authorizations_resource.model
+++ b/model/accounts_mgmt/v1/quota_authorizations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_cost_resource.model
+++ b/model/accounts_mgmt/v1/quota_cost_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_cost_type.model
+++ b/model/accounts_mgmt/v1/quota_cost_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_rules_resource.model
+++ b/model/accounts_mgmt/v1/quota_rules_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/quota_rules_type.model
+++ b/model/accounts_mgmt/v1/quota_rules_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/registries_resource.model
+++ b/model/accounts_mgmt/v1/registries_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/registry_credential_resource.model
+++ b/model/accounts_mgmt/v1/registry_credential_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/registry_credential_type.model
+++ b/model/accounts_mgmt/v1/registry_credential_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,5 +21,5 @@ class RegistryCredential {
 	Registry Registry
 	Account Account
 	CreatedAt Date
-    UpdatedAt Date
+	UpdatedAt Date
 }

--- a/model/accounts_mgmt/v1/registry_credentials_resource.model
+++ b/model/accounts_mgmt/v1/registry_credentials_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/registry_resource.model
+++ b/model/accounts_mgmt/v1/registry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/registry_type.model
+++ b/model/accounts_mgmt/v1/registry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,5 +22,5 @@ class Registry {
 	Type String
 	CloudAlias Boolean
 	CreatedAt Date
-    UpdatedAt Date
+	UpdatedAt Date
 }

--- a/model/accounts_mgmt/v1/related_resource_type.model
+++ b/model/accounts_mgmt/v1/related_resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/reserved_resource_type.model
+++ b/model/accounts_mgmt/v1/reserved_resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/resource_quota_resource.model
+++ b/model/accounts_mgmt/v1/resource_quota_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/resource_quota_type.model
+++ b/model/accounts_mgmt/v1/resource_quota_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,5 +20,5 @@ class ResourceQuota {
 	SkuCount Integer
 	Type String
 	CreatedAt Date
-    UpdatedAt Date
+	UpdatedAt Date
 }

--- a/model/accounts_mgmt/v1/resource_quotas_resource.model
+++ b/model/accounts_mgmt/v1/resource_quotas_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/resource_type.model
+++ b/model/accounts_mgmt/v1/resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Identifies computing resources
 class Resource {
-    SKU String
+	SKU String
 	// platform-specific name, such as "M5.2Xlarge" for a type of EC2 node
 	ResourceName String
 	ResourceType String

--- a/model/accounts_mgmt/v1/role_binding_resource.model
+++ b/model/accounts_mgmt/v1/role_binding_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/role_binding_type.model
+++ b/model/accounts_mgmt/v1/role_binding_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/role_bindings_resource.model
+++ b/model/accounts_mgmt/v1/role_bindings_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/role_resource.model
+++ b/model/accounts_mgmt/v1/role_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/role_type.model
+++ b/model/accounts_mgmt/v1/role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/roles_resource.model
+++ b/model/accounts_mgmt/v1/roles_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ resource Roles {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the role
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve roles named starting with `Organization`:
+			// retrieve roles named starting with `Organization`:
 		//
 		// ```sql
 		// name like 'Organization%'

--- a/model/accounts_mgmt/v1/root_resource.model
+++ b/model/accounts_mgmt/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/sku_rule_resource.model
+++ b/model/accounts_mgmt/v1/sku_rule_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/sku_rule_type.model
+++ b/model/accounts_mgmt/v1/sku_rule_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,9 +19,9 @@ class SkuRule {
 	// Specifies the sku, such as ""MW00504""
 	Sku String
 
-    // Specifies the quota id
+	// Specifies the quota id
 	QuotaId String
 
-    // Specifies the allowed parameter for calculation
+	// Specifies the allowed parameter for calculation
 	Allowed Integer
 }

--- a/model/accounts_mgmt/v1/sku_rules_resource.model
+++ b/model/accounts_mgmt/v1/sku_rules_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,7 +33,7 @@ resource SkuRules {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the SKU
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve SKUS large sized resources:
+			// retrieve SKUS large sized resources:
 		//
 		// ```sql
 		// resource_name like '%large'

--- a/model/accounts_mgmt/v1/subscription_metrics_type.model
+++ b/model/accounts_mgmt/v1/subscription_metrics_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,26 +17,26 @@ limitations under the License.
 
 // Each field is a metric fetched for a specific Subscription's cluster.
 struct SubscriptionMetrics {
-    HealthState String
-    Memory ClusterResource
-    Cpu ClusterResource
-    Sockets ClusterResource
-    ComputeNodesMemory ClusterResource
-    ComputeNodesCpu ClusterResource
-    ComputeNodesSockets ClusterResource
-    Storage ClusterResource
-    Nodes ClusterMetricsNodes
-    OperatingSystem String
-    Upgrade ClusterUpgrade
-    State String
-    StateDescription String
-    OpenshiftVersion String
-    CloudProvider String
-    Region String
-    ConsoleUrl String
-    CriticalAlertsFiring Float
-    OperatorsConditionFailing Float
-    SubscriptionCpuTotal Float
-    SubscriptionSocketTotal Float
-    SubscriptionObligationExists Float
+	HealthState String
+	Memory ClusterResource
+	Cpu ClusterResource
+	Sockets ClusterResource
+	ComputeNodesMemory ClusterResource
+	ComputeNodesCpu ClusterResource
+	ComputeNodesSockets ClusterResource
+	Storage ClusterResource
+	Nodes ClusterMetricsNodes
+	OperatingSystem String
+	Upgrade ClusterUpgrade
+	State String
+	StateDescription String
+	OpenshiftVersion String
+	CloudProvider String
+	Region String
+	ConsoleUrl String
+	CriticalAlertsFiring Float
+	OperatorsConditionFailing Float
+	SubscriptionCpuTotal Float
+	SubscriptionSocketTotal Float
+	SubscriptionObligationExists Float
 }

--- a/model/accounts_mgmt/v1/subscription_registration_type.model
+++ b/model/accounts_mgmt/v1/subscription_registration_type.model
@@ -3,7 +3,7 @@ Copyright (c) 2020 Red Hat, Inc.
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/model/accounts_mgmt/v1/subscription_reserved_resource_resource.model
+++ b/model/accounts_mgmt/v1/subscription_reserved_resource_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/subscription_reserved_resources_resource.model
+++ b/model/accounts_mgmt/v1/subscription_reserved_resources_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/subscription_resource.model
+++ b/model/accounts_mgmt/v1/subscription_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -42,8 +42,8 @@ resource Subscription {
 		target GenericLabels
 	}
 
-    //Reference to the role bindings
+	//Reference to the role bindings
 	locator RoleBindings {
-        	target RoleBindings
-    }
+			target RoleBindings
+	}
 }

--- a/model/accounts_mgmt/v1/subscription_type.model
+++ b/model/accounts_mgmt/v1/subscription_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/subscriptions_resource.model
+++ b/model/accounts_mgmt/v1/subscriptions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -86,7 +86,7 @@ resource Subscriptions {
 		out Items []Subscription
 	}
 
-    // Create a new subscription and register a cluster for it.
+	// Create a new subscription and register a cluster for it.
 	method Post {
 		in Request SubscriptionRegistration
 		out Response Subscription

--- a/model/accounts_mgmt/v1/summary_dashboard_resource.model
+++ b/model/accounts_mgmt/v1/summary_dashboard_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/summary_dashboard_type.model
+++ b/model/accounts_mgmt/v1/summary_dashboard_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/summary_metrics_type.model
+++ b/model/accounts_mgmt/v1/summary_metrics_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/summary_vector_type.model
+++ b/model/accounts_mgmt/v1/summary_vector_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/support_case_request_type.model
+++ b/model/accounts_mgmt/v1/support_case_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,24 +15,24 @@ limitations under the License.
 */
 
 class SupportCaseRequest {
-    // Support case title.
-    Summary String
+	// Support case title.
+	Summary String
 
-    // Support case desciption.
-    Description String
-    
-    // Support case severity.
-    Severity String
+	// Support case desciption.
+	Description String
+	
+	// Support case severity.
+	Severity String
 
-    // (optional) event stream id for the support case so we could track it.
-    EventStreamId String
+	// (optional) event stream id for the support case so we could track it.
+	EventStreamId String
 
-    // (optional) cluster uuid of the cluster on which we create the support case for.
-    ClusterUuid String
+	// (optional) cluster uuid of the cluster on which we create the support case for.
+	ClusterUuid String
 
-    // (optional) cluster id of the cluster on which we create the support case for.
-    ClusterId String
+	// (optional) cluster id of the cluster on which we create the support case for.
+	ClusterId String
 
-    // (optional) subscription id of the subscription on which we create the support case for.
-    SubscriptionId String
+	// (optional) subscription id of the subscription on which we create the support case for.
+	SubscriptionId String
 }

--- a/model/accounts_mgmt/v1/support_case_resource.model
+++ b/model/accounts_mgmt/v1/support_case_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/support_case_response_type.model
+++ b/model/accounts_mgmt/v1/support_case_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,30 +15,30 @@ limitations under the License.
 */
 
 class SupportCaseResponse {
-    // Support case title.
-    Summary String
+	// Support case title.
+	Summary String
 
-    // Support case desciption.
-    Description String
-    
-    // Support case severity.
-    Severity String
+	// Support case desciption.
+	Description String
+	
+	// Support case severity.
+	Severity String
 
-    // Support case status.
-    Status String
+	// Support case status.
+	Status String
 
-    // Support case uri.
-    URI String
+	// Support case uri.
+	URI String
 
-    // Support case number.
-    CaseNumber String
+	// Support case number.
+	CaseNumber String
 
-    // (optional) cluster uuid of the cluster on which we created the support case for.
-    ClusterUuid String
+	// (optional) cluster uuid of the cluster on which we created the support case for.
+	ClusterUuid String
 
-    // (optional) cluster id of the cluster on which we created the support case for.
-    ClusterId String
+	// (optional) cluster id of the cluster on which we created the support case for.
+	ClusterId String
 
-    // (optional) subscription id of the subscription on which we created the support case for.
-    SubscriptionId String
+	// (optional) subscription id of the subscription on which we created the support case for.
+	SubscriptionId String
 }

--- a/model/accounts_mgmt/v1/support_cases_resource.model
+++ b/model/accounts_mgmt/v1/support_cases_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/template_parameter_type.model
+++ b/model/accounts_mgmt/v1/template_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/token_authorization_request_type.model
+++ b/model/accounts_mgmt/v1/token_authorization_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 struct TokenAuthorizationRequest {
-    // The pull secret of a given account
+	// The pull secret of a given account
 	AuthorizationToken String
 }

--- a/model/accounts_mgmt/v1/token_authorization_resource.model
+++ b/model/accounts_mgmt/v1/token_authorization_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/accounts_mgmt/v1/token_authorization_response_type.model
+++ b/model/accounts_mgmt/v1/token_authorization_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 struct TokenAuthorizationResponse {
-    Account Account
+	Account Account
 }

--- a/model/accounts_mgmt/v1/value_unit_type.model
+++ b/model/accounts_mgmt/v1/value_unit_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 
 struct ValueUnit {
-    Value Float
-    Unit String
+	Value Float
+	Unit String
 }

--- a/model/addons_mgmt/v1/addon_cluster_resources.model
+++ b/model/addons_mgmt/v1/addon_cluster_resources.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Manages a specific cluster.
 resource Cluster {
-    // Reference to the status of addon installation on a specific cluster
-    locator Status {
-        target AddonStatuses
-    }
+	// Reference to the status of addon installation on a specific cluster
+	locator Status {
+		target AddonStatuses
+	}
 
-    // Reference to the inquiries of addons on a specific cluster
-    locator AddonInquiries {
-        target AddonInquiries
-    }
+	// Reference to the inquiries of addons on a specific cluster
+	locator AddonInquiries {
+		target AddonInquiries
+	}
 
-    // Reference to the installations of addon on a specific cluster
-    locator Addons {
-        target AddonInstallations
-    }
+	// Reference to the installations of addon on a specific cluster
+	locator Addons {
+		target AddonInstallations
+	}
 }

--- a/model/addons_mgmt/v1/addon_clusters_resource.model
+++ b/model/addons_mgmt/v1/addon_clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages a list of clusters.
 resource Clusters {
-    // Reference to the specific cluster which an addon can be installed on
-    locator Cluster {
-        target Cluster
-        variable ID
-    }
+	// Reference to the specific cluster which an addon can be installed on
+	locator Cluster {
+		target Cluster
+		variable ID
+	}
 }

--- a/model/addons_mgmt/v1/addon_config_type.model
+++ b/model/addons_mgmt/v1/addon_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ limitations under the License.
 // Representation of an addon config.
 // The attributes under it are to be used by the addon once its installed in the cluster.
 struct AddonConfig {
-    // List of environment variables for the addon
-    AddOnEnvironmentVariables []AddonEnvironmentVariable
+	// List of environment variables for the addon
+	AddOnEnvironmentVariables []AddonEnvironmentVariable
 
-    // List of secret propagations for the addon
-    AddOnSecretPropagations []AddonSecretPropagation
+	// List of secret propagations for the addon
+	AddOnSecretPropagations []AddonSecretPropagation
 }

--- a/model/addons_mgmt/v1/addon_credential_request_type.model
+++ b/model/addons_mgmt/v1/addon_credential_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Contains the necessary attributes to allow each operator to access the necessary AWS resources
 struct CredentialRequest {
-    // Name of the credentials secret used to access cloud resources
-    Name String
+	// Name of the credentials secret used to access cloud resources
+	Name String
 
-    // Namespace where the credentials secret lives in the cluster
-    Namespace String
+	// Namespace where the credentials secret lives in the cluster
+	Namespace String
 
-    // Service account name to use when authenticating
-    ServiceAccount String
+	// Service account name to use when authenticating
+	ServiceAccount String
 
-    // List of policy permissions needed to access cloud resources
-    PolicyPermissions []String
+	// List of policy permissions needed to access cloud resources
+	PolicyPermissions []String
 }

--- a/model/addons_mgmt/v1/addon_environment_variable_type.model
+++ b/model/addons_mgmt/v1/addon_environment_variable_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon env object.
 struct AddonEnvironmentVariable {
-    // ID for the environment variable
-    ID string
+	// ID for the environment variable
+	ID string
 
-    // Name of the environment variable
-    Name String
+	// Name of the environment variable
+	Name String
 
-    // Value of the environment variable
-    Value String
+	// Value of the environment variable
+	Value String
 
-    // Indicates is this environment variable is enabled for the addon
-    Enabled Boolean
+	// Indicates is this environment variable is enabled for the addon
+	Enabled Boolean
 }

--- a/model/addons_mgmt/v1/addon_inquiries_resource.model
+++ b/model/addons_mgmt/v1/addon_inquiries_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,53 +17,53 @@ limitations under the License.
 // Manages add-on inquiries, inquiries perform validation of add-on(s) on a per cluster basis
 // based on add-on conditions and requirements.
 resource AddonInquiries {
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Maximum number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // Search criteria.
-        //
-        // The syntax of this parameter is similar to the syntax of the _where_ clause of an
-        // SQL statement, but using the names of the attributes of the add-on instead of
-        // the names of the columns of a table. For example, in order to retrieve all the
-        // add-ons with a name starting with `my` the value should be:
-        //
-        // ```sql
-        // name like 'my%'
-        // ```
-        //
-        // If the parameter isn't provided, or if the value is empty, then all the add-ons
-        // that the user has permission to see will be returned.
-        in Search String
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+		// SQL statement, but using the names of the attributes of the add-on instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// add-ons with a name starting with `my` the value should be:
+		//
+		// ```sql
+		// name like 'my%'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the add-ons
+		// that the user has permission to see will be returned.
+		in Search String
 
-        // Order criteria.
-        //
-        // The syntax of this parameter is similar to the syntax of the _order by_ clause of
-        // a SQL statement, but using the names of the attributes of the add-on instead of
-        // the names of the columns of a table. For example, in order to sort the add-ons
-        // descending by name the value should be:
-        //
-        // ```sql
-        // name desc
-        // ```
-        //
-        // If the parameter isn't provided, or if the value is empty, then the order of the
-        // results is undefined.
-        in Order String
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the add-on instead of
+		// the names of the columns of a table. For example, in order to sort the add-ons
+		// descending by name the value should be:
+		//
+		// ```sql
+		// name desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page.
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
 
-        // Retrieved list of add-ons.
-        out Items []Addon
-    }
+		// Retrieved list of add-ons.
+		out Items []Addon
+	}
 
-    locator AddonInquiry {
-        target AddonInquiry
-        variable AddonID
-    }
+	locator AddonInquiry {
+		target AddonInquiry
+		variable AddonID
+	}
 }

--- a/model/addons_mgmt/v1/addon_inquiry_resource.model
+++ b/model/addons_mgmt/v1/addon_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Manages a specific add-on inquiry
 resource AddonInquiry {
-    method Get {
-        out Body Addon
-    }
+	method Get {
+		out Body Addon
+	}
 }

--- a/model/addons_mgmt/v1/addon_install_mode_type.model
+++ b/model/addons_mgmt/v1/addon_install_mode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,11 +16,11 @@ limitations under the License.
 
 // Representation of an addon InstallMode field.
 enum AddonInstallMode {
-    // This mode means that the the addon CRD exists in a single specific namespace.
-    // This namespace is reflected by the TargetNamespace addon field
-    OwnNamespace
+	// This mode means that the the addon CRD exists in a single specific namespace.
+	// This namespace is reflected by the TargetNamespace addon field
+	OwnNamespace
 
-    // This mode means that the addon is deployed in all namespaces.
-    // However, the addon status is retrieved from the target namespace
-    AllNamespaces
+	// This mode means that the addon is deployed in all namespaces.
+	// However, the addon status is retrieved from the target namespace
+	AllNamespaces
 }

--- a/model/addons_mgmt/v1/addon_installation_billing_model_type.model
+++ b/model/addons_mgmt/v1/addon_installation_billing_model_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an billing model field.
 enum BillingModel {
-    @json(name = "marketplace")
-    Marketplace
+	@json(name = "marketplace")
+	Marketplace
 
-    @json(name = "marketplace-aws")
-    MarketplaceAws
+	@json(name = "marketplace-aws")
+	MarketplaceAws
 
-    @json(name = "marketplace-rhm")
-    MarketplaceRhm
+	@json(name = "marketplace-rhm")
+	MarketplaceRhm
 
-    @json(name = "marketplace-azure")
-    MarketplaceAzure
+	@json(name = "marketplace-azure")
+	MarketplaceAzure
 
-    @json(name = "standard")
-    Standard
+	@json(name = "standard")
+	Standard
 }

--- a/model/addons_mgmt/v1/addon_installation_billing_type.model
+++ b/model/addons_mgmt/v1/addon_installation_billing_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an add-on installation billing.
 struct AddonInstallationBilling {
-    // Indicates the type of this object
-    Kind String
+	// Indicates the type of this object
+	Kind String
 
-    // Unique identifier of the object
-    Id String
+	// Unique identifier of the object
+	Id String
 
-    // Self link
-    Href String
+	// Self link
+	Href String
 
-    // Billing Model for addon resources
-    BillingModel BillingModel
-    
-    // Account ID for billing market place
-    BillingMarketplaceAccount String
+	// Billing Model for addon resources
+	BillingModel BillingModel
+	
+	// Account ID for billing market place
+	BillingMarketplaceAccount String
 }

--- a/model/addons_mgmt/v1/addon_installation_object_reference_type.model
+++ b/model/addons_mgmt/v1/addon_installation_object_reference_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // representation of object reference/subscription
 struct ObjectReference {
-    // Indicates the type of this object.
-    Kind String
+	// Indicates the type of this object.
+	Kind String
 
-    // Unique identifier of the object.
-    Id String
+	// Unique identifier of the object.
+	Id String
 
-    // Self Link
-    Href String
+	// Self Link
+	Href String
 }

--- a/model/addons_mgmt/v1/addon_installation_parameter_type.model
+++ b/model/addons_mgmt/v1/addon_installation_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // representation of addon installation parameter
 struct AddonInstallationParameter {
-    // Indicates the type of this object
-    Kind String
+	// Indicates the type of this object
+	Kind String
 
-    // Unique identifier of the object
-    Id String
+	// Unique identifier of the object
+	Id String
 
-    // Self link
-    Href String
+	// Self link
+	Href String
 
-    // Value of the parameter
-    Value String
+	// Value of the parameter
+	Value String
 }

--- a/model/addons_mgmt/v1/addon_installation_parameters_type.model
+++ b/model/addons_mgmt/v1/addon_installation_parameters_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // representation of addon installation parameter
 struct AddonInstallationParameters {
-    // list of addon installation parameters
-    Items []AddonInstallationParameter
+	// list of addon installation parameters
+	Items []AddonInstallationParameter
 }

--- a/model/addons_mgmt/v1/addon_installation_resource.model
+++ b/model/addons_mgmt/v1/addon_installation_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/addons_mgmt/v1/addon_installation_state_type.model
+++ b/model/addons_mgmt/v1/addon_installation_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,33 +16,33 @@ limitations under the License.
 
 // representation of addon installation state
 enum AddonInstallationState {
-    @json(name = "deleting")
-    Deleting
+	@json(name = "deleting")
+	Deleting
 
-    @json(name = "failed")
-    Failed
+	@json(name = "failed")
+	Failed
 
-    @json(name = "installing")
-    Installing
+	@json(name = "installing")
+	Installing
 
-    @json(name = "pending")
-    Pending
+	@json(name = "pending")
+	Pending
 
-    @json(name = "ready")
-    Ready
+	@json(name = "ready")
+	Ready
 
-    @json(name = "upgrading")
-    Upgrading
+	@json(name = "upgrading")
+	Upgrading
 
-    @json(name = "deleted")
-    Deleted
+	@json(name = "deleted")
+	Deleted
 
-    @json(name = "delete-pending")
-    DeletePending
+	@json(name = "delete-pending")
+	DeletePending
 
-    @json(name = "delete-failed")
-    DeleteFailed
+	@json(name = "delete-failed")
+	DeleteFailed
 
-    @json(name = "undefined")
-    Undefined
+	@json(name = "undefined")
+	Undefined
 }

--- a/model/addons_mgmt/v1/addon_installation_type.model
+++ b/model/addons_mgmt/v1/addon_installation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,42 +16,42 @@ limitations under the License.
 
 // Representation of addon installation
 class AddonInstallation {
-    // Addon installed
-    Addon Addon
+	// Addon installed
+	Addon Addon
 
-    // Addon version of the addon
-    AddonVersion AddonVersion
+	// Addon version of the addon
+	AddonVersion AddonVersion
 
-    // Billing of addon installation.
-    Billing AddonInstallationBilling
+	// Billing of addon installation.
+	Billing AddonInstallationBilling
 
-    // Date and time when the add-on was initially installed in the cluster.
-    CreationTimestamp Date
+	// Date and time when the add-on was initially installed in the cluster.
+	CreationTimestamp Date
 
-    // Version of the operator installed by the add-on.
-    OperatorVersion String
+	// Version of the operator installed by the add-on.
+	OperatorVersion String
 
-    // Version of the next scheduled upgrade
-    DesiredVersion String
+	// Version of the next scheduled upgrade
+	DesiredVersion String
 
-    // Current CSV installed on cluster
-    CsvName String
+	// Current CSV installed on cluster
+	CsvName String
 
-    // Parameters in the installation
-    link Parameters []AddonInstallationParameter
+	// Parameters in the installation
+	link Parameters []AddonInstallationParameter
 
-    // Addon Installation State
-    State AddonInstallationState
+	// Addon Installation State
+	State AddonInstallationState
 
-    // Subscription for the addon installation
-    Subscription ObjectReference
+	// Subscription for the addon installation
+	Subscription ObjectReference
 
-    // Reason for the current State.
-    StateDescription String
+	// Reason for the current State.
+	StateDescription String
 
-    // Date and time when the add-on installation information was last updated.
-    UpdatedTimestamp Date
+	// Date and time when the add-on installation information was last updated.
+	UpdatedTimestamp Date
 
-    // Date and time when the add-on installation deleted at.
-    DeletedTimestamp Date
+	// Date and time when the add-on installation deleted at.
+	DeletedTimestamp Date
 }

--- a/model/addons_mgmt/v1/addon_installations_resource.model
+++ b/model/addons_mgmt/v1/addon_installations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/addons_mgmt/v1/addon_metrics_federation_type.model
+++ b/model/addons_mgmt/v1/addon_metrics_federation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of Metrics Federation
 struct MetricsFederation {
-    // Indicates the name of the service port fronting the prometheus server.
-    PortName String
+	// Indicates the name of the service port fronting the prometheus server.
+	PortName String
 
-    // Namespace where the prometheus server is running.
-    Namespace String
+	// Namespace where the prometheus server is running.
+	Namespace String
 
-    // List of series names to federate from the prometheus server.
-    MatchNames []String
+	// List of series names to federate from the prometheus server.
+	MatchNames []String
 
-    // List of labels used to discover the prometheus server(s) to be federated.
-    MatchLabels [String]String
+	// List of labels used to discover the prometheus server(s) to be federated.
+	MatchLabels [String]String
 }

--- a/model/addons_mgmt/v1/addon_namespace_type.model
+++ b/model/addons_mgmt/v1/addon_namespace_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon namespace object.
 struct AddonNamespace {
-    // Name of the namespace
-    Name String
+	// Name of the namespace
+	Name String
 
-    // Enabled shows if this namespace object is in use
-    Enabled Boolean
+	// Enabled shows if this namespace object is in use
+	Enabled Boolean
 
-    // Labels to be included in the addon namespace
-    Labels [String]String
+	// Labels to be included in the addon namespace
+	Labels [String]String
 
-    // Annotations to be included in the addon namespace
-    Annotations [String]String
+	// Annotations to be included in the addon namespace
+	Annotations [String]String
 }

--- a/model/addons_mgmt/v1/addon_parameter_option_type.model
+++ b/model/addons_mgmt/v1/addon_parameter_option_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon parameter option.
 struct AddonParameterOption {
-    // Name of the addon parameter option.
-    Name String
+	// Name of the addon parameter option.
+	Name String
 
-    // Value of the addon parameter option.
-    Value String
+	// Value of the addon parameter option.
+	Value String
 
-    // Rank of option to be used in cases where editable direction should be restricted.
-    Rank Integer
+	// Rank of option to be used in cases where editable direction should be restricted.
+	Rank Integer
 
-    // List of addon requirements for this parameter option.
-    Requirements []AddonRequirement
+	// List of addon requirements for this parameter option.
+	Requirements []AddonRequirement
 }

--- a/model/addons_mgmt/v1/addon_parameter_type.model
+++ b/model/addons_mgmt/v1/addon_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,48 +16,48 @@ limitations under the License.
 
 // Representation of an addon parameter.
 struct AddonParameter {
-    // ID for this addon parameter
-    ID String
+	// ID for this addon parameter
+	ID String
 
-    // Name of the addon parameter.
-    Name String
+	// Name of the addon parameter.
+	Name String
 
-    // Description of the addon parameter.
-    Description String
+	// Description of the addon parameter.
+	Description String
 
-    // Type of value of the addon parameter.
-    ValueType AddonParameterValueType
+	// Type of value of the addon parameter.
+	ValueType AddonParameterValueType
 
-    // Validation rule for the addon parameter.
-    Validation String
+	// Validation rule for the addon parameter.
+	Validation String
 
-    // Error message to return should the parameter be invalid.
-    ValidationErrMsg String
+	// Error message to return should the parameter be invalid.
+	ValidationErrMsg String
 
-    // Indicates if this parameter is required by the addon.
-    Required Boolean
+	// Indicates if this parameter is required by the addon.
+	Required Boolean
 
-    // Indicates if this parameter can be edited after creation.
-    Editable Boolean
+	// Indicates if this parameter can be edited after creation.
+	Editable Boolean
 
-    // Restricts if the parameter can be upscaled/downscaled
-    // Expected values are "up", "down", or "" (no restriction).
-    EditableDirection String
+	// Restricts if the parameter can be upscaled/downscaled
+	// Expected values are "up", "down", or "" (no restriction).
+	EditableDirection String
 
-    // Indicates if this parameter is enabled for the addon.
-    Enabled Boolean
+	// Indicates if this parameter is enabled for the addon.
+	Enabled Boolean
 
-    // Indicates the value default for the addon parameter.
-    DefaultValue String
+	// Indicates the value default for the addon parameter.
+	DefaultValue String
 
-    // List of options for the addon parameter value.
-    Options []AddonParameterOption
+	// List of options for the addon parameter value.
+	Options []AddonParameterOption
 
-    // Conditions in which this parameter is valid for
-    Conditions []AddonRequirement
+	// Conditions in which this parameter is valid for
+	Conditions []AddonRequirement
 
-    Addon Addon
+	Addon Addon
 
-    // Indicates the weight of the AddonParameter which would be used by sort order
-    Order Integer
+	// Indicates the weight of the AddonParameter which would be used by sort order
+	Order Integer
 }

--- a/model/addons_mgmt/v1/addon_parameter_value_type.model
+++ b/model/addons_mgmt/v1/addon_parameter_value_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Representation of the value type for this specific addon parameter
 enum AddonParameterValueType {
-    // This value type must be a valid string
-    String
+	// This value type must be a valid string
+	String
 
-    // This value type must be a valid boolean
-    Boolean
+	// This value type must be a valid boolean
+	Boolean
 
-    // This value type must be a valid number, this includes integer and float type numbers
-    Number
+	// This value type must be a valid number, this includes integer and float type numbers
+	Number
 
-    // This value type enforces a valid CIDR value to be passed as parameter value
-    CIDR
+	// This value type enforces a valid CIDR value to be passed as parameter value
+	CIDR
 
-    // This value must match a valid SKU resource in OCM
-    Resource
+	// This value must match a valid SKU resource in OCM
+	Resource
 
-    // This value must match a valid SKU resource in OCM and allows for validation of SKU resource in OCM
-    ResourceRequirement
+	// This value must match a valid SKU resource in OCM and allows for validation of SKU resource in OCM
+	ResourceRequirement
 }

--- a/model/addons_mgmt/v1/addon_parameters_type.model
+++ b/model/addons_mgmt/v1/addon_parameters_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Representation of AddonParameters
 struct AddonParameters {
-    // List of addon parameters
-    Items []AddonParameter
+	// List of addon parameters
+	Items []AddonParameter
 }

--- a/model/addons_mgmt/v1/addon_requirement_resource_type.model
+++ b/model/addons_mgmt/v1/addon_requirement_resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,13 @@ limitations under the License.
 
 // Addon requirement resource type
 enum AddonRequirementResource {
-    // This requirement resource data will be validated and checked against cluster resources
-    Cluster
+	// This requirement resource data will be validated and checked against cluster resources
+	Cluster
 
-    // This requirement resource data will be validated and checked against machine pool resources
-    @json(name = "machine_pool")
-    MachinePool
+	// This requirement resource data will be validated and checked against machine pool resources
+	@json(name = "machine_pool")
+	MachinePool
 
-    // This requirement resource data will be validated and checked against addon installation resources
-    Addon
+	// This requirement resource data will be validated and checked against addon installation resources
+	Addon
 }

--- a/model/addons_mgmt/v1/addon_requirement_status_type.model
+++ b/model/addons_mgmt/v1/addon_requirement_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of an addon requirement status.
 struct AddonRequirementStatus {
-    // Indicates if this requirement is fulfilled.
-    Fulfilled Boolean
+	// Indicates if this requirement is fulfilled.
+	Fulfilled Boolean
 
-    // Error messages detailing reasons for unfulfilled requirements.
-    ErrorMsgs []String
+	// Error messages detailing reasons for unfulfilled requirements.
+	ErrorMsgs []String
 }

--- a/model/addons_mgmt/v1/addon_requirement_type.model
+++ b/model/addons_mgmt/v1/addon_requirement_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an addon requirement.
 struct AddonRequirement {
-    // ID of the addon requirement.
-    ID String
+	// ID of the addon requirement.
+	ID String
 
-    // Type of resource of the addon requirement.
-    Resource AddonRequirementResource
+	// Type of resource of the addon requirement.
+	Resource AddonRequirementResource
 
-    // Data for the addon requirement.
-    Data [String]Interface
+	// Data for the addon requirement.
+	Data [String]Interface
 
-    // Indicates if this requirement is enabled for the addon.
-    Enabled Boolean
+	// Indicates if this requirement is enabled for the addon.
+	Enabled Boolean
 
-    // Optional cluster specific status for the addon.
-    Status AddonRequirementStatus
+	// Optional cluster specific status for the addon.
+	Status AddonRequirementStatus
 }

--- a/model/addons_mgmt/v1/addon_resource.model
+++ b/model/addons_mgmt/v1/addon_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/addons_mgmt/v1/addon_secret_propagation_type.model
+++ b/model/addons_mgmt/v1/addon_secret_propagation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon secret propagation
 struct AddonSecretPropagation {
-    // ID of the secret propagation
-    ID string
+	// ID of the secret propagation
+	ID string
 
-    // SourceSecret is location of the source secret
-    SourceSecret String
+	// SourceSecret is location of the source secret
+	SourceSecret String
 
-    // DestinationSecret is location of the secret to be added
-    DestinationSecret String
+	// DestinationSecret is location of the secret to be added
+	DestinationSecret String
 
-    // Indicates is this secret propagation is enabled for the addon
-    Enabled Boolean
+	// Indicates is this secret propagation is enabled for the addon
+	Enabled Boolean
 }

--- a/model/addons_mgmt/v1/addon_status_condition_type.model
+++ b/model/addons_mgmt/v1/addon_status_condition_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ limitations under the License.
 
 // Representation of an addon status condition type.
 struct AddonStatusCondition {
-    // Type of the reported addon status condition
-    StatusType AddonStatusConditionType
+	// Type of the reported addon status condition
+	StatusType AddonStatusConditionType
 
-    // Value of the reported addon status condition
-    StatusValue AddonStatusConditionValue
+	// Value of the reported addon status condition
+	StatusValue AddonStatusConditionValue
 
-    // Reason for the condition
-    Reason String
+	// Reason for the condition
+	Reason String
 
-    // Message for the condition
-    Message String
+	// Message for the condition
+	Message String
 }

--- a/model/addons_mgmt/v1/addon_status_condition_type_type.model
+++ b/model/addons_mgmt/v1/addon_status_condition_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,30 +16,30 @@ limitations under the License.
 
 // Representation of an addon status condition type field.
 enum AddonStatusConditionType {
-    @json(name = "Available")
-    Available
+	@json(name = "Available")
+	Available
 
-    @json(name = "Healthy")
-    Healthy
+	@json(name = "Healthy")
+	Healthy
 
-    @json(name = "Installed")
-    Installed
+	@json(name = "Installed")
+	Installed
 
-    @json(name = "Degraded")
-    Degraded
+	@json(name = "Degraded")
+	Degraded
 
-    @json(name = "UpgradeStarted")
-    UpgradeStarted
+	@json(name = "UpgradeStarted")
+	UpgradeStarted
 
-    @json(name = "Paused")
-    Paused
+	@json(name = "Paused")
+	Paused
 
-    @json(name = "UpgradeSucceeded")
-    UpgradeSucceeded
+	@json(name = "UpgradeSucceeded")
+	UpgradeSucceeded
 
-    @json(name = "ReadyToBeDeleted")
-    ReadyToBeDeleted
+	@json(name = "ReadyToBeDeleted")
+	ReadyToBeDeleted
 
-    @json(name = "DeleteTimeout")
-    DeleteTimeout
+	@json(name = "DeleteTimeout")
+	DeleteTimeout
 }

--- a/model/addons_mgmt/v1/addon_status_condition_value_type.model
+++ b/model/addons_mgmt/v1/addon_status_condition_value_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Representation of an addon status condition value field.
 enum AddonStatusConditionValue {
-    @json(name = "True")
-    True
+	@json(name = "True")
+	True
 
-    @json(name = "False")
-    False
+	@json(name = "False")
+	False
 
-    @json(name = "Unknown")
-    Unknown
+	@json(name = "Unknown")
+	Unknown
 }

--- a/model/addons_mgmt/v1/addon_status_resource.model
+++ b/model/addons_mgmt/v1/addon_status_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Manages a specific addon status.
 resource AddonStatus {
-    // Retrieves the details of the addon version.
-    method Get {
-        out Body AddonStatus
-    }
+	// Retrieves the details of the addon version.
+	method Get {
+		out Body AddonStatus
+	}
 
-    // Updates the addon version.
-    method Update {
-        in out Body AddonStatus
-    }
+	// Updates the addon version.
+	method Update {
+		in out Body AddonStatus
+	}
 
-    // Deletes the addon version.
-    method Delete {
-    }
+	// Deletes the addon version.
+	method Delete {
+	}
 }

--- a/model/addons_mgmt/v1/addon_status_type.model
+++ b/model/addons_mgmt/v1/addon_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ limitations under the License.
 
 // Representation of an addon status.
 class AddonStatus {
-    // ID of the addon whose status belongs to.
-    AddonId String
+	// ID of the addon whose status belongs to.
+	AddonId String
 
-    // Identifier for co-relating current AddonCR revision and reported status.
-    CorrelationID String
+	// Identifier for co-relating current AddonCR revision and reported status.
+	CorrelationID String
 
-    // List of reported addon status conditions
-    StatusConditions []AddonStatusCondition
+	// List of reported addon status conditions
+	StatusConditions []AddonStatusCondition
 
-    // Version of the addon reporting the status
-    Version String
+	// Version of the addon reporting the status
+	Version String
 }

--- a/model/addons_mgmt/v1/addon_statuses_resource.model
+++ b/model/addons_mgmt/v1/addon_statuses_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,34 +16,34 @@ limitations under the License.
 
 // Manages the collection of addon statuses for a cluster.
 resource AddonStatuses {
-    // Retrieves the list of addon statuses for a cluster.
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	// Retrieves the list of addon statuses for a cluster.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Maximum number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // If the parameter isn't provided, or if the value is empty, then the order of the
-        // results is undefined.
-        in Order String
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
-        // Total number of items of the collection regardless of the size of the page.
-        out Total Integer
+		// Total number of items of the collection regardless of the size of the page.
+		out Total Integer
 
-        // Retrieved list of addon status conditions
-        out Items []AddonStatus
-    }
+		// Retrieved list of addon status conditions
+		out Items []AddonStatus
+	}
 
-    // Create a new addon status and add it to the collection of addons statuses.
-    method Add {
-        // Description of the addon status.
-        in out Body AddonStatus
-    }
+	// Create a new addon status and add it to the collection of addons statuses.
+	method Add {
+		// Description of the addon status.
+		in out Body AddonStatus
+	}
 
-    // Returns a reference to a specific addon status.
-    locator Addon {
-        target AddonStatus
-        variable ID
-    }
+	// Returns a reference to a specific addon status.
+	locator Addon {
+		target AddonStatus
+		variable ID
+	}
 }

--- a/model/addons_mgmt/v1/addon_sub_operator_type.model
+++ b/model/addons_mgmt/v1/addon_sub_operator_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ limitations under the License.
 // Representation of an addon sub operator. A sub operator is an operator
 // who's life cycle is controlled by the addon umbrella operator.
 struct AddonSubOperator {
-    // Name of the addon sub operator
-    OperatorName String
+	// Name of the addon sub operator
+	OperatorName String
 
-    // Namespace of the addon sub operator
-    OperatorNamespace String
+	// Namespace of the addon sub operator
+	OperatorNamespace String
 
-    // Indicates if the sub operator is enabled for the addon
-    Enabled Boolean
+	// Indicates if the sub operator is enabled for the addon
+	Enabled Boolean
 
-    Addon Addon
+	Addon Addon
 }
 

--- a/model/addons_mgmt/v1/addon_type.model
+++ b/model/addons_mgmt/v1/addon_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,72 +16,72 @@ limitations under the License.
 
 // Representation of an addon that can be installed in a cluster.
 class Addon {
-    // Name of the addon.
-    Name String
+	// Name of the addon.
+	Name String
 
-    // Description of the addon.
-    Description String
+	// Description of the addon.
+	Description String
 
-    // Link to documentation about the addon.
-    DocsLink String
+	// Link to documentation about the addon.
+	DocsLink String
 
-    // Label used to attach to a cluster deployment when addon is installed.
-    Label String
+	// Label used to attach to a cluster deployment when addon is installed.
+	Label String
 
-    // Base64-encoded icon representing an addon. The icon should be in PNG format.
-    Icon String
+	// Base64-encoded icon representing an addon. The icon should be in PNG format.
+	Icon String
 
-    // Indicates if this addon can be added to clusters.
-    Enabled Boolean
+	// Indicates if this addon can be added to clusters.
+	Enabled Boolean
 
-    // Indicates if this addon is hidden.
-    Hidden Boolean
+	// Indicates if this addon is hidden.
+	Hidden Boolean
 
-    // Used to determine from where to reserve quota for this addon.
-    ResourceName String
+	// Used to determine from where to reserve quota for this addon.
+	ResourceName String
 
-    // Used to determine how many units of quota an addon consumes per resource name.
-    ResourceCost Float
+	// Used to determine how many units of quota an addon consumes per resource name.
+	ResourceCost Float
 
-    // The namespace in which the addon CRD exists.
-    TargetNamespace String
+	// The namespace in which the addon CRD exists.
+	TargetNamespace String
 
-    // The mode in which the addon is deployed.
-    InstallMode AddonInstallMode
+	// The mode in which the addon is deployed.
+	InstallMode AddonInstallMode
 
-    // The name of the operator installed by this addon.
-    OperatorName String
+	// The name of the operator installed by this addon.
+	OperatorName String
 
-    // Indicates if this addon has external resources associated with it
-    HasExternalResources Boolean
+	// Indicates if this addon has external resources associated with it
+	HasExternalResources Boolean
 
-    // List of parameters for this addon.
-    link Parameters []AddonParameter
+	// List of parameters for this addon.
+	link Parameters []AddonParameter
 
-    // List of requirements for this addon.
-    Requirements []AddonRequirement
+	// List of requirements for this addon.
+	Requirements []AddonRequirement
 
-    // List of sub operators for this addon.
-    SubOperators []AddonSubOperator
+	// List of sub operators for this addon.
+	SubOperators []AddonSubOperator
 
-    // List of credentials requests to authenticate operators to access cloud resources.
-    CredentialsRequests []CredentialRequest
+	// List of credentials requests to authenticate operators to access cloud resources.
+	CredentialsRequests []CredentialRequest
 
-    // Additional configs to be used by the addon once its installed in the cluster.
-    Config  AddonConfig
+	// Additional configs to be used by the addon once its installed in the cluster.
+	Config  AddonConfig
 
-    // List of namespaces associated with this addon.
-    Namespaces []AddonNamespace
+	// List of namespaces associated with this addon.
+	Namespaces []AddonNamespace
 
-    // Link to the current default version of this addon.
-    link Version AddonVersion
+	// Link to the current default version of this addon.
+	link Version AddonVersion
 
-    // Indicates if addon is part of a managed service
-    ManagedService Boolean
+	// Indicates if addon is part of a managed service
+	ManagedService Boolean
 
-    // Common Labels for this addon.
-    CommonLabels [String]String
+	// Common Labels for this addon.
+	CommonLabels [String]String
 
-    // Common Annotations for this addon.
-    CommonAnnotations [String]String
+	// Common Annotations for this addon.
+	CommonAnnotations [String]String
 }

--- a/model/addons_mgmt/v1/addon_version_additional_catalog_sources_type.model
+++ b/model/addons_mgmt/v1/addon_version_additional_catalog_sources_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon catalog source object used by addon versions.
 struct AdditionalCatalogSource {
-    // ID of the additional catalog source
-    ID String
+	// ID of the additional catalog source
+	ID String
 
-    // Name of the additional catalog source.
-    Name String
+	// Name of the additional catalog source.
+	Name String
 
-    // Image of the additional catalog source.
-    Image String
+	// Image of the additional catalog source.
+	Image String
 
-    // Indicates is this additional catalog source is enabled for the addon
-    Enabled Boolean
+	// Indicates is this additional catalog source is enabled for the addon
+	Enabled Boolean
 }

--- a/model/addons_mgmt/v1/addon_version_monitoring_stack_resource_type.model
+++ b/model/addons_mgmt/v1/addon_version_monitoring_stack_resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of Monitoring Stack Resource
 struct MonitoringStackResource {
-    // Indicates the CPU resource for monitoring stack.
-    Cpu String
+	// Indicates the CPU resource for monitoring stack.
+	Cpu String
 
-    // Indicates the memory resource for monitoring stack.
-    Memory String
+	// Indicates the memory resource for monitoring stack.
+	Memory String
 }

--- a/model/addons_mgmt/v1/addon_version_monitoring_stack_resources_type.model
+++ b/model/addons_mgmt/v1/addon_version_monitoring_stack_resources_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of Monitoring Stack Resources
 struct MonitoringStackResources {
-    // Indicates the requested amount of resource for monitoring stack.
-    Requests MonitoringStackResource
+	// Indicates the requested amount of resource for monitoring stack.
+	Requests MonitoringStackResource
 
-    // Indicates the limit of resource for monitoring stack.
-    Limits MonitoringStackResource
+	// Indicates the limit of resource for monitoring stack.
+	Limits MonitoringStackResource
 }

--- a/model/addons_mgmt/v1/addon_version_monitoring_stack_type.model
+++ b/model/addons_mgmt/v1/addon_version_monitoring_stack_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of Monitoring Stack
 struct MonitoringStack {
-    // Indicates if the monitoring stack can be added to clusters for the addon.
-    Enabled Boolean
+	// Indicates if the monitoring stack can be added to clusters for the addon.
+	Enabled Boolean
 
-    // Indicates the resources for the monitoring stack
-    Resources MonitoringStackResources
+	// Indicates the resources for the monitoring stack
+	Resources MonitoringStackResources
 }

--- a/model/addons_mgmt/v1/addon_version_resource.model
+++ b/model/addons_mgmt/v1/addon_version_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/addons_mgmt/v1/addon_version_type.model
+++ b/model/addons_mgmt/v1/addon_version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,45 +16,45 @@ limitations under the License.
 
 // Representation of an addon version.
 class AddonVersion {
-    // Indicates if this addon version can be added to clusters.
-    Enabled Boolean
+	// Indicates if this addon version can be added to clusters.
+	Enabled Boolean
 
-    // The catalog source image for this addon version.
-    SourceImage String
+	// The catalog source image for this addon version.
+	SourceImage String
 
-    // The pull secret name used for this addon version.
-    PullSecretName String
+	// The pull secret name used for this addon version.
+	PullSecretName String
 
-    // The specific addon catalog source channel of packages
-    Channel String
+	// The specific addon catalog source channel of packages
+	Channel String
 
-    // Additional catalog sources associated with this addon version
-    AdditionalCatalogSources []AdditionalCatalogSource
+	// Additional catalog sources associated with this addon version
+	AdditionalCatalogSources []AdditionalCatalogSource
 
-    // The url for the package image
-    PackageImage String
+	// The url for the package image
+	PackageImage String
 
-    // Indicates if upgrade plans have been created for this addon version
-    UpgradePlansCreated Boolean
+	// Indicates if upgrade plans have been created for this addon version
+	UpgradePlansCreated Boolean
 
-    // List of parameters for this addon version.
-    Parameters AddonParameters
+	// List of parameters for this addon version.
+	Parameters AddonParameters
 
-    // List of requirements for this addon version.
-    Requirements []AddonRequirement
+	// List of requirements for this addon version.
+	Requirements []AddonRequirement
 
-    // List of sub operators for this addon version.
-    SubOperators []AddonSubOperator
+	// List of sub operators for this addon version.
+	SubOperators []AddonSubOperator
 
-    // Additional configs to be used by the addon once its installed in the cluster.
-    Config  AddonConfig
+	// Additional configs to be used by the addon once its installed in the cluster.
+	Config  AddonConfig
 
-    // AvailableUpgrades is the list of versions this version can be upgraded to.
-    AvailableUpgrades []String
+	// AvailableUpgrades is the list of versions this version can be upgraded to.
+	AvailableUpgrades []String
 
-    // Configuration parameters which will determine the underlying configuration of the MonitoringStack CR. 
-    MonitoringStack MonitoringStack
+	// Configuration parameters which will determine the underlying configuration of the MonitoringStack CR. 
+	MonitoringStack MonitoringStack
 
-    // Configuration parameters to be injected in the ServiceMonitor used for federation.
-    MetricsFederation MetricsFederation
+	// Configuration parameters to be injected in the ServiceMonitor used for federation.
+	MetricsFederation MetricsFederation
 }

--- a/model/addons_mgmt/v1/addon_versions_resource.model
+++ b/model/addons_mgmt/v1/addon_versions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/addons_mgmt/v1/addons_resource.model
+++ b/model/addons_mgmt/v1/addons_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/addons_mgmt/v1/root_resource.model
+++ b/model/addons_mgmt/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,13 @@ limitations under the License.
 
 // Root of the tree of resources of the Addons Management.
 resource Root {
-    // Reference to the resource that manages the collection of Addons.
-    locator Addons {
-        target Addons
-    }
+	// Reference to the resource that manages the collection of Addons.
+	locator Addons {
+		target Addons
+	}
 
-    locator Clusters {
-        target Clusters
-    }
+	locator Clusters {
+		target Clusters
+	}
 
 }

--- a/model/aro_hcp/v1alpha1/UpgradePolicyStateValue.model
+++ b/model/aro_hcp/v1alpha1/UpgradePolicyStateValue.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Overall state of a cluster upgrade policy.
 enum UpgradePolicyStateValue {
-    // Upgrade policy set but an upgrade wasn't scheduled yet
-    Pending
+	// Upgrade policy set but an upgrade wasn't scheduled yet
+	Pending
 
-    // Upgrade policy set and was scheduled
-    Scheduled
+	// Upgrade policy set and was scheduled
+	Scheduled
 
-    // Upgrade started
-    Started
+	// Upgrade started
+	Started
 
-    // Upgrade completed (temporary state - the policy will be removed in case of 
-    // manual upgrade, or move back to pending in case of automatic upgrade)
-    Completed
+	// Upgrade completed (temporary state - the policy will be removed in case of 
+	// manual upgrade, or move back to pending in case of automatic upgrade)
+	Completed
 
-    // Upgrade failed
-    Failed
+	// Upgrade failed
+	Failed
 
-    // Upgrade is taking longer than expected
-    Delayed
+	// Upgrade is taking longer than expected
+	Delayed
 
-    // Upgrade got cancelled (temporary state - the policy will get removed).
-    Cancelled
+	// Upgrade got cancelled (temporary state - the policy will get removed).
+	Cancelled
 }

--- a/model/aro_hcp/v1alpha1/add_on_additional_catalog_sources_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_additional_catalog_sources_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon catalog source object used by addon versions.
 struct AdditionalCatalogSource {
-    // ID of the additional catalog source
-    ID String
+	// ID of the additional catalog source
+	ID String
 
-    // Name of the additional catalog source.
-    Name String
+	// Name of the additional catalog source.
+	Name String
 
-    // Image of the additional catalog source.
-    Image String
+	// Image of the additional catalog source.
+	Image String
 
-    // Indicates is this additional catalog source is enabled for the addon
-    Enabled Boolean
+	// Indicates is this additional catalog source is enabled for the addon
+	Enabled Boolean
 }

--- a/model/aro_hcp/v1alpha1/add_on_config_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ limitations under the License.
 // Representation of an add-on config.
 // The attributes under it are to be used by the addon once its installed in the cluster.
 class AddOnConfig {
-    // List of environment variables for the addon
-    AddOnEnvironmentVariables []AddOnEnvironmentVariable
+	// List of environment variables for the addon
+	AddOnEnvironmentVariables []AddOnEnvironmentVariable
 
-    // List of secret propagations for the addon
-    SecretPropagations []AddOnSecretPropagation
+	// List of secret propagations for the addon
+	SecretPropagations []AddOnSecretPropagation
 }

--- a/model/aro_hcp/v1alpha1/add_on_environment_variable_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_environment_variable_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of an add-on env object.
 class AddOnEnvironmentVariable {
-    // Name of the env object.
-    Name String
+	// Name of the env object.
+	Name String
 
-    // Value of the env object.
-    Value String
+	// Value of the env object.
+	Value String
 }

--- a/model/aro_hcp/v1alpha1/add_on_install_mode_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_install_mode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_installation_billing.model
+++ b/model/aro_hcp/v1alpha1/add_on_installation_billing.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Representation of an add-on installation billing.
 class AddOnInstallationBilling {
-  // Billing Model for addon resources
-  BillingModel BillingModel
-  // Account ID for billing market place
-  BillingMarketplaceAccount String
+	// Billing Model for addon resources
+	BillingModel BillingModel
+	// Account ID for billing market place
+	BillingMarketplaceAccount String
 }

--- a/model/aro_hcp/v1alpha1/add_on_installation_parameter_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_installation_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_installation_state_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_installation_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_installation_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_installation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_namespace_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_namespace_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 class AddOnNamespace{
-    // Name of the namespace.
-    Name String
-    
-    // Labels to be applied to this namespace.
-    Labels [String]String
+	// Name of the namespace.
+	Name String
+	
+	// Labels to be applied to this namespace.
+	Labels [String]String
 
-    // Annotations to be applied to this namespace.
-    Annotations [String]String
+	// Annotations to be applied to this namespace.
+	Annotations [String]String
 }

--- a/model/aro_hcp/v1alpha1/add_on_parameter_option_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_parameter_option_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_parameter_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_requirement_status_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_requirement_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_requirement_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_requirement_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ struct AddOnRequirement {
 	// Indicates if this requirement is enabled for the add-on.
 	Enabled Boolean
 
-    // Optional cluster specific status for the add-on.
+	// Optional cluster specific status for the add-on.
 	Status AddOnRequirementStatus
 
 }

--- a/model/aro_hcp/v1alpha1/add_on_secret_propagation_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_secret_propagation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon secret propagation
 struct AddOnSecretPropagation {
-    // ID of the secret propagation
-    ID string
+	// ID of the secret propagation
+	ID string
 
-    // SourceSecret is location of the source secret
-    SourceSecret String
+	// SourceSecret is location of the source secret
+	SourceSecret String
 
-    // DestinationSecret is location of the secret to be added
-    DestinationSecret String
+	// DestinationSecret is location of the secret to be added
+	DestinationSecret String
 
-    // Indicates is this secret propagation is enabled for the addon
-    Enabled Boolean
+	// Indicates is this secret propagation is enabled for the addon
+	Enabled Boolean
 }

--- a/model/aro_hcp/v1alpha1/add_on_sub_operator_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_sub_operator_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,14 +17,14 @@ limitations under the License.
 // Representation of an add-on sub operator. A sub operator is an operator
 // who's life cycle is controlled by the add-on umbrella operator. 
 struct AddOnSubOperator {
-  
-  // Name of the add-on sub operator
-  OperatorName String
+	
+	// Name of the add-on sub operator
+	OperatorName String
 
-  // Namespace of the add-on sub operator
-  OperatorNamespace String
- 
-  // Indicates if the sub operator is enabled for the add-on
-  Enabled Boolean
+	// Namespace of the add-on sub operator
+	OperatorNamespace String
+	
+	// Indicates if the sub operator is enabled for the add-on
+	Enabled Boolean
 }
 

--- a/model/aro_hcp/v1alpha1/add_on_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/add_on_version_type.model
+++ b/model/aro_hcp/v1alpha1/add_on_version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/addon_upgrade_policy_state_type.model
+++ b/model/aro_hcp/v1alpha1/addon_upgrade_policy_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/addon_upgrade_policy_type.model
+++ b/model/aro_hcp/v1alpha1/addon_upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/admin_credentials_type.model
+++ b/model/aro_hcp/v1alpha1/admin_credentials_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/alert_info_type.model
+++ b/model/aro_hcp/v1alpha1/alert_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/alert_severity_type.model
+++ b/model/aro_hcp/v1alpha1/alert_severity_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/alerts_info_type.model
+++ b/model/aro_hcp/v1alpha1/alerts_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/ami_override_type.model
+++ b/model/aro_hcp/v1alpha1/ami_override_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // AMIOverride specifies what Amazon Machine Image should be used for a particular product and region.
 class AMIOverride {
-    // Link to the product type.
-    link Product Product
+	// Link to the product type.
+	link Product Product
 
-    // Link to the cloud provider region.
-    link Region CloudRegion
+	// Link to the cloud provider region.
+	link Region CloudRegion
 
-    // AMI is the id of the Amazon Machine Image.
-    AMI String
+	// AMI is the id of the Amazon Machine Image.
+	AMI String
 }

--- a/model/aro_hcp/v1alpha1/audit_log_type.model
+++ b/model/aro_hcp/v1alpha1/audit_log_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/autoscaler_resource.model
+++ b/model/aro_hcp/v1alpha1/autoscaler_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/autoscaler_resource_limits_gpu_limit_type.model
+++ b/model/aro_hcp/v1alpha1/autoscaler_resource_limits_gpu_limit_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/autoscaler_resource_limits_type.model
+++ b/model/aro_hcp/v1alpha1/autoscaler_resource_limits_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/autoscaler_scale_down_config_type.model
+++ b/model/aro_hcp/v1alpha1/autoscaler_scale_down_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_autonode_type.model
+++ b/model/aro_hcp/v1alpha1/aws_autonode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
 struct AwsAutoNode {
-    // The AWS ARN of the IAM Role that has the permissions required for the AutoNode
-    // controller.
-    // The role must exist prior to enabling AutoNode on the cluster.
-    RoleArn String
+	// The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+	// controller.
+	// The role must exist prior to enabling AutoNode on the cluster.
+	RoleArn String
 }

--- a/model/aro_hcp/v1alpha1/aws_backup_config_type.model
+++ b/model/aro_hcp/v1alpha1/aws_backup_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Backup configuration for AWS clusters
 struct AWSBackupConfig {
-    // ID of the AWS Disaster Recovery (DR) account
-    AccountId           string
+	// ID of the AWS Disaster Recovery (DR) account
+	AccountId           string
 
-    // ARN of the role used by the CS Trusted Account to gain access to the Disaster Recovery (DR) account
-    RoleArn             string
+	// ARN of the role used by the CS Trusted Account to gain access to the Disaster Recovery (DR) account
+	RoleArn             string
 
-    // ARN of the identity provider created in the Disaster Recovery (DR) account for the Management Cluster
-    IdentityProviderArn string
+	// ARN of the identity provider created in the Disaster Recovery (DR) account for the Management Cluster
+	IdentityProviderArn string
 
-    // Name of the S3 bucket used to save the backup
-    S3Bucket            string
+	// Name of the S3 bucket used to save the backup
+	S3Bucket            string
 
-    // Name of the management cluster the backup config refers to
-    ManagementCluster String
+	// Name of the management cluster the backup config refers to
+	ManagementCluster String
 }

--- a/model/aro_hcp/v1alpha1/aws_capacity_reservation_type.model
+++ b/model/aro_hcp/v1alpha1/aws_capacity_reservation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // AWS Capacity Reservation specification.
 struct AWSCapacityReservation {
-    // Specify the target Capacity Reservation in which the EC2 instances will be launched.
-    Id String
+	// Specify the target Capacity Reservation in which the EC2 instances will be launched.
+	Id String
 
-    // marketType specifies the market type of the CapacityReservation for the EC2
-    // instances. Valid values are OnDemand, CapacityBlocks.
-    // "OnDemand": EC2 instances run as standard On-Demand instances.
-    // "CapacityBlocks": scheduled pre-purchased compute capacity.
-    MarketType MarketType
+	// marketType specifies the market type of the CapacityReservation for the EC2
+	// instances. Valid values are OnDemand, CapacityBlocks.
+	// "OnDemand": EC2 instances run as standard On-Demand instances.
+	// "CapacityBlocks": scheduled pre-purchased compute capacity.
+	MarketType MarketType
 }

--- a/model/aro_hcp/v1alpha1/aws_etcd_enryption_type.model
+++ b/model/aro_hcp/v1alpha1/aws_etcd_enryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_flavour_type.model
+++ b/model/aro_hcp/v1alpha1/aws_flavour_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_http_token_state_type.model
+++ b/model/aro_hcp/v1alpha1/aws_http_token_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_grant_state_type.model
+++ b/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_grant_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_grant_type.model
+++ b/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_grant_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_state_type.model
+++ b/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_type.model
+++ b/model/aro_hcp/v1alpha1/aws_infrastructure_access_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_machine_pool_type.model
+++ b/model/aro_hcp/v1alpha1/aws_machine_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Representation of aws machine pool specific parameters.
 class AWSMachinePool {
-    // Use spot instances on this machine pool to reduce cost.
-    SpotMarketOptions AWSSpotMarketOptions
+	// Use spot instances on this machine pool to reduce cost.
+	SpotMarketOptions AWSSpotMarketOptions
 
-    // Additional AWS Security Groups to be added machine pool. Note that machine pools can only be worker node at the time.
-    AdditionalSecurityGroupIds []String
+	// Additional AWS Security Groups to be added machine pool. Note that machine pools can only be worker node at the time.
+	AdditionalSecurityGroupIds []String
 
-    // Associates nodepool subnets with AWS Outposts.
-    SubnetOutposts [String]String
+	// Associates nodepool subnets with AWS Outposts.
+	SubnetOutposts [String]String
 
-    // Associates nodepool availability zones with zone types (e.g. wavelength, local).
-    AvailabilityZoneTypes [String]String
+	// Associates nodepool availability zones with zone types (e.g. wavelength, local).
+	AvailabilityZoneTypes [String]String
 
-    // Optional keys and values that the machine pool provisioner will add as AWS tags to all AWS resources it creates.
-    //
-    // AWS tags must conform to the following standards:
-    // - Each resource may have a maximum of 25 tags
-    // - Tags beginning with "aws:" are reserved for system use and may not be set
-    // - Tag keys may be between 1 and 128 characters in length
-    // - Tag values may be between 0 and 256 characters in length
-    // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
-    Tags [String]String
+	// Optional keys and values that the machine pool provisioner will add as AWS tags to all AWS resources it creates.
+	//
+	// AWS tags must conform to the following standards:
+	// - Each resource may have a maximum of 25 tags
+	// - Tags beginning with "aws:" are reserved for system use and may not be set
+	// - Tag keys may be between 1 and 128 characters in length
+	// - Tag values may be between 0 and 256 characters in length
+	// - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
+	Tags [String]String
 }

--- a/model/aro_hcp/v1alpha1/aws_node_pool_type.model
+++ b/model/aro_hcp/v1alpha1/aws_node_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,39 +16,39 @@ limitations under the License.
 
 // Representation of aws node pool specific parameters.
 class AWSNodePool {
-    // InstanceType is an ec2 instance type for node instances (e.g. m5.large).
-    InstanceType String
+	// InstanceType is an ec2 instance type for node instances (e.g. m5.large).
+	InstanceType String
 
-    // InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
-    InstanceProfile String
+	// InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
+	InstanceProfile String
 
-    // Optional keys and values that the installer will add as tags to all AWS resources it creates.
-    //
-    // AWS tags must conform to the following standards:
-    // - Each resource may have a maximum of 25 tags
-    // - Tags beginning with "aws:" are reserved for system use and may not be set
-    // - Tag keys may be between 1 and 128 characters in length
-    // - Tag values may be between 0 and 256 characters in length
-    // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
-    Tags [String]String
+	// Optional keys and values that the installer will add as tags to all AWS resources it creates.
+	//
+	// AWS tags must conform to the following standards:
+	// - Each resource may have a maximum of 25 tags
+	// - Tags beginning with "aws:" are reserved for system use and may not be set
+	// - Tag keys may be between 1 and 128 characters in length
+	// - Tag values may be between 0 and 256 characters in length
+	// - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
+	Tags [String]String
 
-    // Associates nodepool subnets with AWS Outposts.
-    SubnetOutposts [String]String
+	// Associates nodepool subnets with AWS Outposts.
+	SubnetOutposts [String]String
 
-    // Associates nodepool availability zones with zone types (e.g. wavelength, local).
-    AvailabilityZoneTypes [String]String
+	// Associates nodepool availability zones with zone types (e.g. wavelength, local).
+	AvailabilityZoneTypes [String]String
 
-    // Additional AWS Security Groups to be added node pool.
-    AdditionalSecurityGroupIds []String
+	// Additional AWS Security Groups to be added node pool.
+	AdditionalSecurityGroupIds []String
 
-    // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
-    @json(name = "ec2_metadata_http_tokens")
-    Ec2MetadataHttpTokens Ec2MetadataHttpTokens    
-    
-    // AWS Volume specification to be used to set custom worker disk size
-    RootVolume AWSVolume
+	// Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
+	@json(name = "ec2_metadata_http_tokens")
+	Ec2MetadataHttpTokens Ec2MetadataHttpTokens    
+	
+	// AWS Volume specification to be used to set custom worker disk size
+	RootVolume AWSVolume
 
-    // If present it defines the AWS Capacity Reservation used for this NodePool
-    @json(name = "capacity_reservation")
-    CapacityReservation AWSCapacityReservation
+	// If present it defines the AWS Capacity Reservation used for this NodePool
+	@json(name = "capacity_reservation")
+	CapacityReservation AWSCapacityReservation
 }

--- a/model/aro_hcp/v1alpha1/aws_security_group_type.model
+++ b/model/aro_hcp/v1alpha1/aws_security_group_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_shard_type.model
+++ b/model/aro_hcp/v1alpha1/aws_shard_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_spot_market_options_type.model
+++ b/model/aro_hcp/v1alpha1/aws_spot_market_options_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Spot market options for AWS machine pool.
 class AWSSpotMarketOptions {
-    // The max price for spot instance. Optional.
-    // If not set, use the on-demand price.
-    MaxPrice Float
+	// The max price for spot instance. Optional.
+	// If not set, use the on-demand price.
+	MaxPrice Float
 }

--- a/model/aro_hcp/v1alpha1/aws_sts_account_role_type.model
+++ b/model/aro_hcp/v1alpha1/aws_sts_account_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ limitations under the License.
 // Representation of an sts account role for a rosa cluster
 struct AWSSTSAccountRole {
 
-    //The Prefix for this Account Role
-    Prefix String
+	//The Prefix for this Account Role
+	Prefix String
 
-    //The list of STS Roles for this Account Role
-    Items []AWSSTSRole
+	//The list of STS Roles for this Account Role
+	Items []AWSSTSRole
 }

--- a/model/aro_hcp/v1alpha1/aws_sts_policies_type.model
+++ b/model/aro_hcp/v1alpha1/aws_sts_policies_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ limitations under the License.
 // Representation of an sts policies for rosa cluster
 struct AWSSTSPolicy {
 
-    //Policy ID
-    ID String
+	//Policy ID
+	ID String
 
-    //Policy Details
-    Details String
+	//Policy Details
+	Details String
 
-    //Type of policy operator/account role
-    Type String
+	//Type of policy operator/account role
+	Type String
 
-    //The ARN of the managed policy
-    ARN String
+	//The ARN of the managed policy
+	ARN String
 }

--- a/model/aro_hcp/v1alpha1/aws_sts_role_type.model
+++ b/model/aro_hcp/v1alpha1/aws_sts_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,27 +17,27 @@ limitations under the License.
 // Representation of an sts role for a rosa cluster
 struct AWSSTSRole {
 
-    //The AWS ARN for this Role
-    @json(name = "arn")
-    RoleARN String
+	//The AWS ARN for this Role
+	@json(name = "arn")
+	RoleARN String
 
-    //The type of this Role
-    @json(name = "type")
-    RoleType String
+	//The type of this Role
+	@json(name = "type")
+	RoleType String
 
-    //Does this role have Admin permission?
-    @json(name = "isAdmin")
-    IsAdmin Boolean
+	//Does this role have Admin permission?
+	@json(name = "isAdmin")
+	IsAdmin Boolean
 
-    //The Openshift Version for this Role
-    @json(name = "roleVersion")
-    RoleVersion String
+	//The Openshift Version for this Role
+	@json(name = "roleVersion")
+	RoleVersion String
 
-    //Does this Role have Managed Policies?
-    @json(name = "managedPolicies")
-    ManagedPolicies Boolean
+	//Does this Role have Managed Policies?
+	@json(name = "managedPolicies")
+	ManagedPolicies Boolean
 
-    //Does this Role have HCP Managed Policies?
-    @json(name = "hcpManagedPolicies")
-    HcpManagedPolicies Boolean
+	//Does this Role have HCP Managed Policies?
+	@json(name = "hcpManagedPolicies")
+	HcpManagedPolicies Boolean
 }

--- a/model/aro_hcp/v1alpha1/aws_subnetwork_type.model
+++ b/model/aro_hcp/v1alpha1/aws_subnetwork_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/aws_type.model
+++ b/model/aro_hcp/v1alpha1/aws_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,6 +80,6 @@ struct AWS {
 	// Additional allowed principal ARNs to be added to the hosted control plane's VPC Endpoint Service.
 	AdditionalAllowedPrincipals []String
 
-    // AWS specific configuration for AutoNode
+	// AWS specific configuration for AutoNode
 	AutoNode AwsAutoNode
 }

--- a/model/aro_hcp/v1alpha1/aws_volume_type.model
+++ b/model/aro_hcp/v1alpha1/aws_volume_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_container_registry_credential_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_credential_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_container_registry_credentials_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_credentials_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_container_registry_type.model
+++ b/model/aro_hcp/v1alpha1/azure_container_registry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_etcd_data_encryption_customer_managed_type.model
+++ b/model/aro_hcp/v1alpha1/azure_etcd_data_encryption_customer_managed_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_etcd_data_encryption_type.model
+++ b/model/aro_hcp/v1alpha1/azure_etcd_data_encryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_etcd_encryption_type.model
+++ b/model/aro_hcp/v1alpha1/azure_etcd_encryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_kms_encryption_type.model
+++ b/model/aro_hcp/v1alpha1/azure_kms_encryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_kms_encryption_visibility_type.model
+++ b/model/aro_hcp/v1alpha1/azure_kms_encryption_visibility_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_kms_key_type.model
+++ b/model/aro_hcp/v1alpha1/azure_kms_key_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_node_pool_encryption_at_host_type.model
+++ b/model/aro_hcp/v1alpha1/azure_node_pool_encryption_at_host_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_node_pool_os_disk_type.model
+++ b/model/aro_hcp/v1alpha1/azure_node_pool_os_disk_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,39 +16,39 @@ limitations under the License.
 
 // Defines the configuration of a Node Pool's OS disk.
 struct AzureNodePoolOsDisk {
-    // The size in GiB to assign to the OS disks of the
-    // Nodes in the Node Pool. The property
-    // is the number of bytes x 1024^3.
-    // If not specified, OS disk size is 64 GiB.
-    SizeGibibytes Integer
+	// The size in GiB to assign to the OS disks of the
+	// Nodes in the Node Pool. The property
+	// is the number of bytes x 1024^3.
+	// If not specified, OS disk size is 64 GiB.
+	SizeGibibytes Integer
 
-    // The disk storage account type to use for the OS disks of the Nodes in the
-    // Node Pool. Valid values are:
-    // * Standard_LRS: HDD
-    // * StandardSSD_LRS: Standard SSD
-    // * Premium_LRS: Premium SDD
-    // * UltraSSD_LRS: Ultra SDD
-    //
-    // If not specified, `Premium_LRS` is used.
-    StorageAccountType String
+	// The disk storage account type to use for the OS disks of the Nodes in the
+	// Node Pool. Valid values are:
+	// * Standard_LRS: HDD
+	// * StandardSSD_LRS: Standard SSD
+	// * Premium_LRS: Premium SDD
+	// * UltraSSD_LRS: Ultra SDD
+	//
+	// If not specified, `Premium_LRS` is used.
+	StorageAccountType String
 
-    // Specifies the OS Disk persistence for the OS Disks of the Nodes in the Node Pool.
-    // Valid values are:
-    // * persistent
-    // * ephemeral
-    // If not specified, Persistent OS Disks are used.
-    Persistence String
+	// Specifies the OS Disk persistence for the OS Disks of the Nodes in the Node Pool.
+	// Valid values are:
+	// * persistent
+	// * ephemeral
+	// If not specified, Persistent OS Disks are used.
+	Persistence String
 
-    // The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-    // When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-    // is performed using the provided Disk Encryption Set.
-    // It must be located in the same Azure location as the parent Cluster.  
-    // It must be located in the same Azure Subscription as the parent Cluster.
-    // The Azure Resource Group Name specified as part of it must be a different resource group name
-    // than the one specified in the parent Cluster's `managed_resource_group_name`.
-    // The Azure Resource Group Name specified as part of it can be the same, or a different one
-    // than the one specified in the parent Cluster's `resource_group_name`.
-    // If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool 
-    // is performed with platform managed keys.
-    SseEncryptionSetResourceId String
+	// The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
+	// When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
+	// is performed using the provided Disk Encryption Set.
+	// It must be located in the same Azure location as the parent Cluster.  
+	// It must be located in the same Azure Subscription as the parent Cluster.
+	// The Azure Resource Group Name specified as part of it must be a different resource group name
+	// than the one specified in the parent Cluster's `managed_resource_group_name`.
+	// The Azure Resource Group Name specified as part of it can be the same, or a different one
+	// than the one specified in the parent Cluster's `resource_group_name`.
+	// If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool 
+	// is performed with platform managed keys.
+	SseEncryptionSetResourceId String
 }

--- a/model/aro_hcp/v1alpha1/azure_node_pool_type.model
+++ b/model/aro_hcp/v1alpha1/azure_node_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,33 +16,33 @@ limitations under the License.
 
 // Representation of azure node pool specific parameters.
 struct AzureNodePool {
-    // ResourceName is the Azure Resource Name of the NodePool.
-    // ResourceName must be within the Azure Resource Group Name of the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Location as the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Subscription as the parent
-    // Cluster it belongs to.
-    // ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
-    // Cluster it belongs to.
-    // Required during creation.
-    // Immutable.
-    ResourceName String
+	// ResourceName is the Azure Resource Name of the NodePool.
+	// ResourceName must be within the Azure Resource Group Name of the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Location as the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Subscription as the parent
+	// Cluster it belongs to.
+	// ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
+	// Cluster it belongs to.
+	// Required during creation.
+	// Immutable.
+	ResourceName String
 
-    // The Azure Virtual Machine size identifier used for the
-    // Nodes of the Node Pool.
-    // Availability of VM sizes are dependent on the Azure Location
-    // of the parent Cluster.
-    // Required during creation.
-    VMSize String
+	// The Azure Virtual Machine size identifier used for the
+	// Nodes of the Node Pool.
+	// Availability of VM sizes are dependent on the Azure Location
+	// of the parent Cluster.
+	// Required during creation.
+	VMSize String
 
-    // EncryptionAtHost contains Encryption At Host disk encryption configuration.
-    // When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
-    // and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
-    // If not specified, Encryption at Host is not enabled.
-    // Immutable.
-    EncryptionAtHost AzureNodePoolEncryptionAtHost
+	// EncryptionAtHost contains Encryption At Host disk encryption configuration.
+	// When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
+	// and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
+	// If not specified, Encryption at Host is not enabled.
+	// Immutable.
+	EncryptionAtHost AzureNodePoolEncryptionAtHost
 
-    // The configuration for the OS disk used by the nodes in the Node Pool.
-    OsDisk AzureNodePoolOsDisk
+	// The configuration for the OS disk used by the nodes in the Node Pool.
+	OsDisk AzureNodePoolOsDisk
 }

--- a/model/aro_hcp/v1alpha1/azure_nodes_outbound_connectivity_types.model
+++ b/model/aro_hcp/v1alpha1/azure_nodes_outbound_connectivity_types.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_operators_authentication_types.model
+++ b/model/aro_hcp/v1alpha1/azure_operators_authentication_types.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/azure_type.model
+++ b/model/aro_hcp/v1alpha1/azure_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -143,16 +143,16 @@ struct Azure {
 	// Mutable.
 	ContainerRegistry AzureContainerRegistry
 
-    // Vnet Integration Subnet Resource ID is the Azure Resource ID of a pre-existing Azure
-    // Subnet used for SWIFT networking (Azure Container Networking Interface).
-    // This subnet is delegated to Microsoft.RedHatOpenShift/hcpOpenShiftClusters
-    // via a Service Association Link and is used for pod networking in the cluster.
-    // Vnet Integration Subnet Resource ID must be located in the same Azure location as the
-    // cluster's region and in the same VNet as Subnet Resource ID.
-    // The Azure Subscription specified as part of the Vnet Integration Subnet Resource ID must
-    // be located in the same Azure Subscription as Subscription ID.
-    // This field is optional - if not specified, SWIFT networking will not be enabled.
-    // Immutable.
-    VnetIntegrationSubnetResourceID string
+	// Vnet Integration Subnet Resource ID is the Azure Resource ID of a pre-existing Azure
+	// Subnet used for SWIFT networking (Azure Container Networking Interface).
+	// This subnet is delegated to Microsoft.RedHatOpenShift/hcpOpenShiftClusters
+	// via a Service Association Link and is used for pod networking in the cluster.
+	// Vnet Integration Subnet Resource ID must be located in the same Azure location as the
+	// cluster's region and in the same VNet as Subnet Resource ID.
+	// The Azure Subscription specified as part of the Vnet Integration Subnet Resource ID must
+	// be located in the same Azure Subscription as Subscription ID.
+	// This field is optional - if not specified, SWIFT networking will not be enabled.
+	// Immutable.
+	VnetIntegrationSubnetResourceID string
 
 }

--- a/model/aro_hcp/v1alpha1/azure_user_assigned_managed_identity_type.model
+++ b/model/aro_hcp/v1alpha1/azure_user_assigned_managed_identity_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/backup_type.model
+++ b/model/aro_hcp/v1alpha1/backup_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/billing_model_item_type.model
+++ b/model/aro_hcp/v1alpha1/billing_model_item_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/billing_model_type.model
+++ b/model/aro_hcp/v1alpha1/billing_model_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,19 +22,19 @@ enum BillingModel {
 	// BillingModel Marketplace Legacy Marketplace billing model. Currently only used for tests. Use cloud-provider specific billing models instead.
 	Marketplace
 
-    // AWS Marketplace billing model.
-    @json(name = "marketplace-aws")
-    MarketplaceAWS
+	// AWS Marketplace billing model.
+	@json(name = "marketplace-aws")
+	MarketplaceAWS
 
-    // Azure Marketplace billing model.
-    @json(name = "marketplace-azure")
-    MarketplaceAzure
+	// Azure Marketplace billing model.
+	@json(name = "marketplace-azure")
+	MarketplaceAzure
 
-    // RH Marketplace billing model.
-    @json(name = "marketplace-rhm")
-    MarketplaceRHM
+	// RH Marketplace billing model.
+	@json(name = "marketplace-rhm")
+	MarketplaceRHM
 
-    // GCP Marketplace billing model.
-    @json(name = "marketplace-gcp")
-    MarketplaceGCP
+	// GCP Marketplace billing model.
+	@json(name = "marketplace-gcp")
+	MarketplaceGCP
 }

--- a/model/aro_hcp/v1alpha1/break_glass_credential_type.model
+++ b/model/aro_hcp/v1alpha1/break_glass_credential_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/byo_oidc_type.model
+++ b/model/aro_hcp/v1alpha1/byo_oidc_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/ccs_type.model
+++ b/model/aro_hcp/v1alpha1/ccs_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 class CCS {
-    // Indicates if Customer Cloud Subscription is enabled on the cluster.
-    Enabled Boolean
+	// Indicates if Customer Cloud Subscription is enabled on the cluster.
+	Enabled Boolean
 
-    // Indicates if cloud permissions checks are disabled,
-    // when attempting installation of the cluster.
-    DisableSCPChecks Boolean
+	// Indicates if cloud permissions checks are disabled,
+	// when attempting installation of the cluster.
+	DisableSCPChecks Boolean
 }

--- a/model/aro_hcp/v1alpha1/cloud_provider_type.model
+++ b/model/aro_hcp/v1alpha1/cloud_provider_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cloud_region_type.model
+++ b/model/aro_hcp/v1alpha1/cloud_region_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_api_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_api_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_arch_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_arch_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Possible cluster architectures.
 enum ClusterArchitecture {
-    @json(name = "classic")
-    Classic
+	@json(name = "classic")
+	Classic
 
-    @json(name = "hcp")
-    Hcp
+	@json(name = "hcp")
+	Hcp
 }

--- a/model/aro_hcp/v1alpha1/cluster_autonode_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_autonode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // The AutoNode configuration for the Cluster.
 struct ClusterAutoNode {
-    // Mode indicates the current state of AutoNode on this cluster.
-    // Valid values: "enabled", "disabled".
-    Mode String
-    Status ClusterAutoNodeStatus
+	// Mode indicates the current state of AutoNode on this cluster.
+	// Valid values: "enabled", "disabled".
+	Mode String
+	Status ClusterAutoNodeStatus
 }
 
 // Additional status information on the AutoNode configuration on this Cluster
 struct ClusterAutoNodeStatus {
-    // Messages relating to the status of the AutoNode installation on this Cluster
-    Message String
+	// Messages relating to the status of the AutoNode installation on this Cluster
+	Message String
 }

--- a/model/aro_hcp/v1alpha1/cluster_autoscaler_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_autoscaler_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_configuration_mode_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_configuration_mode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Configuration mode of a cluster.
 enum ClusterConfigurationMode {
-    // Full configuration (default).
-    Full
+	// Full configuration (default).
+	Full
 
-    // Only read configuration operations are supported.
-    // The cluster can't be deleted, reshaped, configure IDPs, add/remove users, etc.
-    ReadOnly
+	// Only read configuration operations are supported.
+	// The cluster can't be deleted, reshaped, configure IDPs, add/remove users, etc.
+	ReadOnly
 }

--- a/model/aro_hcp/v1alpha1/cluster_console_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_console_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_credentials_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_credentials_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_deployment_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_deployment_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_health_state_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_health_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // ClusterHealthState indicates the health of a cluster.
 enum ClusterHealthState {
-  // Cluster is Ready and healthy.
-  Healthy
+	// Cluster is Ready and healthy.
+	Healthy
 
-  // Cluster is Ready and unhealthy.
-  Unhealthy
+	// Cluster is Ready and unhealthy.
+	Unhealthy
 
-  // Cluster health is unknown.
-  Unknown
+	// Cluster health is unknown.
+	Unknown
 }

--- a/model/aro_hcp/v1alpha1/cluster_image_registry_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_image_registry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // ClusterImageRegistry represents the configuration for the cluster's internal image registry.
 struct ClusterImageRegistry {
-    // State indicates whether the image registry is enabled.
-    // Unless explicitly set, the image registry is enabled by default.
-    // This setting is immutable and cannot be changed after the cluster is created.
-    // Valid values: "enabled", "disabled".
-    State String
+	// State indicates whether the image registry is enabled.
+	// Unless explicitly set, the image registry is enabled by default.
+	// This setting is immutable and cannot be changed after the cluster is created.
+	// Valid values: "enabled", "disabled".
+	State String
 }

--- a/model/aro_hcp/v1alpha1/cluster_link_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_link_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_migration_state_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_migration_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Representation of a cluster migration state.
 struct ClusterMigrationState {
-    // The current state of the cluster migration.
-    Value ClusterMigrationStateValue
+	// The current state of the cluster migration.
+	Value ClusterMigrationStateValue
 
-    // A longer description of the current state of the cluster migration.
-    Description string
+	// A longer description of the current state of the cluster migration.
+	Description string
 }
 
 //  The state of the cluster migration.
 enum ClusterMigrationStateValue {
-    @json(name = "scheduled")
-    Scheduled
+	@json(name = "scheduled")
+	Scheduled
 
-    @json(name = "in progress")
-    InProgress
+	@json(name = "in progress")
+	InProgress
 
-    @json(name = "completed")
-    Completed
+	@json(name = "completed")
+	Completed
 }

--- a/model/aro_hcp/v1alpha1/cluster_migration_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_migration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Representation of a cluster migration.
 class ClusterMigration {
-    // Internal cluster ID.
-    ClusterID string
+	// Internal cluster ID.
+	ClusterID string
 
-    // Type of cluster migration. The rest of the attributes will be populated according to this
-    // value. For example, if the type is `sdnToOvn` then only the `SdnToOvn` attribute will be
-    // populated.
-    Type ClusterMigrationType
+	// Type of cluster migration. The rest of the attributes will be populated according to this
+	// value. For example, if the type is `sdnToOvn` then only the `SdnToOvn` attribute will be
+	// populated.
+	Type ClusterMigrationType
 
-    // The state of the cluster migration.
-    State ClusterMigrationState
+	// The state of the cluster migration.
+	State ClusterMigrationState
 
-    // Details for `SdnToOvn` cluster migrations.
-    SdnToOvn SdnToOvnClusterMigration
+	// Details for `SdnToOvn` cluster migrations.
+	SdnToOvn SdnToOvnClusterMigration
 
-    // Date and time when the cluster migration was initially created, using the
-    // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
-    CreationTimestamp Date
+	// Date and time when the cluster migration was initially created, using the
+	// format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
+	CreationTimestamp Date
 
-    // Date and time when the cluster migration was last updated, using the
-    // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
-    UpdatedTimestamp Date
+	// Date and time when the cluster migration was last updated, using the
+	// format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
+	UpdatedTimestamp Date
 }

--- a/model/aro_hcp/v1alpha1/cluster_migration_type_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_migration_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Type of cluster migration.
 enum ClusterMigrationType {
-    @json(name = "sdnToOvn")
-    SdnToOvn
+	@json(name = "sdnToOvn")
+	SdnToOvn
 }

--- a/model/aro_hcp/v1alpha1/cluster_nodes_root_volume_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_nodes_root_volume_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_nodes_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_nodes_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_operator_info_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_operator_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_operators_info_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_operators_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_operators_state_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_operators_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_provision_shard_subresource_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_provision_shard_subresource_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_registration_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_registration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_registry_config_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_registry_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -77,6 +77,6 @@ resource Cluster {
 
 	// Reference to cluster resources.
 	locator Resources {
-	    target Resources
+		target Resources
 	}
 }

--- a/model/aro_hcp/v1alpha1/cluster_state_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_status_resource.model
+++ b/model/aro_hcp/v1alpha1/cluster_status_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cluster_status_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,6 +40,6 @@ class ClusterStatus {
 	// Limited Support Reason Count
 	LimitedSupportReasonCount Integer
 
-    // Current Replicas available for a Hosted Cluster
-    CurrentCompute Integer
+	// Current Replicas available for a Hosted Cluster
+	CurrentCompute Integer
 }

--- a/model/aro_hcp/v1alpha1/cluster_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -171,9 +171,9 @@ class Cluster {
 	// List of machine pools on this cluster.
 	link MachinePools []MachinePool
 
-    // List of node pools on this cluster.
-    // NodePool is a scalable set of worker nodes attached to a hosted cluster.
-    link NodePools []NodePool
+	// List of node pools on this cluster.
+	// NodePool is a scalable set of worker nodes attached to a hosted cluster.
+	link NodePools []NodePool
 
 	// List of ingresses on this cluster.
 	link Ingresses []Ingress
@@ -219,8 +219,8 @@ class Cluster {
 	// Billing model for cluster resources.
 	BillingModel BillingModel
 
-    // Contains information about Managed Service
-    ManagedService ManagedService
+	// Contains information about Managed Service
+	ManagedService ManagedService
 
 	// Hypershift configuration.
 	Hypershift Hypershift

--- a/model/aro_hcp/v1alpha1/cluster_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_type.model
@@ -257,4 +257,10 @@ class Cluster {
 	// The AutoNode settings for this cluster.
 	// This is currently only supported for ROSA HCP
 	AutoNode ClusterAutoNode
+
+	// The SSH public key used for secure access to cluster nodes. When set, this key
+	// is distributed to all nodes, enabling SSH access for debugging
+	// and maintenance purposes.
+	// This is currently only supported for ARO HCP
+	NodeSSHPublicKey String
 }

--- a/model/aro_hcp/v1alpha1/clusters_resource.model
+++ b/model/aro_hcp/v1alpha1/clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/component_route_kind_type.model
+++ b/model/aro_hcp/v1alpha1/component_route_kind_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/component_route_type.model
+++ b/model/aro_hcp/v1alpha1/component_route_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/control_plane_type.model
+++ b/model/aro_hcp/v1alpha1/control_plane_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/control_plane_upgrade_policies_resource.model
+++ b/model/aro_hcp/v1alpha1/control_plane_upgrade_policies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/control_plane_upgrade_policy_resource.model
+++ b/model/aro_hcp/v1alpha1/control_plane_upgrade_policy_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/control_plane_upgrade_policy_type.model
+++ b/model/aro_hcp/v1alpha1/control_plane_upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cpu_total_node_role_os_metric_node_type.model
+++ b/model/aro_hcp/v1alpha1/cpu_total_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/cpu_totals_node_role_os_metric_node_type.model
+++ b/model/aro_hcp/v1alpha1/cpu_totals_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/credential_request_type.model
+++ b/model/aro_hcp/v1alpha1/credential_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/delete_protection_type.model
+++ b/model/aro_hcp/v1alpha1/delete_protection_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/dns_domain_type.model
+++ b/model/aro_hcp/v1alpha1/dns_domain_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Contains the properties of a DNS domain.
 class DNSDomain {
-    // Link to the organization that reserved the DNS domain.
-    link Organization OrganizationLink
+	// Link to the organization that reserved the DNS domain.
+	link Organization OrganizationLink
 
-    // Link to the cluster that is registered with the DNS domain (optional).
-    link Cluster ClusterLink
+	// Link to the cluster that is registered with the DNS domain (optional).
+	link Cluster ClusterLink
 
-    // Date and time when the DNS domain was reserved.
-    ReservedAtTimestamp Date
+	// Date and time when the DNS domain was reserved.
+	ReservedAtTimestamp Date
 
-    // Indicates if this dns domain is user defined.
-    UserDefined Boolean
+	// Indicates if this dns domain is user defined.
+	UserDefined Boolean
 
-    // Signals which cluster architecture the domain is ready for.
-    ClusterArch ClusterArchitecture
+	// Signals which cluster architecture the domain is ready for.
+	ClusterArch ClusterArchitecture
 }

--- a/model/aro_hcp/v1alpha1/dns_type.model
+++ b/model/aro_hcp/v1alpha1/dns_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/encryption_key_inquiry_type.model
+++ b/model/aro_hcp/v1alpha1/encryption_key_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/environment_type.model
+++ b/model/aro_hcp/v1alpha1/environment_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/errors.model
+++ b/model/aro_hcp/v1alpha1/errors.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/event_type.model
+++ b/model/aro_hcp/v1alpha1/event_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/external_auth_config_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auth_config_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Manages the external authentication configuration for an ARO HCP cluster.
 resource ExternalAuthConfig {
-   method Get {
-        out Body ExternalAuthConfig
-   }
+	method Get {
+		out Body ExternalAuthConfig
+	}
 
-    // Reference to the resource that manages the collection of ExternalAuths resources.
-    locator ExternalAuths {
-        target ExternalAuths
-    }
+	// Reference to the resource that manages the collection of ExternalAuths resources.
+	locator ExternalAuths {
+		target ExternalAuths
+	}
 }

--- a/model/aro_hcp/v1alpha1/external_auth_config_type.model
+++ b/model/aro_hcp/v1alpha1/external_auth_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,36 +16,36 @@ limitations under the License.
 
 // Represents an external authentication configuration
 class ExternalAuthConfig {
-    // Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
-    //
-    // By default this is false.
-    //
-    // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
-    // to have the `external-authentication` feature toggle enabled.
-    //
-    // For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
-    Enabled Boolean
+	// Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
+	//
+	// By default this is false.
+	//
+	// To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
+	// to have the `external-authentication` feature toggle enabled.
+	//
+	// For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
+	Enabled Boolean
 
-    // Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
-    // 
-    // For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
-    // 
-    // FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
-    State ExternalAuthConfigState
+	// Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+	// 
+	// For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+	// 
+	// FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+	State ExternalAuthConfigState
 
-    // A list of external authentication providers configured for the cluster.
-    // 
-    // Only one external authentication provider can be configured.
-    link ExternalAuths []ExternalAuth
+	// A list of external authentication providers configured for the cluster.
+	// 
+	// Only one external authentication provider can be configured.
+	link ExternalAuths []ExternalAuth
 }
 
 // Representation of the possible values for the state field of an external authentication configuration
 enum ExternalAuthConfigState {
-    // Indicates that the cluster supports configuration of external authentication providers
-    @json(name="enabled")
-    Enabled
+	// Indicates that the cluster supports configuration of external authentication providers
+	@json(name="enabled")
+	Enabled
 
-    // Indicates that the cluster does not support configuration of external authentication providers
-    @json(name="disabled")
-    Disabled
+	// Indicates that the cluster does not support configuration of external authentication providers
+	@json(name="disabled")
+	Disabled
 }

--- a/model/aro_hcp/v1alpha1/external_auth_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auth_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/external_auth_status_type.model
+++ b/model/aro_hcp/v1alpha1/external_auth_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,19 @@ limitations under the License.
 
 // Representation of the status of an external authentication provider.
 struct ExternalAuthStatus {
-    // The current state of the external authentication provider.
-    State ExternalAuthState
+	// The current state of the external authentication provider.
+	State ExternalAuthState
 
-    // A descriptive message providing additional context about the current 
-    // state of the external authentication provider.
-    Message String
+	// A descriptive message providing additional context about the current 
+	// state of the external authentication provider.
+	Message String
 }
 
 // Representation of the state of an external authentication provider.
 struct ExternalAuthState {
-    // A string value representing the external authentication provider's current state.
-    Value String
+	// A string value representing the external authentication provider's current state.
+	Value String
 
-    // The date and time when the external authentication provider state was last updated.
-    LastUpdatedTimestamp Date
+	// The date and time when the external authentication provider state was last updated.
+	LastUpdatedTimestamp Date
 }

--- a/model/aro_hcp/v1alpha1/external_auth_type.model
+++ b/model/aro_hcp/v1alpha1/external_auth_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,7 @@ struct TokenIssuer {
 	// "aud" claim.
 	// Must have at least one audience and a maximum of ten.
 	// Any clients defined for this external authentication must have their id included here.
-  Audiences []String
+	Audiences []String
 
 	// Certificate bundle to use to validate server certificates for the configured URL.
 	CA String
@@ -110,7 +110,7 @@ struct TokenClaimMappings {
 	UserName UsernameClaim
 
 	// Groups is a name of the claim that should be used to construct groups for the cluster identity.
-  Groups GroupsClaim
+	Groups GroupsClaim
 }
 
 // The username claim mapping.

--- a/model/aro_hcp/v1alpha1/external_auths_resource.model
+++ b/model/aro_hcp/v1alpha1/external_auths_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/external_configuration_type.model
+++ b/model/aro_hcp/v1alpha1/external_configuration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/flavour_nodes_type.model
+++ b/model/aro_hcp/v1alpha1/flavour_nodes_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/flavour_type.model
+++ b/model/aro_hcp/v1alpha1/flavour_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/gcp_authentication_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_authentication_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Google cloud platform authentication method of a cluster.
 struct GcpAuthentication {
-    // Indicates the type of this object
-    Kind String
+	// Indicates the type of this object
+	Kind String
 
-    // Unique identifier of the object
-    Id String
+	// Unique identifier of the object
+	Id String
 
-    // Self link
-    Href String
+	// Self link
+	Href String
 }

--- a/model/aro_hcp/v1alpha1/gcp_encryption_key_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_encryption_key_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/gcp_flavour_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_flavour_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/gcp_image_override_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_image_override_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // GcpImageOverride specifies what a GCP VM Image should be used for a particular product and billing model
 class GCPImageOverride {
-    // Link to the product type.
-    link Product Product
+	// Link to the product type.
+	link Product Product
 
-    // Link to the billing model.
-    link BillingModel BillingModelItem
+	// Link to the billing model.
+	link BillingModel BillingModelItem
 
-    // ImageID is the id of the Google Cloud Platform image.
-    ImageID String
+	// ImageID is the id of the Google Cloud Platform image.
+	ImageID String
 
-    // ProjectID is the id of the Google Cloud Platform project that hosts the image.
-    ProjectID String
+	// ProjectID is the id of the Google Cloud Platform project that hosts the image.
+	ProjectID String
 }

--- a/model/aro_hcp/v1alpha1/gcp_machine_pool_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_machine_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/gcp_network_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_network_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // GCP Network configuration of a cluster.
 struct GCPNetwork {
-    // VPC mame used by the cluster.
-    VPCName  String
+	// VPC mame used by the cluster.
+	VPCName  String
 
-    // The name of the host project where the shared VPC exists.
-    VPCProjectID String
+	// The name of the host project where the shared VPC exists.
+	VPCProjectID String
 
-    // Control plane subnet used by the cluster.
-    ControlPlaneSubnet String
+	// Control plane subnet used by the cluster.
+	ControlPlaneSubnet String
 
-    // Compute subnet used by the cluster.
-    ComputeSubnet   String
+	// Compute subnet used by the cluster.
+	ComputeSubnet   String
 }

--- a/model/aro_hcp/v1alpha1/gcp_private_service_connect_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_private_service_connect_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Google cloud platform private service connect configuration of a cluster.
 struct GcpPrivateServiceConnect {
-    // The name of the subnet where the PSC service attachment is created
-    ServiceAttachmentSubnet String
+	// The name of the subnet where the PSC service attachment is created
+	ServiceAttachmentSubnet String
 }

--- a/model/aro_hcp/v1alpha1/gcp_security_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_security_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/gcp_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/gcp_volume_type.model
+++ b/model/aro_hcp/v1alpha1/gcp_volume_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/group_type.model
+++ b/model/aro_hcp/v1alpha1/group_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/htpasswd_user_type.model
+++ b/model/aro_hcp/v1alpha1/htpasswd_user_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,17 +15,17 @@ limitations under the License.
 */
 
 struct HTPasswdUser {
-    // ID for a secondary user in the _HTPasswd_ data file.
-    ID String
+	// ID for a secondary user in the _HTPasswd_ data file.
+	ID String
 
-    // Username for a secondary user in the _HTPasswd_ data file.
-    Username String
+	// Username for a secondary user in the _HTPasswd_ data file.
+	Username String
 
-    // Password in plain-text for a  user in the _HTPasswd_ data file.
-    // The value of this field is hashed before setting it in the  _HTPasswd_ data file for the HTPasswd IDP
-    Password String
+	// Password in plain-text for a  user in the _HTPasswd_ data file.
+	// The value of this field is hashed before setting it in the  _HTPasswd_ data file for the HTPasswd IDP
+	Password String
 
-   // HTPasswd Hashed Password for a user in the _HTPasswd_ data file.
-   // The value of this field is set as-is in the _HTPasswd_ data file for the HTPasswd IDP
-    HashedPassword String
+	// HTPasswd Hashed Password for a user in the _HTPasswd_ data file.
+	// The value of this field is set as-is in the _HTPasswd_ data file for the HTPasswd IDP
+	HashedPassword String
 }

--- a/model/aro_hcp/v1alpha1/hypershift_config_type.model
+++ b/model/aro_hcp/v1alpha1/hypershift_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/hypershift_type.model
+++ b/model/aro_hcp/v1alpha1/hypershift_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/identity_provider_type.model
+++ b/model/aro_hcp/v1alpha1/identity_provider_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -144,8 +144,8 @@ struct HTPasswdIdentityProvider {
 	// Password to be used in the _HTPasswd_ data file.
 	Password String
 
-    // Link to the collection of _HTPasswd_ users.
-    link Users []HTPasswdUser
+	// Link to the collection of _HTPasswd_ users.
+	link Users []HTPasswdUser
 }
 
 // Details for `ldap` identity providers.

--- a/model/aro_hcp/v1alpha1/image_mirror_type.model
+++ b/model/aro_hcp/v1alpha1/image_mirror_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/image_overrides_type.model
+++ b/model/aro_hcp/v1alpha1/image_overrides_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // ImageOverrides holds the lists of available images per cloud provider.
 class ImageOverrides {
-    AWS []AMIOverride
-    GCP []GCPImageOverride
+	AWS []AMIOverride
+	GCP []GCPImageOverride
 }

--- a/model/aro_hcp/v1alpha1/inflight_check_resource.model
+++ b/model/aro_hcp/v1alpha1/inflight_check_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/inflight_check_state_type.model
+++ b/model/aro_hcp/v1alpha1/inflight_check_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/inflight_check_type.model
+++ b/model/aro_hcp/v1alpha1/inflight_check_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Representation of check running before the cluster is provisioned.
 class InflightCheck {
-    // The name of the inflight check.
-    Name String
+	// The name of the inflight check.
+	Name String
 
-    // State of the inflight check.
-    State InflightCheckState
+	// State of the inflight check.
+	State InflightCheckState
 
-    // Details regarding the state of the inflight check.
-    Details Interface
+	// Details regarding the state of the inflight check.
+	Details Interface
 
-    // The time the check started running.
-    StartedAt Date
+	// The time the check started running.
+	StartedAt Date
 
-    // The time the check finished running.
-    EndedAt Date
+	// The time the check finished running.
+	EndedAt Date
 
-    // The number of times the inflight check restarted.
-    Restarts Integer
+	// The number of times the inflight check restarted.
+	Restarts Integer
 }

--- a/model/aro_hcp/v1alpha1/inflight_checks_resource.model
+++ b/model/aro_hcp/v1alpha1/inflight_checks_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/ingress_type.model
+++ b/model/aro_hcp/v1alpha1/ingress_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/instance_iam_roles.model
+++ b/model/aro_hcp/v1alpha1/instance_iam_roles.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/key_ring_inquiry_type.model
+++ b/model/aro_hcp/v1alpha1/key_ring_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/kubelet_config_type.model
+++ b/model/aro_hcp/v1alpha1/kubelet_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/label_type.model
+++ b/model/aro_hcp/v1alpha1/label_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/limited_support_reason_override_type.model
+++ b/model/aro_hcp/v1alpha1/limited_support_reason_override_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/limited_support_reason_template_type.model
+++ b/model/aro_hcp/v1alpha1/limited_support_reason_template_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/limited_support_reason_type.model
+++ b/model/aro_hcp/v1alpha1/limited_support_reason_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 enum DetectionType {
-    Manual
-    Auto
+	Manual
+	Auto
 }
 
 // A reason that a cluster is in limited support.

--- a/model/aro_hcp/v1alpha1/listening_method_type.model
+++ b/model/aro_hcp/v1alpha1/listening_method_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/load_balancer_flavor_type.model
+++ b/model/aro_hcp/v1alpha1/load_balancer_flavor_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/log_type.model
+++ b/model/aro_hcp/v1alpha1/log_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/machine_pool_autoscaling_type.model
+++ b/model/aro_hcp/v1alpha1/machine_pool_autoscaling_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a autoscaling in a machine pool.
 class MachinePoolAutoscaling {
-    // The minimum number of replicas for the machine pool.
+	// The minimum number of replicas for the machine pool.
 	MinReplicas Integer
 
-    // The maximum number of replicas for the machine pool.
+	// The maximum number of replicas for the machine pool.
 	MaxReplicas Integer
 }

--- a/model/aro_hcp/v1alpha1/machine_pool_aws_security_group_filter_type.model
+++ b/model/aro_hcp/v1alpha1/machine_pool_aws_security_group_filter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Security Group Filter object, containing name of the filter tag and value of the filter tag
 struct MachinePoolSecurityGroupFilter {
-  Name String
-  Value String
+	Name String
+	Value String
 } 

--- a/model/aro_hcp/v1alpha1/machine_pool_type.model
+++ b/model/aro_hcp/v1alpha1/machine_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/machine_type_category_type.model
+++ b/model/aro_hcp/v1alpha1/machine_type_category_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/machine_type_size_type.model
+++ b/model/aro_hcp/v1alpha1/machine_type_size_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/machine_type_type.model
+++ b/model/aro_hcp/v1alpha1/machine_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/managed_identities_requirements_resource.model
+++ b/model/aro_hcp/v1alpha1/managed_identities_requirements_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/managed_identities_requirements_type.model
+++ b/model/aro_hcp/v1alpha1/managed_identities_requirements_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,86 +25,86 @@ limitations under the License.
 // Additionally, the Managed Identities that the end-users will need to precreate will have to have a 
 // set of required permissions assigned to them which also have to be returned to the end users.
 class ManagedIdentitiesRequirements {
-  // The control plane operators managed identities requirements
-  ControlPlaneOperatorsIdentities []ControlPlaneOperatorIdentityRequirement
-  // The data plane operators managed identities requirements
-  DataPlaneOperatorsIdentities []DataPlaneOperatorIdentityRequirement
+	// The control plane operators managed identities requirements
+	ControlPlaneOperatorsIdentities []ControlPlaneOperatorIdentityRequirement
+	// The data plane operators managed identities requirements
+	DataPlaneOperatorsIdentities []DataPlaneOperatorIdentityRequirement
 }
 
 struct ControlPlaneOperatorIdentityRequirement {
-  // Indicates whether the identity is always required or not.
-  // "always" means that the identity is always required
-  // "on_enablement" means that the identity is only required when a functionality 
-  // that leverages the operator is enabled. 
-  // Possible values are ("always", "on_enablement")
-  Required String
+	// Indicates whether the identity is always required or not.
+	// "always" means that the identity is always required
+	// "on_enablement" means that the identity is only required when a functionality 
+	// that leverages the operator is enabled. 
+	// Possible values are ("always", "on_enablement")
+	Required String
 
-  // The name of the control plane operator that needs the identity
-  OperatorName String
+	// The name of the control plane operator that needs the identity
+	OperatorName String
 
-  // The field is a string and it is of format X.Y.
-  // Not specifying it indicates support for this operator in all Openshift versions,
-  // starting from min_openshift_version if min_openshift_version is defined. 
-  @json(name="max_openshift_version")
-  MaxOpenShiftVersion String
+	// The field is a string and it is of format X.Y.
+	// Not specifying it indicates support for this operator in all Openshift versions,
+	// starting from min_openshift_version if min_openshift_version is defined. 
+	@json(name="max_openshift_version")
+	MaxOpenShiftVersion String
 
-  // The field is a string and it is of format X.Y.
-  // Not specifying it indicates support for this operator in all Openshift versions,
-  // or up to max_openshift_version, if defined. 
-  @json(name="min_openshift_version")
-  MinOpenShiftVersion String   
+	// The field is a string and it is of format X.Y.
+	// Not specifying it indicates support for this operator in all Openshift versions,
+	// or up to max_openshift_version, if defined. 
+	@json(name="min_openshift_version")
+	MinOpenShiftVersion String   
 
-  // A list of roles that are required by the operator 
-  RoleDefinitions []RoleDefinitionOperatorIdentityRequirement
+	// A list of roles that are required by the operator 
+	RoleDefinitions []RoleDefinitionOperatorIdentityRequirement
 }
 
 struct DataPlaneOperatorIdentityRequirement {
-   // Indicates whether the identity is always required or not
-   // "always" means that the identity is always required
-   // "on_enablement" means that the identity is only required when a functionality 
-   // that leverages the operator is enabled.
-   // Possible values are ("always", "on_enablement")
-   Required String
+	// Indicates whether the identity is always required or not
+	// "always" means that the identity is always required
+	// "on_enablement" means that the identity is only required when a functionality 
+	// that leverages the operator is enabled.
+	// Possible values are ("always", "on_enablement")
+	Required String
 
-   // The name of the data plane operator that needs the identity
-   OperatorName String
+	// The name of the data plane operator that needs the identity
+	OperatorName String
 
-   // The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and 
-   // minor segments of the OpenShift version respectively.
-   // Not specifying it indicates support for this operator in all Openshift versions,
-   // starting from min_openshift_version if min_openshift_version is defined. 
-   @json(name="max_openshift_version")
-   MaxOpenShiftVersion String
+	// The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and 
+	// minor segments of the OpenShift version respectively.
+	// Not specifying it indicates support for this operator in all Openshift versions,
+	// starting from min_openshift_version if min_openshift_version is defined. 
+	@json(name="max_openshift_version")
+	MaxOpenShiftVersion String
 
-   // The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and 
-   // minor segments of the OpenShift version respectively.
-   // Not specifying it indicates support for this operator in all Openshift versions,
-   // or up to max_openshift_version, if defined. 
-   @json(name="min_openshift_version")
-   MinOpenShiftVersion String
+	// The field is a string and it is of format X.Y (e.g 4.18) where X and Y are major and 
+	// minor segments of the OpenShift version respectively.
+	// Not specifying it indicates support for this operator in all Openshift versions,
+	// or up to max_openshift_version, if defined. 
+	@json(name="min_openshift_version")
+	MinOpenShiftVersion String
 
-   // It is a list of K8s ServiceAccounts leveraged by the operator.
-   // There must be at least a single service account specified.
-   // This information is needed to federate a managed identity to a k8s subject.
-   // There should be no duplicated "name:namespace" entries within this field. 
-   ServiceAccounts []K8sServiceAccountOperatorIdentityRequirement
+	// It is a list of K8s ServiceAccounts leveraged by the operator.
+	// There must be at least a single service account specified.
+	// This information is needed to federate a managed identity to a k8s subject.
+	// There should be no duplicated "name:namespace" entries within this field. 
+	ServiceAccounts []K8sServiceAccountOperatorIdentityRequirement
 
-   // A list of roles that are required by the operator 
-   RoleDefinitions []RoleDefinitionOperatorIdentityRequirement
+	// A list of roles that are required by the operator 
+	RoleDefinitions []RoleDefinitionOperatorIdentityRequirement
 }
 
 struct K8sServiceAccountOperatorIdentityRequirement {
-  // The name of the service account to be leveraged by the operator
-  Name String
-  // The namespace of the service account to be leveraged by the operator
-  Namespace String
+	// The name of the service account to be leveraged by the operator
+	Name String
+	// The namespace of the service account to be leveraged by the operator
+	Namespace String
 }
 
 struct RoleDefinitionOperatorIdentityRequirement {
-  // The official name of the Role defined in resource_id. 
-  // It is purely a friendly/descriptive name.
-  Name String
-  // A string representing the Resource ID of an Azure Role Definition. 
-  // The role definition indicates what permissions are needed by the operator
-  ResourceId String
+	// The official name of the Role defined in resource_id. 
+	// It is purely a friendly/descriptive name.
+	Name String
+	// A string representing the Resource ID of an Azure Role Definition. 
+	// The role definition indicates what permissions are needed by the operator
+	ResourceId String
 }

--- a/model/aro_hcp/v1alpha1/managedservice_type.model
+++ b/model/aro_hcp/v1alpha1/managedservice_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/manifest_type.model
+++ b/model/aro_hcp/v1alpha1/manifest_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/market_type.model
+++ b/model/aro_hcp/v1alpha1/market_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,11 +16,11 @@ limitations under the License.
 
 // Market type for AWS Capacity Reservations.
 enum MarketType {
-    // EC2 instances run as standard On-Demand instances.
+	// EC2 instances run as standard On-Demand instances.
 	@json(name = "OnDemand")
-    OnDemand
+	OnDemand
 
-    // Scheduled pre-purchased compute capacity.
+	// Scheduled pre-purchased compute capacity.
 	@json(name = "CapacityBlocks")
-    CapacityBlocks
+	CapacityBlocks
 } 

--- a/model/aro_hcp/v1alpha1/namespace_ownership_policy_type.model
+++ b/model/aro_hcp/v1alpha1/namespace_ownership_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/network_type.model
+++ b/model/aro_hcp/v1alpha1/network_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/network_verification_type.model
+++ b/model/aro_hcp/v1alpha1/network_verification_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_info_type.model
+++ b/model/aro_hcp/v1alpha1/node_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pool_autoscaling_type.model
+++ b/model/aro_hcp/v1alpha1/node_pool_autoscaling_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a autoscaling in a node pool.
 class NodePoolAutoscaling {
-    // The minimum number of replicas for the node pool.
-    MinReplica Integer
+	// The minimum number of replicas for the node pool.
+	MinReplica Integer
 
-    // The maximum number of replicas for the node pool.
-    MaxReplica Integer
+	// The maximum number of replicas for the node pool.
+	MaxReplica Integer
 }

--- a/model/aro_hcp/v1alpha1/node_pool_management_upgrade_type.model
+++ b/model/aro_hcp/v1alpha1/node_pool_management_upgrade_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Representation of node pool management.
 class NodePoolManagementUpgrade {
-    // Type of strategy for handling upgrades.
-    Type String
+	// Type of strategy for handling upgrades.
+	Type String
 
-    // Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be unavailable during the upgrade.
-    MaxUnavailable String
+	// Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be unavailable during the upgrade.
+	MaxUnavailable String
 
-    // Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be scheduled above the desired number of nodes during the upgrade.
-    MaxSurge String
+	// Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be scheduled above the desired number of nodes during the upgrade.
+	MaxSurge String
 }

--- a/model/aro_hcp/v1alpha1/node_pool_resource.model
+++ b/model/aro_hcp/v1alpha1/node_pool_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pool_state_type.model
+++ b/model/aro_hcp/v1alpha1/node_pool_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pool_status_resource.model
+++ b/model/aro_hcp/v1alpha1/node_pool_status_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pool_status_type.model
+++ b/model/aro_hcp/v1alpha1/node_pool_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Representation of the status of a node pool.
 class NodePoolStatus {
-    // The current state of the node pool
-    State NodePoolState
-    
-    // The current number of replicas for the node pool.
-    CurrentReplicas Integer
+	// The current state of the node pool
+	State NodePoolState
+	
+	// The current number of replicas for the node pool.
+	CurrentReplicas Integer
 
-    // Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas.
-    Message String
+	// Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas.
+	Message String
 }

--- a/model/aro_hcp/v1alpha1/node_pool_type.model
+++ b/model/aro_hcp/v1alpha1/node_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,50 +16,50 @@ limitations under the License.
 
 // Representation of a node pool in a cluster.
 class NodePool {
-    // The number of Machines (and Nodes) to create.
-    // Replicas and autoscaling cannot be used together.
-    Replicas Integer
+	// The number of Machines (and Nodes) to create.
+	// Replicas and autoscaling cannot be used together.
+	Replicas Integer
 
-    // Details for auto-scaling the machine pool.
-    // Replicas and autoscaling cannot be used together.
-    Autoscaling NodePoolAutoscaling
+	// Details for auto-scaling the machine pool.
+	// Replicas and autoscaling cannot be used together.
+	Autoscaling NodePoolAutoscaling
 
-    // Specifies whether health checks should be enabled for machines in the NodePool.
-    AutoRepair Boolean
+	// Specifies whether health checks should be enabled for machines in the NodePool.
+	AutoRepair Boolean
 
-    // AWS specific parameters (Optional).
-    AWSNodePool AWSNodePool
+	// AWS specific parameters (Optional).
+	AWSNodePool AWSNodePool
 
-    // Azure specific parameters.
-    AzureNodePool AzureNodePool
+	// Azure specific parameters.
+	AzureNodePool AzureNodePool
 
-    // The availability zone upon which the node is created.
-    AvailabilityZone String
+	// The availability zone upon which the node is created.
+	AvailabilityZone String
 
-    // The subnet upon which the nodes are created.
-    Subnet String
+	// The subnet upon which the nodes are created.
+	Subnet String
 
-    // NodePool status.
-    Status NodePoolStatus
+	// NodePool status.
+	Status NodePoolStatus
 
-    // Version of the node pool.
-    Version Version
+	// Version of the node pool.
+	Version Version
 
-    // The labels set on the Nodes created.
-    Labels [String]String
+	// The labels set on the Nodes created.
+	Labels [String]String
 
-    // The taints set on the Nodes created.
-    Taints []Taint
+	// The taints set on the Nodes created.
+	Taints []Taint
 
-    // The names of the tuning configs for this node pool.
-    TuningConfigs []String
+	// The names of the tuning configs for this node pool.
+	TuningConfigs []String
 
-    // The names of the KubeletConfigs for this node pool.
-    KubeletConfigs []String
+	// The names of the KubeletConfigs for this node pool.
+	KubeletConfigs []String
 
-    // Time to wait for a NodePool to drain when it is upgraded or replaced before it is forcibly removed.
-    NodeDrainGracePeriod Value
+	// Time to wait for a NodePool to drain when it is upgraded or replaced before it is forcibly removed.
+	NodeDrainGracePeriod Value
 
-    // Management parameters (Optional).
-    ManagementUpgrade NodePoolManagementUpgrade
+	// Management parameters (Optional).
+	ManagementUpgrade NodePoolManagementUpgrade
 }

--- a/model/aro_hcp/v1alpha1/node_pool_upgrade_policies_resource.model
+++ b/model/aro_hcp/v1alpha1/node_pool_upgrade_policies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pool_upgrade_policy_resource.model
+++ b/model/aro_hcp/v1alpha1/node_pool_upgrade_policy_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pool_upgrade_policy_type.model
+++ b/model/aro_hcp/v1alpha1/node_pool_upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_pools_resource.model
+++ b/model/aro_hcp/v1alpha1/node_pools_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/node_type.model
+++ b/model/aro_hcp/v1alpha1/node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/nodes_info_type.model
+++ b/model/aro_hcp/v1alpha1/nodes_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/oidc_config_type.model
+++ b/model/aro_hcp/v1alpha1/oidc_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ struct OidcConfig {
 	ID String
 
 	// HREF for the oidc config, filled in response.
-  	HREF String
+		HREF String
 
 	// Organization ID, filled in response respecting token provided.
 	OrganizationId String

--- a/model/aro_hcp/v1alpha1/oidc_thumbprint_input_type.model
+++ b/model/aro_hcp/v1alpha1/oidc_thumbprint_input_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/oidc_thumbprint_type.model
+++ b/model/aro_hcp/v1alpha1/oidc_thumbprint_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,8 +27,8 @@ struct OidcThumbprint {
 	Thumbprint String
 
 	// HREF for the oidc config thumbprint, filled in response.
-  	HREF String
+		HREF String
 
-  	// Kind is the resource type, filled in response.
-  	Kind String
+		// Kind is the resource type, filled in response.
+		Kind String
 }

--- a/model/aro_hcp/v1alpha1/operator_iam_role_type.model
+++ b/model/aro_hcp/v1alpha1/operator_iam_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/organization_link_type.model
+++ b/model/aro_hcp/v1alpha1/organization_link_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/pending_delete_cluster_type.model
+++ b/model/aro_hcp/v1alpha1/pending_delete_cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/platform_type.model
+++ b/model/aro_hcp/v1alpha1/platform_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an platform type field.
 enum Platform {
-    @json(name = "aws")
-    Aws
+	@json(name = "aws")
+	Aws
 
-    @json(name = "gcp")
-    Gcp
+	@json(name = "gcp")
+	Gcp
 
-    @json(name = "hostedcluster")
-    HostedCluster
+	@json(name = "hostedcluster")
+	HostedCluster
 
-    @json(name = "aws-classic")
-    AwsClassic
+	@json(name = "aws-classic")
+	AwsClassic
 
-    @json(name = "aws-hosted-cp")
-    AwsHostedCp
+	@json(name = "aws-hosted-cp")
+	AwsHostedCp
 }

--- a/model/aro_hcp/v1alpha1/private_link_cluster_configuration_type.model
+++ b/model/aro_hcp/v1alpha1/private_link_cluster_configuration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Manages the configuration for the Private Links.
 struct PrivateLinkClusterConfiguration {
-    // List of additional principals for the Private Link
-    Principals []PrivateLinkPrincipal
+	// List of additional principals for the Private Link
+	Principals []PrivateLinkPrincipal
 }
 
 

--- a/model/aro_hcp/v1alpha1/private_link_configuration_principal_type.model
+++ b/model/aro_hcp/v1alpha1/private_link_configuration_principal_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 class PrivateLinkPrincipal {
-    // ARN for a principal that is allowed for this Private Link.
-    Principal String
+	// ARN for a principal that is allowed for this Private Link.
+	Principal String
 }

--- a/model/aro_hcp/v1alpha1/private_link_configuration_principals_type.model
+++ b/model/aro_hcp/v1alpha1/private_link_configuration_principals_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Contains a list of principals for the Private Link.
 class PrivateLinkPrincipals {
-    // List of additional principals for the Private Link
-    Principals []PrivateLinkPrincipal
+	// List of additional principals for the Private Link
+	Principals []PrivateLinkPrincipal
 }

--- a/model/aro_hcp/v1alpha1/private_link_configuration_type.model
+++ b/model/aro_hcp/v1alpha1/private_link_configuration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Manages the configuration for the Private Links.
 struct PrivateLinkConfiguration {
-	  // List of additional principals for the Private Link
-    link Principals PrivateLinkPrincipals
+		// List of additional principals for the Private Link
+	link Principals PrivateLinkPrincipals
 }
 
 

--- a/model/aro_hcp/v1alpha1/processor_type_type.model
+++ b/model/aro_hcp/v1alpha1/processor_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/product_minimal_version_type.model
+++ b/model/aro_hcp/v1alpha1/product_minimal_version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/product_technology_preview_type.model
+++ b/model/aro_hcp/v1alpha1/product_technology_preview_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/product_type.model
+++ b/model/aro_hcp/v1alpha1/product_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/provider_data_inquiry_type.model
+++ b/model/aro_hcp/v1alpha1/provider_data_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,30 +16,30 @@ limitations under the License.
 
 // Description of a cloud provider data used for cloud provider inquiries.
 struct CloudProviderData {
-    // Amazon Web Services settings.
-    AWS AWS
+	// Amazon Web Services settings.
+	AWS AWS
 
-    // Google cloud platform settings.
-    GCP GCP
+	// Google cloud platform settings.
+	GCP GCP
 
-    // Region
-    Region CloudRegion
+	// Region
+	Region CloudRegion
 
-    // Key location
-    KeyLocation String
+	// Key location
+	KeyLocation String
 
-    // Key ring name
-    KeyRingName  String
+	// Key ring name
+	KeyRingName  String
 
-    // Openshift version
-    Version Version
+	// Openshift version
+	Version Version
 
-    // Availability zone
-    AvailabilityZones []String
+	// Availability zone
+	AvailabilityZones []String
 
-    // Subnets
-    Subnets []String
+	// Subnets
+	Subnets []String
 
-    // VPC ids
-    VpcIds []string
+	// VPC ids
+	VpcIds []string
 }

--- a/model/aro_hcp/v1alpha1/provision_shard_azure_shard.model
+++ b/model/aro_hcp/v1alpha1/provision_shard_azure_shard.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/provision_shard_maestro_config.model
+++ b/model/aro_hcp/v1alpha1/provision_shard_maestro_config.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/provision_shard_resource.model
+++ b/model/aro_hcp/v1alpha1/provision_shard_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/provision_shard_topology_type.model
+++ b/model/aro_hcp/v1alpha1/provision_shard_topology_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/provision_shard_type.model
+++ b/model/aro_hcp/v1alpha1/provision_shard_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/provision_shards_resource.model
+++ b/model/aro_hcp/v1alpha1/provision_shards_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/proxy_type.model
+++ b/model/aro_hcp/v1alpha1/proxy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/registry_allowlist_type.model
+++ b/model/aro_hcp/v1alpha1/registry_allowlist_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/release_image_details_type.model
+++ b/model/aro_hcp/v1alpha1/release_image_details_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/release_images_type.model
+++ b/model/aro_hcp/v1alpha1/release_images_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 struct ReleaseImages {
-    // Arm64 will contain the reference for the arm64 image which will be used for cluster deployments
-    ARM64 ReleaseImageDetails
+	// Arm64 will contain the reference for the arm64 image which will be used for cluster deployments
+	ARM64 ReleaseImageDetails
 
-    // Multi will contain the reference for the multi image which will be used for cluster deployments
-    Multi ReleaseImageDetails
+	// Multi will contain the reference for the multi image which will be used for cluster deployments
+	Multi ReleaseImageDetails
 }

--- a/model/aro_hcp/v1alpha1/resource_range_type.model
+++ b/model/aro_hcp/v1alpha1/resource_range_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/resource_type.model
+++ b/model/aro_hcp/v1alpha1/resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Cluster Resource which belongs to a cluster, example Cluster Deployment.
 class ClusterResources {
-    // Cluster ID for the fetched resources
-    ClusterID String
-    // Returned map of cluster resources fetched.
-    Resources [String]String
-    // Date and time when the resources were fetched.
-    CreationTimestamp Date
+	// Cluster ID for the fetched resources
+	ClusterID String
+	// Returned map of cluster resources fetched.
+	Resources [String]String
+	// Date and time when the resources were fetched.
+	CreationTimestamp Date
 }

--- a/model/aro_hcp/v1alpha1/resources_resource.model
+++ b/model/aro_hcp/v1alpha1/resources_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages a collection of resources for a cluster
 resource Resources {
-    // Retrieves a list of resources for a cluster
-    method Get {
-        // List of cluster resources
-        out Body ClusterResources
-    }
+	// Retrieves a list of resources for a cluster
+	method Get {
+		// List of cluster resources
+		out Body ClusterResources
+	}
 }

--- a/model/aro_hcp/v1alpha1/role_policy_binding_status_type.model
+++ b/model/aro_hcp/v1alpha1/role_policy_binding_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/role_policy_binding_type.model
+++ b/model/aro_hcp/v1alpha1/role_policy_binding_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/role_policy_type.model
+++ b/model/aro_hcp/v1alpha1/role_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/root_resource.model
+++ b/model/aro_hcp/v1alpha1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/sdn_to_ovn_cluster_migration_type.model
+++ b/model/aro_hcp/v1alpha1/sdn_to_ovn_cluster_migration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Details for `SdnToOvn` cluster migrations.
 struct SdnToOvnClusterMigration {
-    // The IP address range to use for the internalTransSwitchSubnet parameter of OVN-Kubernetes
-    // upon migration.
-    @json(name = "transit_ipv4")
-    TransitIpv4 String
+	// The IP address range to use for the internalTransSwitchSubnet parameter of OVN-Kubernetes
+	// upon migration.
+	@json(name = "transit_ipv4")
+	TransitIpv4 String
 
-    // The IP address range to use for the internalJoinSubnet parameter of OVN-Kubernetes
-    // upon migration.
-    @json(name = "join_ipv4")
-    JoinIpv4 String
+	// The IP address range to use for the internalJoinSubnet parameter of OVN-Kubernetes
+	// upon migration.
+	@json(name = "join_ipv4")
+	JoinIpv4 String
 
-    // The IP address range to us for the internalMasqueradeSubnet parameter of OVN-Kubernetes
-    // upon migration.
-    @json(name = "masquerade_ipv4")
-    MasqueradeIpv4 String
+	// The IP address range to us for the internalMasqueradeSubnet parameter of OVN-Kubernetes
+	// upon migration.
+	@json(name = "masquerade_ipv4")
+	MasqueradeIpv4 String
 }

--- a/model/aro_hcp/v1alpha1/socket_total_node_role_os_metric_node_type.model
+++ b/model/aro_hcp/v1alpha1/socket_total_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/socket_totals_node_role_os_metric_node_type.model
+++ b/model/aro_hcp/v1alpha1/socket_totals_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/storage_quota_type.model
+++ b/model/aro_hcp/v1alpha1/storage_quota_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/sts_credential_request_type.model
+++ b/model/aro_hcp/v1alpha1/sts_credential_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +17,10 @@ limitations under the License.
 // Representation of an credRequest
 struct STSCredentialRequest {
 
-    //Name of CredRequest
-    Name String
+	//Name of CredRequest
+	Name String
 
-    //Operator Details
-    link Operator STSOperator
+	//Operator Details
+	link Operator STSOperator
 
 }

--- a/model/aro_hcp/v1alpha1/sts_operator_type.model
+++ b/model/aro_hcp/v1alpha1/sts_operator_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an sts operator
 struct STSOperator {
-    //Operator Name
-    Name                String
+	//Operator Name
+	Name                String
 
-    //Operator Namespace
-    Namespace           String
+	//Operator Namespace
+	Namespace           String
 
-    //Service Accounts
-    ServiceAccounts []String
+	//Service Accounts
+	ServiceAccounts []String
 
-    //Minimum ocp version supported
-    MinVersion          String
+	//Minimum ocp version supported
+	MinVersion          String
 
-    //Maximum ocp version supported
-    MaxVersion          String
+	//Maximum ocp version supported
+	MaxVersion          String
 }

--- a/model/aro_hcp/v1alpha1/sts_support_jump_role_type.model
+++ b/model/aro_hcp/v1alpha1/sts_support_jump_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/sts_type.model
+++ b/model/aro_hcp/v1alpha1/sts_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/subnet_network_verification_type.model
+++ b/model/aro_hcp/v1alpha1/subnet_network_verification_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 class SubnetNetworkVerification {
-  // Slice of failures that happened during a subnet network verification.
-  Details []String
-  
-  // State of the subnet network verification.
-  State String
+	// Slice of failures that happened during a subnet network verification.
+	Details []String
+	
+	// State of the subnet network verification.
+	State String
 
-  // Tags supplied to the network verifier for this subnet.
-  Tags [String]String
+	// Tags supplied to the network verifier for this subnet.
+	Tags [String]String
 
-  // Platform supplied to the network verifier for this subnet.
-  Platform Platform
+	// Platform supplied to the network verifier for this subnet.
+	Platform Platform
 }

--- a/model/aro_hcp/v1alpha1/subscription_type.model
+++ b/model/aro_hcp/v1alpha1/subscription_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/syncset_type.model
+++ b/model/aro_hcp/v1alpha1/syncset_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/taint_type.model
+++ b/model/aro_hcp/v1alpha1/taint_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,12 @@ limitations under the License.
 
 // Representation of a Taint set on a MachinePool in a cluster.
 struct Taint {
-    // The key for the taint
-    Key String
+	// The key for the taint
+	Key String
 
-    // The value for the taint.
-    Value String
-    
-    // The effect on the node for the pods matching the taint, i.e: NoSchedule, NoExecute, PreferNoSchedule.
-    Effect String
+	// The value for the taint.
+	Value String
+	
+	// The effect on the node for the pods matching the taint, i.e: NoSchedule, NoExecute, PreferNoSchedule.
+	Effect String
 }

--- a/model/aro_hcp/v1alpha1/trusted_ips_type.model
+++ b/model/aro_hcp/v1alpha1/trusted_ips_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/tuning_config_type.model
+++ b/model/aro_hcp/v1alpha1/tuning_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a tuning config.
 class TuningConfig {
-  // Name of the tuning config.
-  Name String
+	// Name of the tuning config.
+	Name String
 
-  // Spec of the tuning config.
-  Spec Interface
+	// Spec of the tuning config.
+	Spec Interface
 }

--- a/model/aro_hcp/v1alpha1/upgrade_policy_schedule_type.model
+++ b/model/aro_hcp/v1alpha1/upgrade_policy_schedule_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/upgrade_policy_state_type.model
+++ b/model/aro_hcp/v1alpha1/upgrade_policy_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/upgrade_policy_type.model
+++ b/model/aro_hcp/v1alpha1/upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/upgrade_policy_upgrade_type.model
+++ b/model/aro_hcp/v1alpha1/upgrade_policy_upgrade_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/user_type.model
+++ b/model/aro_hcp/v1alpha1/user_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/value_type.model
+++ b/model/aro_hcp/v1alpha1/value_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/version_gate_agreement_type.model
+++ b/model/aro_hcp/v1alpha1/version_gate_agreement_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/version_gate_type.model
+++ b/model/aro_hcp/v1alpha1/version_gate_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,33 +16,33 @@ limitations under the License.
 
 // Representation of an _OpenShift_ version gate.
 class VersionGate {
-  // VersionRawIDPrefix represents the versions prefix that the gate applies to.
-  VersionRawIDPrefix String
+	// VersionRawIDPrefix represents the versions prefix that the gate applies to.
+	VersionRawIDPrefix String
 
-  // Label representing the version gate in OpenShift.
-  Label String
+	// Label representing the version gate in OpenShift.
+	Label String
 
-  // Value represents the required value of the label.
-  Value String
+	// Value represents the required value of the label.
+	Value String
 
-  // WarningMessage is a warning that will be displayed to the user before they acknowledge the gate
-  WarningMessage String
+	// WarningMessage is a warning that will be displayed to the user before they acknowledge the gate
+	WarningMessage String
 
-  // Description of the version gate.
-  Description String
+	// Description of the version gate.
+	Description String
 
-  // DocumentationURL is the URL for the documentation of the version gate.
-  DocumentationURL String
+	// DocumentationURL is the URL for the documentation of the version gate.
+	DocumentationURL String
 
-  // STSOnly indicates if this version gate is for STS clusters only,
-  // deprecated: to be replaced with ClusterCondition
-  STSOnly Boolean
+	// STSOnly indicates if this version gate is for STS clusters only,
+	// deprecated: to be replaced with ClusterCondition
+	STSOnly Boolean
 
-  // ClusterCondition aims at selecting the clusters targeted by this version gate,
-  // ignored if STSOnly is true
-  ClusterCondition String
+	// ClusterCondition aims at selecting the clusters targeted by this version gate,
+	// ignored if STSOnly is true
+	ClusterCondition String
 
-  // CreationTimestamp is the date and time when the version gate was created,
-  // format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].
-  CreationTimestamp Date
+	// CreationTimestamp is the date and time when the version gate was created,
+	// format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].
+	CreationTimestamp Date
 }

--- a/model/aro_hcp/v1alpha1/version_resource.model
+++ b/model/aro_hcp/v1alpha1/version_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/version_type.model
+++ b/model/aro_hcp/v1alpha1/version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/versions_resource.model
+++ b/model/aro_hcp/v1alpha1/versions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/vpc_inquiry_type.model
+++ b/model/aro_hcp/v1alpha1/vpc_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/wif_config_status_type.model
+++ b/model/aro_hcp/v1alpha1/wif_config_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/wif_config_type.model
+++ b/model/aro_hcp/v1alpha1/wif_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/wif_service_account_type.model
+++ b/model/aro_hcp/v1alpha1/wif_service_account_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/wif_support_type.model
+++ b/model/aro_hcp/v1alpha1/wif_support_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/aro_hcp/v1alpha1/wildcard_policy_type.model
+++ b/model/aro_hcp/v1alpha1/wildcard_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/access_review_request_type.model
+++ b/model/authorizations/v1/access_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/access_review_resource.model
+++ b/model/authorizations/v1/access_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/access_review_response_type.model
+++ b/model/authorizations/v1/access_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/capability_review_request_type.model
+++ b/model/authorizations/v1/capability_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/capability_review_resource.model
+++ b/model/authorizations/v1/capability_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/capability_review_response_type.model
+++ b/model/authorizations/v1/capability_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/export_control_review_request_type.model
+++ b/model/authorizations/v1/export_control_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/export_control_review_resource.model
+++ b/model/authorizations/v1/export_control_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/export_control_review_response_type.model
+++ b/model/authorizations/v1/export_control_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/feature_review_request_type.model
+++ b/model/authorizations/v1/feature_review_request_type.model
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ limitations under the License.
 
 // Representation of a feature review
 struct FeatureReviewRequest {
-  // Defines the username of the account of which access is being reviewed 
-  AccountUsername String
+	// Defines the username of the account of which access is being reviewed 
+	AccountUsername String
 
-  // Indicates the feature which can be toggled
-  Feature String
+	// Indicates the feature which can be toggled
+	Feature String
 
-  // Defines the organisation id of the account of which access is being reviewed
-  OrganizationId String
+	// Defines the organisation id of the account of which access is being reviewed
+	OrganizationId String
 
-  // Defines the cluster id which access is being reviewed
-  ClusterId String
+	// Defines the cluster id which access is being reviewed
+	ClusterId String
 }

--- a/model/authorizations/v1/feature_review_resource.model
+++ b/model/authorizations/v1/feature_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages feature review
 resource FeatureReview {
-  // Reviews a user's ability to toggle a feature
-  method Post {
-    in Request FeatureReviewRequest
-    out Request FeatureReviewResponse
-  }
+	// Reviews a user's ability to toggle a feature
+	method Post {
+	in Request FeatureReviewRequest
+	out Request FeatureReviewResponse
+	}
 }

--- a/model/authorizations/v1/feature_review_response_type.model
+++ b/model/authorizations/v1/feature_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a feature review response
 struct FeatureReviewResponse {
-  // Defines whether the feature can be toggled
-  Enabled Boolean
+	// Defines whether the feature can be toggled
+	Enabled Boolean
 
-  // Defines the feature id which can be toggled
-  FeatureID String
+	// Defines the feature id which can be toggled
+	FeatureID String
 }

--- a/model/authorizations/v1/resource_review_request_type.model
+++ b/model/authorizations/v1/resource_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/resource_review_resource.model
+++ b/model/authorizations/v1/resource_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/resource_review_type.model
+++ b/model/authorizations/v1/resource_review_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/root_resource.model
+++ b/model/authorizations/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_access_review_request_type.model
+++ b/model/authorizations/v1/self_access_review_request_type.model
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_access_review_resource.model
+++ b/model/authorizations/v1/self_access_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_access_review_response_type.model
+++ b/model/authorizations/v1/self_access_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_capability_review_request_type.model
+++ b/model/authorizations/v1/self_capability_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Representation of a capability review.
 struct SelfCapabilityReviewRequest {
-    // Defines the username of the account of which capability is being reviewed.
-    AccountUsername String
+	// Defines the username of the account of which capability is being reviewed.
+	AccountUsername String
 
-    // Type of capability [Cluster].
-    Type String
+	// Type of capability [Cluster].
+	Type String
 
-    // Indicates the type of the resource.
-    // See uhc-account-manager/openapi/openapi.yaml for a list of possible values.
-    ResourceType String
+	// Indicates the type of the resource.
+	// See uhc-account-manager/openapi/openapi.yaml for a list of possible values.
+	ResourceType String
 
-    // Capability to review [manage_cluster_admin].
-    Capability String
+	// Capability to review [manage_cluster_admin].
+	Capability String
 
-    // Indicates which Cluster (internal id) the resource type belongs to.
-    ClusterID String
+	// Indicates which Cluster (internal id) the resource type belongs to.
+	ClusterID String
 
-    // Indicates which Subscription the resource type belongs to.
-    SubscriptionID String
+	// Indicates which Subscription the resource type belongs to.
+	SubscriptionID String
 
-    // Indicates which Organization the resource type belongs to.
-    OrganizationID String
+	// Indicates which Organization the resource type belongs to.
+	OrganizationID String
 }

--- a/model/authorizations/v1/self_capability_review_resource.model
+++ b/model/authorizations/v1/self_capability_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_capability_review_response_type.model
+++ b/model/authorizations/v1/self_capability_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_feature_review_request_type.model
+++ b/model/authorizations/v1/self_feature_review_request_type.model
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,6 @@ limitations under the License.
 
 // Representation of a feature review performed against oneself
 struct SelfFeatureReviewRequest {
-  // Indicates the feature which can be toggled
-  Feature String
+	// Indicates the feature which can be toggled
+	Feature String
 }

--- a/model/authorizations/v1/self_feature_review_resource.model
+++ b/model/authorizations/v1/self_feature_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages feature review
 resource SelfFeatureReview {
-  // Reviews ability to toggle a feature
-  method Post {
-    in Request SelfFeatureReviewRequest
-    out Request SelfFeatureReviewResponse
-  }
+	// Reviews ability to toggle a feature
+	method Post {
+	in Request SelfFeatureReviewRequest
+	out Request SelfFeatureReviewResponse
+	}
 }

--- a/model/authorizations/v1/self_feature_review_response_type.model
+++ b/model/authorizations/v1/self_feature_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a feature review response, performed against oneself
 struct SelfFeatureReviewResponse {
-  // Defines whether the feature can be toggled
-  Enabled Boolean
+	// Defines whether the feature can be toggled
+	Enabled Boolean
 
-  // Defines the feature id which can be toggled
-  FeatureID String
+	// Defines the feature id which can be toggled
+	FeatureID String
 }

--- a/model/authorizations/v1/self_terms_review_request_type.model
+++ b/model/authorizations/v1/self_terms_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/self_terms_review_resource.model
+++ b/model/authorizations/v1/self_terms_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/terms_review_request_type.model
+++ b/model/authorizations/v1/terms_review_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,10 +19,10 @@ limitations under the License.
 struct TermsReviewRequest {
 	// Defines the username of the account of which Terms is being reviewed.
 	AccountUsername String
-    // Defines the site code of the terms being checked
-    SiteCode String
-    // Defines the event code of the terms being checked
-    EventCode String
-    // If false, only `terms_required` will be checked
-    CheckOptionalTerms Boolean
+	// Defines the site code of the terms being checked
+	SiteCode String
+	// Defines the event code of the terms being checked
+	EventCode String
+	// If false, only `terms_required` will be checked
+	CheckOptionalTerms Boolean
 }

--- a/model/authorizations/v1/terms_review_resource.model
+++ b/model/authorizations/v1/terms_review_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/authorizations/v1/terms_review_response_type.model
+++ b/model/authorizations/v1/terms_review_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/UpgradePolicyStateValue.model
+++ b/model/clusters_mgmt/v1/UpgradePolicyStateValue.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Overall state of a cluster upgrade policy.
 enum UpgradePolicyStateValue {
-    // Upgrade policy set but an upgrade wasn't scheduled yet
-    Pending
+	// Upgrade policy set but an upgrade wasn't scheduled yet
+	Pending
 
-    // Upgrade policy set and was scheduled
-    Scheduled
+	// Upgrade policy set and was scheduled
+	Scheduled
 
-    // Upgrade started
-    Started
+	// Upgrade started
+	Started
 
-    // Upgrade completed (temporary state - the policy will be removed in case of 
-    // manual upgrade, or move back to pending in case of automatic upgrade)
-    Completed
+	// Upgrade completed (temporary state - the policy will be removed in case of 
+	// manual upgrade, or move back to pending in case of automatic upgrade)
+	Completed
 
-    // Upgrade failed
-    Failed
+	// Upgrade failed
+	Failed
 
-    // Upgrade is taking longer than expected
-    Delayed
+	// Upgrade is taking longer than expected
+	Delayed
 
-    // Upgrade got cancelled (temporary state - the policy will get removed).
-    Cancelled
+	// Upgrade got cancelled (temporary state - the policy will get removed).
+	Cancelled
 }

--- a/model/clusters_mgmt/v1/add_on_additional_catalog_sources_type.model
+++ b/model/clusters_mgmt/v1/add_on_additional_catalog_sources_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon catalog source object used by addon versions.
 struct AdditionalCatalogSource {
-    // ID of the additional catalog source
-    ID String
+	// ID of the additional catalog source
+	ID String
 
-    // Name of the additional catalog source.
-    Name String
+	// Name of the additional catalog source.
+	Name String
 
-    // Image of the additional catalog source.
-    Image String
+	// Image of the additional catalog source.
+	Image String
 
-    // Indicates is this additional catalog source is enabled for the addon
-    Enabled Boolean
+	// Indicates is this additional catalog source is enabled for the addon
+	Enabled Boolean
 }

--- a/model/clusters_mgmt/v1/add_on_config_type.model
+++ b/model/clusters_mgmt/v1/add_on_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ limitations under the License.
 // Representation of an add-on config.
 // The attributes under it are to be used by the addon once its installed in the cluster.
 class AddOnConfig {
-    // List of environment variables for the addon
-    AddOnEnvironmentVariables []AddOnEnvironmentVariable
+	// List of environment variables for the addon
+	AddOnEnvironmentVariables []AddOnEnvironmentVariable
 
-    // List of secret propagations for the addon
-    SecretPropagations []AddOnSecretPropagation
+	// List of secret propagations for the addon
+	SecretPropagations []AddOnSecretPropagation
 }

--- a/model/clusters_mgmt/v1/add_on_environment_variable_type.model
+++ b/model/clusters_mgmt/v1/add_on_environment_variable_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of an add-on env object.
 class AddOnEnvironmentVariable {
-    // Name of the env object.
-    Name String
+	// Name of the env object.
+	Name String
 
-    // Value of the env object.
-    Value String
+	// Value of the env object.
+	Value String
 }

--- a/model/clusters_mgmt/v1/add_on_inquiries_resource.model
+++ b/model/clusters_mgmt/v1/add_on_inquiries_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,53 +17,53 @@ limitations under the License.
 // Manages add-on inquiries, inquiries perform validation of add-on(s) on a per cluster basis
 // based on add-on conditions and requirements.
 resource AddonInquiries {
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Maximum number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // Search criteria.
-        //
-        // The syntax of this parameter is similar to the syntax of the _where_ clause of an
-        // SQL statement, but using the names of the attributes of the add-on instead of
-        // the names of the columns of a table. For example, in order to retrieve all the
-        // add-ons with a name starting with `my` the value should be:
-        //
-        // ```sql
-        // name like 'my%'
-        // ```
-        //
-        // If the parameter isn't provided, or if the value is empty, then all the add-ons
-        // that the user has permission to see will be returned.
-        in Search String
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of an
+		// SQL statement, but using the names of the attributes of the add-on instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// add-ons with a name starting with `my` the value should be:
+		//
+		// ```sql
+		// name like 'my%'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the add-ons
+		// that the user has permission to see will be returned.
+		in Search String
 
-        // Order criteria.
-        //
-        // The syntax of this parameter is similar to the syntax of the _order by_ clause of
-        // a SQL statement, but using the names of the attributes of the add-on instead of
-        // the names of the columns of a table. For example, in order to sort the add-ons
-        // descending by name the value should be:
-        //
-        // ```sql
-        // name desc
-        // ```
-        //
-        // If the parameter isn't provided, or if the value is empty, then the order of the
-        // results is undefined.
-        in Order String
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the add-on instead of
+		// the names of the columns of a table. For example, in order to sort the add-ons
+		// descending by name the value should be:
+		//
+		// ```sql
+		// name desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page.
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
 
-        // Retrieved list of add-ons.
-        out Items []AddOn
-    }
+		// Retrieved list of add-ons.
+		out Items []AddOn
+	}
 
-    locator AddonInquiry {
-        target AddonInquiry
-        variable AddonID
-    }
+	locator AddonInquiry {
+		target AddonInquiry
+		variable AddonID
+	}
 }

--- a/model/clusters_mgmt/v1/add_on_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/add_on_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Manages a specific add-on inquiry
 resource AddonInquiry {
-    method Get {
-        out Body AddOn
-    }
+	method Get {
+		out Body AddOn
+	}
 }

--- a/model/clusters_mgmt/v1/add_on_install_mode_type.model
+++ b/model/clusters_mgmt/v1/add_on_install_mode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_installation_billing.model
+++ b/model/clusters_mgmt/v1/add_on_installation_billing.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Representation of an add-on installation billing.
 class AddOnInstallationBilling {
-  // Billing Model for addon resources
-  BillingModel BillingModel
-  // Account ID for billing market place
-  BillingMarketplaceAccount String
+	// Billing Model for addon resources
+	BillingModel BillingModel
+	// Account ID for billing market place
+	BillingMarketplaceAccount String
 }

--- a/model/clusters_mgmt/v1/add_on_installation_parameter_type.model
+++ b/model/clusters_mgmt/v1/add_on_installation_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_installation_resource.model
+++ b/model/clusters_mgmt/v1/add_on_installation_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ resource AddOnInstallation {
 		in out Body AddOnInstallation
 	}
 
-    // Delete an add-on installation and remove it from the collection of add-on installations on the cluster.
-    method Delete {
-    }
+	// Delete an add-on installation and remove it from the collection of add-on installations on the cluster.
+	method Delete {
+	}
 }

--- a/model/clusters_mgmt/v1/add_on_installation_state_type.model
+++ b/model/clusters_mgmt/v1/add_on_installation_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_installation_type.model
+++ b/model/clusters_mgmt/v1/add_on_installation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_installations_resource.model
+++ b/model/clusters_mgmt/v1/add_on_installations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_namespace_type.model
+++ b/model/clusters_mgmt/v1/add_on_namespace_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,12 +15,12 @@ limitations under the License.
 */
 
 class AddOnNamespace{
-    // Name of the namespace.
-    Name String
-    
-    // Labels to be applied to this namespace.
-    Labels [String]String
+	// Name of the namespace.
+	Name String
+	
+	// Labels to be applied to this namespace.
+	Labels [String]String
 
-    // Annotations to be applied to this namespace.
-    Annotations [String]String
+	// Annotations to be applied to this namespace.
+	Annotations [String]String
 }

--- a/model/clusters_mgmt/v1/add_on_parameter_option_type.model
+++ b/model/clusters_mgmt/v1/add_on_parameter_option_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_parameter_type.model
+++ b/model/clusters_mgmt/v1/add_on_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_requirement_status_type.model
+++ b/model/clusters_mgmt/v1/add_on_requirement_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_requirement_type.model
+++ b/model/clusters_mgmt/v1/add_on_requirement_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ struct AddOnRequirement {
 	// Indicates if this requirement is enabled for the add-on.
 	Enabled Boolean
 
-    // Optional cluster specific status for the add-on.
+	// Optional cluster specific status for the add-on.
 	Status AddOnRequirementStatus
 
 }

--- a/model/clusters_mgmt/v1/add_on_resource.model
+++ b/model/clusters_mgmt/v1/add_on_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_secret_propagation_type.model
+++ b/model/clusters_mgmt/v1/add_on_secret_propagation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Representation of an addon secret propagation
 struct AddOnSecretPropagation {
-    // ID of the secret propagation
-    ID string
+	// ID of the secret propagation
+	ID string
 
-    // SourceSecret is location of the source secret
-    SourceSecret String
+	// SourceSecret is location of the source secret
+	SourceSecret String
 
-    // DestinationSecret is location of the secret to be added
-    DestinationSecret String
+	// DestinationSecret is location of the secret to be added
+	DestinationSecret String
 
-    // Indicates is this secret propagation is enabled for the addon
-    Enabled Boolean
+	// Indicates is this secret propagation is enabled for the addon
+	Enabled Boolean
 }

--- a/model/clusters_mgmt/v1/add_on_sub_operator_type.model
+++ b/model/clusters_mgmt/v1/add_on_sub_operator_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,14 +17,14 @@ limitations under the License.
 // Representation of an add-on sub operator. A sub operator is an operator
 // who's life cycle is controlled by the add-on umbrella operator. 
 struct AddOnSubOperator {
-  
-  // Name of the add-on sub operator
-  OperatorName String
+	
+	// Name of the add-on sub operator
+	OperatorName String
 
-  // Namespace of the add-on sub operator
-  OperatorNamespace String
- 
-  // Indicates if the sub operator is enabled for the add-on
-  Enabled Boolean
+	// Namespace of the add-on sub operator
+	OperatorNamespace String
+	
+	// Indicates if the sub operator is enabled for the add-on
+	Enabled Boolean
 }
 

--- a/model/clusters_mgmt/v1/add_on_type.model
+++ b/model/clusters_mgmt/v1/add_on_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_version_resource.model
+++ b/model/clusters_mgmt/v1/add_on_version_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_version_type.model
+++ b/model/clusters_mgmt/v1/add_on_version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_on_versions_resource.model
+++ b/model/clusters_mgmt/v1/add_on_versions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/add_ons_resource.model
+++ b/model/clusters_mgmt/v1/add_ons_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/addon_upgrade_policies_resource.model
+++ b/model/clusters_mgmt/v1/addon_upgrade_policies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/addon_upgrade_policy_resource.model
+++ b/model/clusters_mgmt/v1/addon_upgrade_policy_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/addon_upgrade_policy_state_resource.model
+++ b/model/clusters_mgmt/v1/addon_upgrade_policy_state_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/addon_upgrade_policy_state_type.model
+++ b/model/clusters_mgmt/v1/addon_upgrade_policy_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/addon_upgrade_policy_type.model
+++ b/model/clusters_mgmt/v1/addon_upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/admin_credentials_type.model
+++ b/model/clusters_mgmt/v1/admin_credentials_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/alert_info_type.model
+++ b/model/clusters_mgmt/v1/alert_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/alert_severity_type.model
+++ b/model/clusters_mgmt/v1/alert_severity_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/alerts_info_type.model
+++ b/model/clusters_mgmt/v1/alerts_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/alerts_metric_query_resource.model
+++ b/model/clusters_mgmt/v1/alerts_metric_query_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/ami_override_type.model
+++ b/model/clusters_mgmt/v1/ami_override_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // AMIOverride specifies what Amazon Machine Image should be used for a particular product and region.
 class AMIOverride {
-    // Link to the product type.
-    link Product Product
+	// Link to the product type.
+	link Product Product
 
-    // Link to the cloud provider region.
-    link Region CloudRegion
+	// Link to the cloud provider region.
+	link Region CloudRegion
 
-    // AMI is the id of the Amazon Machine Image.
-    AMI String
+	// AMI is the id of the Amazon Machine Image.
+	AMI String
 }

--- a/model/clusters_mgmt/v1/audit_log_type.model
+++ b/model/clusters_mgmt/v1/audit_log_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/autoscaler_resource.model
+++ b/model/clusters_mgmt/v1/autoscaler_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/autoscaler_resource_limits_gpu_limit_type.model
+++ b/model/clusters_mgmt/v1/autoscaler_resource_limits_gpu_limit_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/autoscaler_resource_limits_type.model
+++ b/model/clusters_mgmt/v1/autoscaler_resource_limits_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/autoscaler_scale_down_config_type.model
+++ b/model/clusters_mgmt/v1/autoscaler_scale_down_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/available_regions_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/available_regions_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ resource AvailableRegionsInquiry {
 		out Total Integer
 
 		// Retrieved list of regions.
-   		out Items []CloudRegion
+			out Items []CloudRegion
 
 		// Cloud provider data needed for the inquiry
 		in Body CloudProviderData

--- a/model/clusters_mgmt/v1/aws_autonode_type.model
+++ b/model/clusters_mgmt/v1/aws_autonode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // AWS provider configuration settings when using AutoNode on a ROSA HCP Cluster
 struct AwsAutoNode {
-    // The AWS ARN of the IAM Role that has the permissions required for the AutoNode
-    // controller.
-    // The role must exist prior to enabling AutoNode on the cluster.
-    RoleArn String
+	// The AWS ARN of the IAM Role that has the permissions required for the AutoNode
+	// controller.
+	// The role must exist prior to enabling AutoNode on the cluster.
+	RoleArn String
 }

--- a/model/clusters_mgmt/v1/aws_backup_config_type.model
+++ b/model/clusters_mgmt/v1/aws_backup_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Backup configuration for AWS clusters
 struct AWSBackupConfig {
-    // ID of the AWS Disaster Recovery (DR) account
-    AccountId           string
+	// ID of the AWS Disaster Recovery (DR) account
+	AccountId           string
 
-    // ARN of the role used by the CS Trusted Account to gain access to the Disaster Recovery (DR) account
-    RoleArn             string
+	// ARN of the role used by the CS Trusted Account to gain access to the Disaster Recovery (DR) account
+	RoleArn             string
 
-    // ARN of the identity provider created in the Disaster Recovery (DR) account for the Management Cluster
-    IdentityProviderArn string
+	// ARN of the identity provider created in the Disaster Recovery (DR) account for the Management Cluster
+	IdentityProviderArn string
 
-    // Name of the S3 bucket used to save the backup
-    S3Bucket            string
+	// Name of the S3 bucket used to save the backup
+	S3Bucket            string
 
-    // Name of the management cluster the backup config refers to
-    ManagementCluster String
+	// Name of the management cluster the backup config refers to
+	ManagementCluster String
 
-    // ARN of the role used in the Disaster Recovery (DR) account to manipulate backups for deleted clusters
-    AccessSharedRoleArn string
+	// ARN of the role used in the Disaster Recovery (DR) account to manipulate backups for deleted clusters
+	AccessSharedRoleArn string
 }

--- a/model/clusters_mgmt/v1/aws_capacity_reservation_type.model
+++ b/model/clusters_mgmt/v1/aws_capacity_reservation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // AWS Capacity Reservation specification.
 struct AWSCapacityReservation {
-    // Specify the target Capacity Reservation in which the EC2 instances will be launched.
-    Id String
+	// Specify the target Capacity Reservation in which the EC2 instances will be launched.
+	Id String
 
-    // marketType specifies the market type of the CapacityReservation for the EC2
-    // instances. Valid values are OnDemand, CapacityBlocks.
-    // "OnDemand": EC2 instances run as standard On-Demand instances.
-    // "CapacityBlocks": scheduled pre-purchased compute capacity.
-    MarketType MarketType
+	// marketType specifies the market type of the CapacityReservation for the EC2
+	// instances. Valid values are OnDemand, CapacityBlocks.
+	// "OnDemand": EC2 instances run as standard On-Demand instances.
+	// "CapacityBlocks": scheduled pre-purchased compute capacity.
+	MarketType MarketType
 
 	// preference specifies how capacity reservations should be used with this NodePool
 	// "none": EC2 instances in this NodePool should never make use of capacity reservations. Note that this value cannot

--- a/model/clusters_mgmt/v1/aws_etcd_enryption_type.model
+++ b/model/clusters_mgmt/v1/aws_etcd_enryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_flavour_type.model
+++ b/model/clusters_mgmt/v1/aws_flavour_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_http_token_state_type.model
+++ b/model/clusters_mgmt/v1/aws_http_token_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_grant_resource.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_grant_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_grant_state_type.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_grant_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_grant_type.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_grant_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_grants_resource.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_grants_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_resource.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_state_type.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_role_type.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_infrastructure_access_roles_resource.model
+++ b/model/clusters_mgmt/v1/aws_infrastructure_access_roles_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_inquiries_resource.model
+++ b/model/clusters_mgmt/v1/aws_inquiries_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,43 +16,43 @@ limitations under the License.
 
 // Manages the collection of aws inquiries.
 resource AWSInquiries {
-    // Reference to the resource that manages a collection of vpcs.
-    locator Vpcs {
-        target VpcsInquiry
-    }
+	// Reference to the resource that manages a collection of vpcs.
+	locator Vpcs {
+		target VpcsInquiry
+	}
 
-    // Reference to the resource that manages a collection of regions.
-    locator Regions {
-        target AvailableRegionsInquiry
-    }
+	// Reference to the resource that manages a collection of regions.
+	locator Regions {
+		target AvailableRegionsInquiry
+	}
 
-    // Reference to the resource that manages aws sts policies.
-    locator STSPolicies {
-        target AWSSTSPoliciesInquiry
-    }
+	// Reference to the resource that manages aws sts policies.
+	locator STSPolicies {
+		target AWSSTSPoliciesInquiry
+	}
 
-    // Reference to the resource that manages sts cred request.
-    locator STSCredentialRequests {
-        target STSCredentialRequestsInquiry
-    }
+	// Reference to the resource that manages sts cred request.
+	locator STSCredentialRequests {
+		target STSCredentialRequestsInquiry
+	}
 
-    // Reference to the resource that manages aws machine types by regions.
-    locator MachineTypes {
-        target AWSRegionMachineTypesInquiry
-    }
+	// Reference to the resource that manages aws machine types by regions.
+	locator MachineTypes {
+		target AWSRegionMachineTypesInquiry
+	}
 
-    // Reference to the resource that manages aws sts roles.
-    locator STSAccountRoles {
-        target AWSSTSAccountRolesInquiry
-    }
+	// Reference to the resource that manages aws sts roles.
+	locator STSAccountRoles {
+		target AWSSTSAccountRolesInquiry
+	}
 
-    // Reference to the resource that manages creds validation.
-    locator ValidateCredentials {
-        target AwsValidateCredentials
-    }
+	// Reference to the resource that manages creds validation.
+	locator ValidateCredentials {
+		target AwsValidateCredentials
+	}
 
-    // Reference to the resource that manages OIDC Config Thumbprint fetching.
-    locator OidcThumbprint {
-        target OidcThumbprint
-    }
+	// Reference to the resource that manages OIDC Config Thumbprint fetching.
+	locator OidcThumbprint {
+		target OidcThumbprint
+	}
 }

--- a/model/clusters_mgmt/v1/aws_machine_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_machine_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Representation of aws machine pool specific parameters.
 class AWSMachinePool {
-    // Use spot instances on this machine pool to reduce cost.
-    SpotMarketOptions AWSSpotMarketOptions
+	// Use spot instances on this machine pool to reduce cost.
+	SpotMarketOptions AWSSpotMarketOptions
 
-    // Additional AWS Security Groups to be added machine pool. Note that machine pools can only be worker node at the time.
-    AdditionalSecurityGroupIds []String
+	// Additional AWS Security Groups to be added machine pool. Note that machine pools can only be worker node at the time.
+	AdditionalSecurityGroupIds []String
 
-    // Associates nodepool subnets with AWS Outposts.
-    SubnetOutposts [String]String
+	// Associates nodepool subnets with AWS Outposts.
+	SubnetOutposts [String]String
 
-    // Associates nodepool availability zones with zone types (e.g. wavelength, local).
-    AvailabilityZoneTypes [String]String
+	// Associates nodepool availability zones with zone types (e.g. wavelength, local).
+	AvailabilityZoneTypes [String]String
 
-    // Optional keys and values that the machine pool provisioner will add as AWS tags to all AWS resources it creates.
-    //
-    // AWS tags must conform to the following standards:
-    // - Each resource may have a maximum of 25 tags
-    // - Tags beginning with "aws:" are reserved for system use and may not be set
-    // - Tag keys may be between 1 and 128 characters in length
-    // - Tag values may be between 0 and 256 characters in length
-    // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
-    Tags [String]String
+	// Optional keys and values that the machine pool provisioner will add as AWS tags to all AWS resources it creates.
+	//
+	// AWS tags must conform to the following standards:
+	// - Each resource may have a maximum of 25 tags
+	// - Tags beginning with "aws:" are reserved for system use and may not be set
+	// - Tag keys may be between 1 and 128 characters in length
+	// - Tag values may be between 0 and 256 characters in length
+	// - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
+	Tags [String]String
 }

--- a/model/clusters_mgmt/v1/aws_node_pool_type.model
+++ b/model/clusters_mgmt/v1/aws_node_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,39 +16,39 @@ limitations under the License.
 
 // Representation of aws node pool specific parameters.
 class AWSNodePool {
-    // InstanceType is an ec2 instance type for node instances (e.g. m5.large).
-    InstanceType String
+	// InstanceType is an ec2 instance type for node instances (e.g. m5.large).
+	InstanceType String
 
-    // InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
-    InstanceProfile String
+	// InstanceProfile is the AWS EC2 instance profile, which is a container for an IAM role that the EC2 instance uses.
+	InstanceProfile String
 
-    // Optional keys and values that the installer will add as tags to all AWS resources it creates.
-    //
-    // AWS tags must conform to the following standards:
-    // - Each resource may have a maximum of 25 tags
-    // - Tags beginning with "aws:" are reserved for system use and may not be set
-    // - Tag keys may be between 1 and 128 characters in length
-    // - Tag values may be between 0 and 256 characters in length
-    // - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
-    Tags [String]String
+	// Optional keys and values that the installer will add as tags to all AWS resources it creates.
+	//
+	// AWS tags must conform to the following standards:
+	// - Each resource may have a maximum of 25 tags
+	// - Tags beginning with "aws:" are reserved for system use and may not be set
+	// - Tag keys may be between 1 and 128 characters in length
+	// - Tag values may be between 0 and 256 characters in length
+	// - Tags may only contain letters, numbers, spaces, and the following characters: [_ . : / = + - @]
+	Tags [String]String
 
-    // Associates nodepool subnets with AWS Outposts.
-    SubnetOutposts [String]String
+	// Associates nodepool subnets with AWS Outposts.
+	SubnetOutposts [String]String
 
-    // Associates nodepool availability zones with zone types (e.g. wavelength, local).
-    AvailabilityZoneTypes [String]String
+	// Associates nodepool availability zones with zone types (e.g. wavelength, local).
+	AvailabilityZoneTypes [String]String
 
-    // Additional AWS Security Groups to be added node pool.
-    AdditionalSecurityGroupIds []String
+	// Additional AWS Security Groups to be added node pool.
+	AdditionalSecurityGroupIds []String
 
-    // Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
-    @json(name = "ec2_metadata_http_tokens")
-    Ec2MetadataHttpTokens Ec2MetadataHttpTokens    
-    
-    // AWS Volume specification to be used to set custom worker disk size
-    RootVolume AWSVolume
+	// Which Ec2MetadataHttpTokens to use for metadata service interaction options for EC2 instances
+	@json(name = "ec2_metadata_http_tokens")
+	Ec2MetadataHttpTokens Ec2MetadataHttpTokens    
+	
+	// AWS Volume specification to be used to set custom worker disk size
+	RootVolume AWSVolume
 
-    // If present it defines the AWS Capacity Reservation used for this NodePool
-    @json(name = "capacity_reservation")
-    CapacityReservation AWSCapacityReservation
+	// If present it defines the AWS Capacity Reservation used for this NodePool
+	@json(name = "capacity_reservation")
+	CapacityReservation AWSCapacityReservation
 }

--- a/model/clusters_mgmt/v1/aws_region_machine_types_resource.model
+++ b/model/clusters_mgmt/v1/aws_region_machine_types_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_resource.model
+++ b/model/clusters_mgmt/v1/aws_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_security_group_type.model
+++ b/model/clusters_mgmt/v1/aws_security_group_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_shard_type.model
+++ b/model/clusters_mgmt/v1/aws_shard_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_spot_market_options_type.model
+++ b/model/clusters_mgmt/v1/aws_spot_market_options_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Spot market options for AWS machine pool.
 class AWSSpotMarketOptions {
-    // The max price for spot instance. Optional.
-    // If not set, use the on-demand price.
-    MaxPrice Float
+	// The max price for spot instance. Optional.
+	// If not set, use the on-demand price.
+	MaxPrice Float
 }

--- a/model/clusters_mgmt/v1/aws_sts_account_role_type.model
+++ b/model/clusters_mgmt/v1/aws_sts_account_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ limitations under the License.
 // Representation of an sts account role for a rosa cluster
 struct AWSSTSAccountRole {
 
-    //The Prefix for this Account Role
-    Prefix String
+	//The Prefix for this Account Role
+	Prefix String
 
-    //The list of STS Roles for this Account Role
-    Items []AWSSTSRole
+	//The list of STS Roles for this Account Role
+	Items []AWSSTSRole
 }

--- a/model/clusters_mgmt/v1/aws_sts_account_roles_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/aws_sts_account_roles_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,35 +16,35 @@ limitations under the License.
 
 // Manages STS Roles
 resource AWSSTSAccountRolesInquiry {
-    // Retrieves the list of STS Account Roles in the specified AWS Account.
-    // IMPORTANT: This collection doesn't currently support paging or searching, so the returned
-    // `page` will always be 1 and `size` and `total` will always be the total number of available account roles
-    // in the AWS Account
+	// Retrieves the list of STS Account Roles in the specified AWS Account.
+	// IMPORTANT: This collection doesn't currently support paging or searching, so the returned
+	// `page` will always be 1 and `size` and `total` will always be the total number of available account roles
+	// in the AWS Account
 
-    method Search {
+	method Search {
 
-        // AWS Account Details required for the inquiry
-        in Body AWS
+		// AWS Account Details required for the inquiry
+		in Body AWS
 
-        // Index of the returned page, where one corresponds to the first page. As this
-        // collection doesn't support paging the result will always be `1`.
-        in out Page Integer = 1
+		// Index of the returned page, where one corresponds to the first page. As this
+		// collection doesn't support paging the result will always be `1`.
+		in out Page Integer = 1
 
-        // Number of items that will be contained in the returned page. As this collection
-        // doesn't support paging or searching the result will always be the total number of
-        // be the total number of STS account roles.
-        in out Size Integer = 100
+		// Number of items that will be contained in the returned page. As this collection
+		// doesn't support paging or searching the result will always be the total number of
+		// be the total number of STS account roles.
+		in out Size Integer = 100
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page. As this collection doesn't support paging or
-        // searching the result will always be the total number of STS account roles
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page. As this collection doesn't support paging or
+		// searching the result will always be the total number of STS account roles
+		out Total Integer
 
-        // The AWS Account Id for the STS Account Roles
-        @json(name = "aws_acccount_id")
-        out AwsAccountId String
+		// The AWS Account Id for the STS Account Roles
+		@json(name = "aws_acccount_id")
+		out AwsAccountId String
 
-        // Retrieved list of STS Account Roles
-        out Items []AWSSTSAccountRole
-    }
+		// Retrieved list of STS Account Roles
+		out Items []AWSSTSAccountRole
+	}
 }

--- a/model/clusters_mgmt/v1/aws_sts_policies_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/aws_sts_policies_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,50 +16,50 @@ limitations under the License.
 
 // Manages STS policies
 resource AWSSTSPoliciesInquiry {
-    // Retrieves the list of policies.
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	// Retrieves the list of policies.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Maximum number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // Search criteria.
-        //
-        // The syntax of this parameter is similar to the syntax of the _where_ clause of a
-        // SQL statement, but using the names of the attributes of the awsstspolicies instead of
-        // the names of the columns of a table. For example, in order to retrieve all the
-        // policies of type  `operatorrole`
-        // should be:
-        //
-        // ```sql
-        // policy_type like 'OperatorRole%'
-        // ```
-        //
-        // If the parameter isn't provided, or if the value is empty, then all the
-        // policies  will be returned.
-        in Search String
+		// Search criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _where_ clause of a
+		// SQL statement, but using the names of the attributes of the awsstspolicies instead of
+		// the names of the columns of a table. For example, in order to retrieve all the
+		// policies of type  `operatorrole`
+		// should be:
+		//
+		// ```sql
+		// policy_type like 'OperatorRole%'
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then all the
+		// policies  will be returned.
+		in Search String
 
-        // Order criteria.
-        //
-        // The syntax of this parameter is similar to the syntax of the _order by_ clause of
-        // a SQL statement, but using the names of the attributes of the awsstspolicies instead of
-        // the names of the columns of a table. For example, in order to sort the policies
-        // descending by operator type identifier the value should be:
-        //
-        // ```sql
-        // orderBy id desc
-        // ```
-        //
-        // If the parameter isn't provided, or if the value is empty, then the order of the
-        // results is undefined.
-        in Order String
+		// Order criteria.
+		//
+		// The syntax of this parameter is similar to the syntax of the _order by_ clause of
+		// a SQL statement, but using the names of the attributes of the awsstspolicies instead of
+		// the names of the columns of a table. For example, in order to sort the policies
+		// descending by operator type identifier the value should be:
+		//
+		// ```sql
+		// orderBy id desc
+		// ```
+		//
+		// If the parameter isn't provided, or if the value is empty, then the order of the
+		// results is undefined.
+		in Order String
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page.
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
 
-        // Retrieved list of policies.
-        out Items []AWSSTSPolicy
-    }
+		// Retrieved list of policies.
+		out Items []AWSSTSPolicy
+	}
 }

--- a/model/clusters_mgmt/v1/aws_sts_policies_type.model
+++ b/model/clusters_mgmt/v1/aws_sts_policies_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,15 +17,15 @@ limitations under the License.
 // Representation of an sts policies for rosa cluster
 struct AWSSTSPolicy {
 
-    //Policy ID
-    ID String
+	//Policy ID
+	ID String
 
-    //Policy Details
-    Details String
+	//Policy Details
+	Details String
 
-    //Type of policy operator/account role
-    Type String
+	//Type of policy operator/account role
+	Type String
 
-    //The ARN of the managed policy
-    ARN String
+	//The ARN of the managed policy
+	ARN String
 }

--- a/model/clusters_mgmt/v1/aws_sts_role_type.model
+++ b/model/clusters_mgmt/v1/aws_sts_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,27 +17,27 @@ limitations under the License.
 // Representation of an sts role for a rosa cluster
 struct AWSSTSRole {
 
-    //The AWS ARN for this Role
-    @json(name = "arn")
-    RoleARN String
+	//The AWS ARN for this Role
+	@json(name = "arn")
+	RoleARN String
 
-    //The type of this Role
-    @json(name = "type")
-    RoleType String
+	//The type of this Role
+	@json(name = "type")
+	RoleType String
 
-    //Does this role have Admin permission?
-    @json(name = "isAdmin")
-    IsAdmin Boolean
+	//Does this role have Admin permission?
+	@json(name = "isAdmin")
+	IsAdmin Boolean
 
-    //The Openshift Version for this Role
-    @json(name = "roleVersion")
-    RoleVersion String
+	//The Openshift Version for this Role
+	@json(name = "roleVersion")
+	RoleVersion String
 
-    //Does this Role have Managed Policies?
-    @json(name = "managedPolicies")
-    ManagedPolicies Boolean
+	//Does this Role have Managed Policies?
+	@json(name = "managedPolicies")
+	ManagedPolicies Boolean
 
-    //Does this Role have HCP Managed Policies?
-    @json(name = "hcpManagedPolicies")
-    HcpManagedPolicies Boolean
+	//Does this Role have HCP Managed Policies?
+	@json(name = "hcpManagedPolicies")
+	HcpManagedPolicies Boolean
 }

--- a/model/clusters_mgmt/v1/aws_subnetwork_type.model
+++ b/model/clusters_mgmt/v1/aws_subnetwork_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/aws_type.model
+++ b/model/clusters_mgmt/v1/aws_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,7 +80,7 @@ struct AWS {
 	// Additional allowed principal ARNs to be added to the hosted control plane's VPC Endpoint Service.
 	AdditionalAllowedPrincipals []String
 
-    // AWS specific configuration for AutoNode
+	// AWS specific configuration for AutoNode
 	AutoNode AwsAutoNode
 
 	// Zero egress configuration.

--- a/model/clusters_mgmt/v1/aws_validate_credentials_resource.model
+++ b/model/clusters_mgmt/v1/aws_validate_credentials_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages aws creds validation
 resource AwsValidateCredentials {
-    // Manages aws creds validation.
-    method Post {
-        // Cloud provider data needed for the inquiry.
-        in out Body CloudProviderData
-    }
+	// Manages aws creds validation.
+	method Post {
+		// Cloud provider data needed for the inquiry.
+		in out Body CloudProviderData
+	}
 }

--- a/model/clusters_mgmt/v1/aws_volume_type.model
+++ b/model/clusters_mgmt/v1/aws_volume_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_etcd_data_encryption_customer_managed_type.model
+++ b/model/clusters_mgmt/v1/azure_etcd_data_encryption_customer_managed_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_etcd_data_encryption_type.model
+++ b/model/clusters_mgmt/v1/azure_etcd_data_encryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_etcd_encryption_type.model
+++ b/model/clusters_mgmt/v1/azure_etcd_encryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_kms_encryption_type.model
+++ b/model/clusters_mgmt/v1/azure_kms_encryption_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_kms_key_type.model
+++ b/model/clusters_mgmt/v1/azure_kms_key_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_node_pool_encryption_at_host_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_encryption_at_host_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_node_pool_os_disk_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_os_disk_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,39 +16,39 @@ limitations under the License.
 
 // Defines the configuration of a Node Pool's OS disk.
 struct AzureNodePoolOsDisk {
-    // The size in GiB to assign to the OS disks of the
-    // Nodes in the Node Pool. The property
-    // is the number of bytes x 1024^3.
-    // If not specified, OS disk size is 64 GiB.
-    SizeGibibytes Integer
+	// The size in GiB to assign to the OS disks of the
+	// Nodes in the Node Pool. The property
+	// is the number of bytes x 1024^3.
+	// If not specified, OS disk size is 64 GiB.
+	SizeGibibytes Integer
 
-    // The disk storage account type to use for the OS disks of the Nodes in the
-    // Node Pool. Valid values are:
-    // * Standard_LRS: HDD
-    // * StandardSSD_LRS: Standard SSD
-    // * Premium_LRS: Premium SDD
-    // * UltraSSD_LRS: Ultra SDD
-    //
-    // If not specified, `Premium_LRS` is used.
-    StorageAccountType String
+	// The disk storage account type to use for the OS disks of the Nodes in the
+	// Node Pool. Valid values are:
+	// * Standard_LRS: HDD
+	// * StandardSSD_LRS: Standard SSD
+	// * Premium_LRS: Premium SDD
+	// * UltraSSD_LRS: Ultra SDD
+	//
+	// If not specified, `Premium_LRS` is used.
+	StorageAccountType String
 
-    // Specifies the OS Disk persistence for the OS Disks of the Nodes in the Node Pool.
-    // Valid values are:
-    // * persistent
-    // * ephemeral
-    // If not specified, Persistent OS Disks are used.
-    Persistence String
+	// Specifies the OS Disk persistence for the OS Disks of the Nodes in the Node Pool.
+	// Valid values are:
+	// * persistent
+	// * ephemeral
+	// If not specified, Persistent OS Disks are used.
+	Persistence String
 
-    // The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
-    // When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
-    // is performed using the provided Disk Encryption Set.
-    // It must be located in the same Azure location as the parent Cluster.  
-    // It must be located in the same Azure Subscription as the parent Cluster.
-    // The Azure Resource Group Name specified as part of it must be a different resource group name
-    // than the one specified in the parent Cluster's `managed_resource_group_name`.
-    // The Azure Resource Group Name specified as part of it can be the same, or a different one
-    // than the one specified in the parent Cluster's `resource_group_name`.
-    // If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool 
-    // is performed with platform managed keys.
-    SseEncryptionSetResourceId String
+	// The Azure Resource ID of a pre-existing Azure Disk Encryption Set (DES).
+	// When provided, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool
+	// is performed using the provided Disk Encryption Set.
+	// It must be located in the same Azure location as the parent Cluster.  
+	// It must be located in the same Azure Subscription as the parent Cluster.
+	// The Azure Resource Group Name specified as part of it must be a different resource group name
+	// than the one specified in the parent Cluster's `managed_resource_group_name`.
+	// The Azure Resource Group Name specified as part of it can be the same, or a different one
+	// than the one specified in the parent Cluster's `resource_group_name`.
+	// If not specified, Server-Side Encryption (SSE) on the OS Disks of the Nodes of the Node Pool 
+	// is performed with platform managed keys.
+	SseEncryptionSetResourceId String
 }

--- a/model/clusters_mgmt/v1/azure_node_pool_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,33 +16,33 @@ limitations under the License.
 
 // Representation of azure node pool specific parameters.
 struct AzureNodePool {
-    // ResourceName is the Azure Resource Name of the NodePool.
-    // ResourceName must be within the Azure Resource Group Name of the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Location as the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Subscription as the parent
-    // Cluster it belongs to.
-    // ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
-    // Cluster it belongs to.
-    // Required during creation.
-    // Immutable.
-    ResourceName String
+	// ResourceName is the Azure Resource Name of the NodePool.
+	// ResourceName must be within the Azure Resource Group Name of the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Location as the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Subscription as the parent
+	// Cluster it belongs to.
+	// ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
+	// Cluster it belongs to.
+	// Required during creation.
+	// Immutable.
+	ResourceName String
 
-    // The Azure Virtual Machine size identifier used for the
-    // Nodes of the Node Pool.
-    // Availability of VM sizes are dependent on the Azure Location
-    // of the parent Cluster.
-    // Required during creation.
-    VMSize String
+	// The Azure Virtual Machine size identifier used for the
+	// Nodes of the Node Pool.
+	// Availability of VM sizes are dependent on the Azure Location
+	// of the parent Cluster.
+	// Required during creation.
+	VMSize String
 
-    // EncryptionAtHost contains Encryption At Host disk encryption configuration.
-    // When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
-    // and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
-    // If not specified, Encryption at Host is not enabled.
-    // Immutable.
-    EncryptionAtHost AzureNodePoolEncryptionAtHost
+	// EncryptionAtHost contains Encryption At Host disk encryption configuration.
+	// When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
+	// and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
+	// If not specified, Encryption at Host is not enabled.
+	// Immutable.
+	EncryptionAtHost AzureNodePoolEncryptionAtHost
 
-    // The configuration for the OS disk used by the nodes in the Node Pool.
-    OsDisk AzureNodePoolOsDisk
+	// The configuration for the OS disk used by the nodes in the Node Pool.
+	OsDisk AzureNodePoolOsDisk
 }

--- a/model/clusters_mgmt/v1/azure_nodes_outbound_connectivity_types.model
+++ b/model/clusters_mgmt/v1/azure_nodes_outbound_connectivity_types.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_operators_authentication_types.model
+++ b/model/clusters_mgmt/v1/azure_operators_authentication_types.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/azure_type.model
+++ b/model/clusters_mgmt/v1/azure_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/backup_type.model
+++ b/model/clusters_mgmt/v1/backup_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/billing_model_item_type.model
+++ b/model/clusters_mgmt/v1/billing_model_item_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/billing_model_type.model
+++ b/model/clusters_mgmt/v1/billing_model_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,19 +22,19 @@ enum BillingModel {
 	// BillingModel Marketplace Legacy Marketplace billing model. Currently only used for tests. Use cloud-provider specific billing models instead.
 	Marketplace
 
-    // AWS Marketplace billing model.
-    @json(name = "marketplace-aws")
-    MarketplaceAWS
+	// AWS Marketplace billing model.
+	@json(name = "marketplace-aws")
+	MarketplaceAWS
 
-    // Azure Marketplace billing model.
-    @json(name = "marketplace-azure")
-    MarketplaceAzure
+	// Azure Marketplace billing model.
+	@json(name = "marketplace-azure")
+	MarketplaceAzure
 
-    // RH Marketplace billing model.
-    @json(name = "marketplace-rhm")
-    MarketplaceRHM
+	// RH Marketplace billing model.
+	@json(name = "marketplace-rhm")
+	MarketplaceRHM
 
-    // GCP Marketplace billing model.
-    @json(name = "marketplace-gcp")
-    MarketplaceGCP
+	// GCP Marketplace billing model.
+	@json(name = "marketplace-gcp")
+	MarketplaceGCP
 }

--- a/model/clusters_mgmt/v1/break_glass_credential_resource.model
+++ b/model/clusters_mgmt/v1/break_glass_credential_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/break_glass_credential_type.model
+++ b/model/clusters_mgmt/v1/break_glass_credential_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/break_glass_credentials_resource.model
+++ b/model/clusters_mgmt/v1/break_glass_credentials_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/byo_oidc_type.model
+++ b/model/clusters_mgmt/v1/byo_oidc_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/capacity_reservation_preference_type.model
+++ b/model/clusters_mgmt/v1/capacity_reservation_preference_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Market type for AWS Capacity Reservations.
 enum CapacityReservationPreference {
-    // EC2 instances may not make use of any capacity reservations
-    None
+	// EC2 instances may not make use of any capacity reservations
+	None
 
 	// EC2 instances may make use of Open capacity reservations, else run on demand
 	Open

--- a/model/clusters_mgmt/v1/ccs_type.model
+++ b/model/clusters_mgmt/v1/ccs_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,10 +15,10 @@ limitations under the License.
 */
 
 class CCS {
-    // Indicates if Customer Cloud Subscription is enabled on the cluster.
-    Enabled Boolean
+	// Indicates if Customer Cloud Subscription is enabled on the cluster.
+	Enabled Boolean
 
-    // Indicates if cloud permissions checks are disabled,
-    // when attempting installation of the cluster.
-    DisableSCPChecks Boolean
+	// Indicates if cloud permissions checks are disabled,
+	// when attempting installation of the cluster.
+	DisableSCPChecks Boolean
 }

--- a/model/clusters_mgmt/v1/cloud_available_regions_resource.model
+++ b/model/clusters_mgmt/v1/cloud_available_regions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cloud_provider_resource.model
+++ b/model/clusters_mgmt/v1/cloud_provider_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cloud_provider_type.model
+++ b/model/clusters_mgmt/v1/cloud_provider_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cloud_providers_resource.model
+++ b/model/clusters_mgmt/v1/cloud_providers_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cloud_region_resource.model
+++ b/model/clusters_mgmt/v1/cloud_region_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cloud_region_type.model
+++ b/model/clusters_mgmt/v1/cloud_region_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cloud_regions_resource.model
+++ b/model/clusters_mgmt/v1/cloud_regions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_api_type.model
+++ b/model/clusters_mgmt/v1/cluster_api_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_arch_type.model
+++ b/model/clusters_mgmt/v1/cluster_arch_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Possible cluster architectures.
 enum ClusterArchitecture {
-    @json(name = "classic")
-    Classic
+	@json(name = "classic")
+	Classic
 
-    @json(name = "hcp")
-    Hcp
+	@json(name = "hcp")
+	Hcp
 }

--- a/model/clusters_mgmt/v1/cluster_autonode_type.model
+++ b/model/clusters_mgmt/v1/cluster_autonode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // The AutoNode configuration for the Cluster.
 struct ClusterAutoNode {
-    // Mode indicates the current state of AutoNode on this cluster.
-    // Valid values: "enabled", "disabled".
-    Mode String
-    Status ClusterAutoNodeStatus
+	// Mode indicates the current state of AutoNode on this cluster.
+	// Valid values: "enabled", "disabled".
+	Mode String
+	Status ClusterAutoNodeStatus
 }
 
 // Additional status information on the AutoNode configuration on this Cluster
 struct ClusterAutoNodeStatus {
-    // Messages relating to the status of the AutoNode installation on this Cluster
-    Message String
-    // The number of Nodes AutoNode has provisioned in the cluster
-    NodeCount Integer
+	// Messages relating to the status of the AutoNode installation on this Cluster
+	Message String
+	// The number of Nodes AutoNode has provisioned in the cluster
+	NodeCount Integer
 }

--- a/model/clusters_mgmt/v1/cluster_autoscaler_type.model
+++ b/model/clusters_mgmt/v1/cluster_autoscaler_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_configuration_mode_type.model
+++ b/model/clusters_mgmt/v1/cluster_configuration_mode_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Configuration mode of a cluster.
 enum ClusterConfigurationMode {
-    // Full configuration (default).
-    Full
+	// Full configuration (default).
+	Full
 
-    // Only read configuration operations are supported.
-    // The cluster can't be deleted, reshaped, configure IDPs, add/remove users, etc.
-    ReadOnly
+	// Only read configuration operations are supported.
+	// The cluster can't be deleted, reshaped, configure IDPs, add/remove users, etc.
+	ReadOnly
 }

--- a/model/clusters_mgmt/v1/cluster_console_type.model
+++ b/model/clusters_mgmt/v1/cluster_console_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_credentials_type.model
+++ b/model/clusters_mgmt/v1/cluster_credentials_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_deployment_type.model
+++ b/model/clusters_mgmt/v1/cluster_deployment_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_health_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_health_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // ClusterHealthState indicates the health of a cluster.
 enum ClusterHealthState {
-  // Cluster is Ready and healthy.
-  Healthy
+	// Cluster is Ready and healthy.
+	Healthy
 
-  // Cluster is Ready and unhealthy.
-  Unhealthy
+	// Cluster is Ready and unhealthy.
+	Unhealthy
 
-  // Cluster health is unknown.
-  Unknown
+	// Cluster health is unknown.
+	Unknown
 }

--- a/model/clusters_mgmt/v1/cluster_image_registry_type.model
+++ b/model/clusters_mgmt/v1/cluster_image_registry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // ClusterImageRegistry represents the configuration for the cluster's internal image registry.
 struct ClusterImageRegistry {
-    // State indicates whether the image registry is enabled.
-    // Unless explicitly set, the image registry is enabled by default.
-    // This setting is immutable and cannot be changed after the cluster is created.
-    // Valid values: "enabled", "disabled".
-    State String
+	// State indicates whether the image registry is enabled.
+	// Unless explicitly set, the image registry is enabled by default.
+	// This setting is immutable and cannot be changed after the cluster is created.
+	// Valid values: "enabled", "disabled".
+	State String
 }

--- a/model/clusters_mgmt/v1/cluster_link_type.model
+++ b/model/clusters_mgmt/v1/cluster_link_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_migration_resource.model
+++ b/model/clusters_mgmt/v1/cluster_migration_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Manages a specific cluster migration.
 resource ClusterMigration {
-    // Retrieves the details of the cluster migration.
-    method Get {
-        out Body ClusterMigration
-    }
+	// Retrieves the details of the cluster migration.
+	method Get {
+		out Body ClusterMigration
+	}
 }

--- a/model/clusters_mgmt/v1/cluster_migration_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_migration_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Representation of a cluster migration state.
 struct ClusterMigrationState {
-    // The current state of the cluster migration.
-    Value ClusterMigrationStateValue
+	// The current state of the cluster migration.
+	Value ClusterMigrationStateValue
 
-    // A longer description of the current state of the cluster migration.
-    Description string
+	// A longer description of the current state of the cluster migration.
+	Description string
 }
 
 //  The state of the cluster migration.
 enum ClusterMigrationStateValue {
-    @json(name = "scheduled")
-    Scheduled
+	@json(name = "scheduled")
+	Scheduled
 
-    @json(name = "in progress")
-    InProgress
+	@json(name = "in progress")
+	InProgress
 
-    @json(name = "completed")
-    Completed
+	@json(name = "completed")
+	Completed
 }

--- a/model/clusters_mgmt/v1/cluster_migration_type.model
+++ b/model/clusters_mgmt/v1/cluster_migration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Representation of a cluster migration.
 class ClusterMigration {
-    // Internal cluster ID.
-    ClusterID string
+	// Internal cluster ID.
+	ClusterID string
 
-    // Type of cluster migration. The rest of the attributes will be populated according to this
-    // value. For example, if the type is `sdnToOvn` then only the `SdnToOvn` attribute will be
-    // populated.
-    Type ClusterMigrationType
+	// Type of cluster migration. The rest of the attributes will be populated according to this
+	// value. For example, if the type is `sdnToOvn` then only the `SdnToOvn` attribute will be
+	// populated.
+	Type ClusterMigrationType
 
-    // The state of the cluster migration.
-    State ClusterMigrationState
+	// The state of the cluster migration.
+	State ClusterMigrationState
 
-    // Details for `SdnToOvn` cluster migrations.
-    SdnToOvn SdnToOvnClusterMigration
+	// Details for `SdnToOvn` cluster migrations.
+	SdnToOvn SdnToOvnClusterMigration
 
-    // Date and time when the cluster migration was initially created, using the
-    // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
-    CreationTimestamp Date
+	// Date and time when the cluster migration was initially created, using the
+	// format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
+	CreationTimestamp Date
 
-    // Date and time when the cluster migration was last updated, using the
-    // format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
-    UpdatedTimestamp Date
+	// Date and time when the cluster migration was last updated, using the
+	// format defined in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt).
+	UpdatedTimestamp Date
 }

--- a/model/clusters_mgmt/v1/cluster_migration_type_type.model
+++ b/model/clusters_mgmt/v1/cluster_migration_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Type of cluster migration.
 enum ClusterMigrationType {
-    @json(name = "sdnToOvn")
-    SdnToOvn
+	@json(name = "sdnToOvn")
+	SdnToOvn
 }

--- a/model/clusters_mgmt/v1/cluster_migrations_resource.model
+++ b/model/clusters_mgmt/v1/cluster_migrations_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,31 +16,31 @@ limitations under the License.
 
 // Manages the collection of cluster migrations of a cluster.
 resource ClusterMigrations {
-    method List {
-        // Index of the returned page, where one corresponds to the first page.
-        in out Page Integer = 1
+	method List {
+		// Index of the returned page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page. As this collection doesn't support paging or
-        // searching the result will always be the total number of migrations of the cluster.
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page. As this collection doesn't support paging or
+		// searching the result will always be the total number of migrations of the cluster.
+		out Total Integer
 
-        // Retrieved list of cluster migrations.
-        out Items []ClusterMigration
-    }
+		// Retrieved list of cluster migrations.
+		out Items []ClusterMigration
+	}
 
 	// Adds a cluster migration to the database.
 	method Add {
-	    // Description of the cluster migration.
+		// Description of the cluster migration.
 		in out Body ClusterMigration
 	}
 
-    // Returns a reference to the service that manages a specific cluster migration.
-    locator Migration {
-        target ClusterMigration
-        variable ID
-    }
+	// Returns a reference to the service that manages a specific cluster migration.
+	locator Migration {
+		target ClusterMigration
+		variable ID
+	}
 }

--- a/model/clusters_mgmt/v1/cluster_nodes_root_volume_type.model
+++ b/model/clusters_mgmt/v1/cluster_nodes_root_volume_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_nodes_type.model
+++ b/model/clusters_mgmt/v1/cluster_nodes_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_operator_info_type.model
+++ b/model/clusters_mgmt/v1/cluster_operator_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_operators_info_type.model
+++ b/model/clusters_mgmt/v1/cluster_operators_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_operators_metric_query_resource.model
+++ b/model/clusters_mgmt/v1/cluster_operators_metric_query_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_operators_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_operators_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_registration_type.model
+++ b/model/clusters_mgmt/v1/cluster_registration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_registry_config_type.model
+++ b/model/clusters_mgmt/v1/cluster_registry_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_resource.model
+++ b/model/clusters_mgmt/v1/cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -64,10 +64,10 @@ resource Cluster {
 		target IdentityProviders
 	}
 
-    // Reference to the resource that manages the external authentication configuration.
-    locator ExternalAuthConfig {
-        target ExternalAuthConfig
-    }
+	// Reference to the resource that manages the external authentication configuration.
+	locator ExternalAuthConfig {
+		target ExternalAuthConfig
+	}
 
 	// Reference to the resource that manages the external configuration.
 	locator ExternalConfiguration {
@@ -75,9 +75,9 @@ resource Cluster {
 	}
 
 	// Reference to the resource that manages the break glass credentials.
-    locator BreakGlassCredentials {
-        target BreakGlassCredentials
-    }
+	locator BreakGlassCredentials {
+		target BreakGlassCredentials
+	}
 
 	// Reference to the resource that manages the cluster's provision shard.
 	locator ProvisionShard {
@@ -94,26 +94,26 @@ resource Cluster {
 		target InflightChecks
 	}
 
-    // Reference to the resource that manages the collection of machine pool resources.
+	// Reference to the resource that manages the collection of machine pool resources.
 	locator MachinePools {
 		target MachinePools
 	}
 
-    // Reference to the resource that manages the collection of node pool resources.
-    locator NodePools {
-        target NodePools
-    }
+	// Reference to the resource that manages the collection of node pool resources.
+	locator NodePools {
+		target NodePools
+	}
 
 	// Initiates cluster hibernation. While hibernating a cluster will not consume any cloud provider infrastructure
 	// but will be counted for quota.
-    method Hibernate {
+	method Hibernate {
 
-    }
+	}
 
-    // Resumes from Hibernation.
-    method Resume {
+	// Resumes from Hibernation.
+	method Resume {
 
-    }
+	}
 
 	// Reference to the resource that manages metrics queries for the cluster.
 	locator MetricQueries {
@@ -127,7 +127,7 @@ resource Cluster {
 
 	// Reference to the resource that manages the collection of the add-on inquiries on this cluster.
 	locator AddonInquiries {
-	    target AddonInquiries
+		target AddonInquiries
 	}
 
 	// Reference to the resource that manages the collection of AWS infrastructure
@@ -148,7 +148,7 @@ resource Cluster {
 
 	// Reference to the resource that manages the collection of addon upgrade policies defined for this cluster.
 	locator AddonUpgradePolicies {
-	    target AddonUpgradePolicies
+		target AddonUpgradePolicies
 	}
 
 	// Reference to the resource that manages the cluster deployment.
@@ -158,17 +158,17 @@ resource Cluster {
 
 	// Reference to cluster resources.
 	locator Resources {
-	    target Resources
+		target Resources
 	}
 
 	// Reference to cluster limited support reasons.
 	locator LimitedSupportReasons {
-	    target LimitedSupportReasons
+		target LimitedSupportReasons
 	}
 
 	// Reference to cluster's agreed version gate.
 	locator GateAgreements {
-	    target VersionGateAgreements
+		target VersionGateAgreements
 	}
 
 	locator STSOperatorRoles {
@@ -189,7 +189,7 @@ resource Cluster {
 	}
 
 	locator KubeletConfigs {
-	    target KubeletConfigs
+		target KubeletConfigs
 	}
 
 	locator DeleteProtection {
@@ -211,11 +211,11 @@ resource Cluster {
 	}
 
 	locator KubeletConfig {
-	    target KubeletConfig
+		target KubeletConfig
 	}
 
 	locator Migrations {
-	    target ClusterMigrations
+		target ClusterMigrations
 	}
 
 	// Reference to the resource that manages image mirror configurations for the cluster.

--- a/model/clusters_mgmt/v1/cluster_state_type.model
+++ b/model/clusters_mgmt/v1/cluster_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_status_resource.model
+++ b/model/clusters_mgmt/v1/cluster_status_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cluster_status_type.model
+++ b/model/clusters_mgmt/v1/cluster_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,6 +40,6 @@ class ClusterStatus {
 	// Limited Support Reason Count
 	LimitedSupportReasonCount Integer
 
-    // Current Replicas available for a Hosted Cluster
-    CurrentCompute Integer
+	// Current Replicas available for a Hosted Cluster
+	CurrentCompute Integer
 }

--- a/model/clusters_mgmt/v1/cluster_type.model
+++ b/model/clusters_mgmt/v1/cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -179,9 +179,9 @@ class Cluster {
 	// List of machine pools on this cluster.
 	link MachinePools []MachinePool
 
-    // List of node pools on this cluster.
-    // NodePool is a scalable set of worker nodes attached to a hosted cluster.
-    link NodePools []NodePool
+	// List of node pools on this cluster.
+	// NodePool is a scalable set of worker nodes attached to a hosted cluster.
+	link NodePools []NodePool
 
 	// List of ingresses on this cluster.
 	link Ingresses []Ingress
@@ -234,8 +234,8 @@ class Cluster {
 	// This field is deprecated for ROSA Hosted Control Plane clusters and will be removed
 	DisableUserWorkloadMonitoring Boolean
 
-    // Contains information about Managed Service
-    ManagedService ManagedService
+	// Contains information about Managed Service
+	ManagedService ManagedService
 
 	// Hypershift configuration.
 	Hypershift Hypershift

--- a/model/clusters_mgmt/v1/cluster_vpc_resource.model
+++ b/model/clusters_mgmt/v1/cluster_vpc_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/clusterdeployment_resource.model
+++ b/model/clusters_mgmt/v1/clusterdeployment_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/clusters_resource.model
+++ b/model/clusters_mgmt/v1/clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/component_route_kind_type.model
+++ b/model/clusters_mgmt/v1/component_route_kind_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/component_route_type.model
+++ b/model/clusters_mgmt/v1/component_route_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/control_plane_resource.model
+++ b/model/clusters_mgmt/v1/control_plane_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,14 +26,14 @@ resource ControlPlane {
 		target LogForwarders
 	}
 
-    // Retrieves the details of the control plane
-    method Get {
-        out Body ControlPlane
-    }
+	// Retrieves the details of the control plane
+	method Get {
+		out Body ControlPlane
+	}
 
-    // Updates the control plane
-    method Update {
-        in out Body ControlPlane
-    }
+	// Updates the control plane
+	method Update {
+		in out Body ControlPlane
+	}
 
 }

--- a/model/clusters_mgmt/v1/control_plane_type.model
+++ b/model/clusters_mgmt/v1/control_plane_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/control_plane_upgrade_policies_resource.model
+++ b/model/clusters_mgmt/v1/control_plane_upgrade_policies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/control_plane_upgrade_policy_resource.model
+++ b/model/clusters_mgmt/v1/control_plane_upgrade_policy_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/control_plane_upgrade_policy_type.model
+++ b/model/clusters_mgmt/v1/control_plane_upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cpu_total_by_node_roles_os_metric_query_resource.model
+++ b/model/clusters_mgmt/v1/cpu_total_by_node_roles_os_metric_query_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cpu_total_node_role_os_metric_node_type.model
+++ b/model/clusters_mgmt/v1/cpu_total_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/cpu_totals_node_role_os_metric_node_type.model
+++ b/model/clusters_mgmt/v1/cpu_totals_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/credential_request_type.model
+++ b/model/clusters_mgmt/v1/credential_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/credentials_resource.model
+++ b/model/clusters_mgmt/v1/credentials_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/delete_protection_resource.model
+++ b/model/clusters_mgmt/v1/delete_protection_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Manages delete protection specific parts for a specific cluster.
 resource DeleteProtection {
-    method Get {
-        out Body DeleteProtection
-    }
-    method Update {
-	    in out Body DeleteProtection
-    }
+	method Get {
+		out Body DeleteProtection
+	}
+	method Update {
+		in out Body DeleteProtection
+	}
 }

--- a/model/clusters_mgmt/v1/delete_protection_type.model
+++ b/model/clusters_mgmt/v1/delete_protection_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/deleted_cluster_resource.model
+++ b/model/clusters_mgmt/v1/deleted_cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,8 +17,8 @@ limitations under the License.
 // Manages a specific deleted cluster.
 resource DeletedCluster {
 
-    // Retrieves a specific deleted cluster
-    method Get {
-        out Body DeletedCluster
-    }
+	// Retrieves a specific deleted cluster
+	method Get {
+		out Body DeletedCluster
+	}
 }

--- a/model/clusters_mgmt/v1/deleted_cluster_type.model
+++ b/model/clusters_mgmt/v1/deleted_cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,9 @@ limitations under the License.
 // Representation of a deleted cluster with its deleted_timestamp and the entire cluster details
 class DeletedCluster {
 
-    // Reference to the deleted cluster
-    Cluster Cluster
+	// Reference to the deleted cluster
+	Cluster Cluster
 
-    // Date and time the cluster was effectively deleted
-    DeletedTimestamp Date
+	// Date and time the cluster was effectively deleted
+	DeletedTimestamp Date
 }

--- a/model/clusters_mgmt/v1/deleted_clusters_resource.model
+++ b/model/clusters_mgmt/v1/deleted_clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,31 +17,31 @@ limitations under the License.
 // Manages a specific deleted cluster.
 resource DeletedClusters {
 
-    // Retrieves a list of deleted clusters
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	// Retrieves a list of deleted clusters
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Maximum number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // Search criteria.
-        in Search String
+		// Search criteria.
+		in Search String
 
-        // Order criteria.
-        in Order String
+		// Order criteria.
+		in Order String
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page.
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
 
-        // Retrieved list of clusters.
-        out Items []DeletedCluster
-    }
+		// Retrieved list of clusters.
+		out Items []DeletedCluster
+	}
 
-    // Returns a reference to the service that manages an specific deleted cluster.
-    locator DeletedCluster {
-        target DeletedCluster
-        variable ID
-    }
+	// Returns a reference to the service that manages an specific deleted cluster.
+	locator DeletedCluster {
+		target DeletedCluster
+		variable ID
+	}
 }

--- a/model/clusters_mgmt/v1/dns_cloud_provider_type.model
+++ b/model/clusters_mgmt/v1/dns_cloud_provider_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 enum DnsCloudProvider {
-    @json(name = "aws")
-    aws
+	@json(name = "aws")
+	aws
 
-    @json(name = "gcp")
-    gcp
+	@json(name = "gcp")
+	gcp
 }

--- a/model/clusters_mgmt/v1/dns_domain_resource.model
+++ b/model/clusters_mgmt/v1/dns_domain_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/dns_domain_type.model
+++ b/model/clusters_mgmt/v1/dns_domain_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,24 +16,24 @@ limitations under the License.
 
 // Contains the properties of a DNS domain.
 class DNSDomain {
-    // Link to the organization that reserved the DNS domain.
-    link Organization OrganizationLink
+	// Link to the organization that reserved the DNS domain.
+	link Organization OrganizationLink
 
-    // Link to the cluster that is registered with the DNS domain (optional).
-    link Cluster ClusterLink
+	// Link to the cluster that is registered with the DNS domain (optional).
+	link Cluster ClusterLink
 
-    // Date and time when the DNS domain was reserved.
-    ReservedAtTimestamp Date
+	// Date and time when the DNS domain was reserved.
+	ReservedAtTimestamp Date
 
-    // Indicates if this dns domain is user defined.
-    UserDefined Boolean
+	// Indicates if this dns domain is user defined.
+	UserDefined Boolean
 
-    // Signals which cluster architecture the domain is ready for.
-    ClusterArch ClusterArchitecture
+	// Signals which cluster architecture the domain is ready for.
+	ClusterArch ClusterArchitecture
 
-    // Signals which cloud provider the domain is ready for.
-    CloudProvider DnsCloudProvider
-    
-    // Gcp contains Google Cloud Platform-specific DNS domain configuration.
-	  Gcp GcpDnsDomain
+	// Signals which cloud provider the domain is ready for.
+	CloudProvider DnsCloudProvider
+	
+	// Gcp contains Google Cloud Platform-specific DNS domain configuration.
+		Gcp GcpDnsDomain
 }

--- a/model/clusters_mgmt/v1/dns_domains_resource.model
+++ b/model/clusters_mgmt/v1/dns_domains_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/dns_type.model
+++ b/model/clusters_mgmt/v1/dns_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/encryption_key_inquiry_type.model
+++ b/model/clusters_mgmt/v1/encryption_key_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/encryption_keys_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/encryption_keys_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ resource EncryptionKeysInquiry {
 		out Total Integer
 
 		// Retrieved list of encryption keys.
-   		out Items []EncryptionKey
+			out Items []EncryptionKey
 
 		// Cloud provider data needed for the inquiry
 		in Body CloudProviderData

--- a/model/clusters_mgmt/v1/environment_resource.model
+++ b/model/clusters_mgmt/v1/environment_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,12 +22,12 @@ resource Environment {
 	}
 
 	// Updates the environment.
-    //
-    // Attributes that can be updated are:
-    //
-    // - `last_upgrade_available_check`
-    // - `last_limited_support_check`
-    method Update {
-    	in out Body Environment
-    }
+	//
+	// Attributes that can be updated are:
+	//
+	// - `last_upgrade_available_check`
+	// - `last_limited_support_check`
+	method Update {
+		in out Body Environment
+	}
 }

--- a/model/clusters_mgmt/v1/environment_type.model
+++ b/model/clusters_mgmt/v1/environment_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/errors.model
+++ b/model/clusters_mgmt/v1/errors.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/event_type.model
+++ b/model/clusters_mgmt/v1/event_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/events_resource.model
+++ b/model/clusters_mgmt/v1/events_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/external_auth_config_resource.model
+++ b/model/clusters_mgmt/v1/external_auth_config_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Manages the external authentication configuration for a ROSA HCP cluster.
 resource ExternalAuthConfig {
-   method Get {
-        out Body ExternalAuthConfig
-   }
+	method Get {
+		out Body ExternalAuthConfig
+	}
 
-    // Reference to the resource that manages the collection of ExternalAuths resources.
-    locator ExternalAuths {
-        target ExternalAuths
-    }
+	// Reference to the resource that manages the collection of ExternalAuths resources.
+	locator ExternalAuths {
+		target ExternalAuths
+	}
 }

--- a/model/clusters_mgmt/v1/external_auth_config_type.model
+++ b/model/clusters_mgmt/v1/external_auth_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,36 +16,36 @@ limitations under the License.
 
 // Represents an external authentication configuration
 class ExternalAuthConfig {
-    // Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
-    //
-    // By default this is false.
-    //
-    // To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
-    // to have the `external-authentication` feature toggle enabled.
-    //
-    // For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
-    Enabled Boolean
+	// Boolean flag indicating if the cluster should use an external authentication configuration for ROSA HCP clusters.
+	//
+	// By default this is false.
+	//
+	// To enable it the cluster needs to be ROSA HCP cluster and the organization of the user needs
+	// to have the `external-authentication` feature toggle enabled.
+	//
+	// For ARO HCP clusters, use the "State" property to enable/disable this feature instead.
+	Enabled Boolean
 
-    // Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
-    // 
-    // For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
-    // 
-    // FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
-    State ExternalAuthConfigState
+	// Controls whether the cluster uses an external authentication configuration for ARO HCP clusters.
+	// 
+	// For ARO HCP clusters, this will be "enabled" by default and cannot be set to "disabled".
+	// 
+	// FOR ROSA HCP clusters, use the "Enabled" boolean flag to enable/disable this feature instead.
+	State ExternalAuthConfigState
 
-    // A list of external authentication providers configured for the cluster.
-    // 
-    // Only one external authentication provider can be configured.
-    link ExternalAuths []ExternalAuth
+	// A list of external authentication providers configured for the cluster.
+	// 
+	// Only one external authentication provider can be configured.
+	link ExternalAuths []ExternalAuth
 }
 
 // Representation of the possible values for the state field of an external authentication configuration
 enum ExternalAuthConfigState {
-    // Indicates that the cluster supports configuration of external authentication providers
-    @json(name="enabled")
-    Enabled
+	// Indicates that the cluster supports configuration of external authentication providers
+	@json(name="enabled")
+	Enabled
 
-    // Indicates that the cluster does not support configuration of external authentication providers
-    @json(name="disabled")
-    Disabled
+	// Indicates that the cluster does not support configuration of external authentication providers
+	@json(name="disabled")
+	Disabled
 }

--- a/model/clusters_mgmt/v1/external_auth_resource.model
+++ b/model/clusters_mgmt/v1/external_auth_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Manages a specific external authentication.
 resource ExternalAuth {
-    // Retrieves the details of an external authentication.
-    method Get {
-        out Body ExternalAuth
-    }
+	// Retrieves the details of an external authentication.
+	method Get {
+		out Body ExternalAuth
+	}
 
-    // Updates the external authentication.
-    method Update {
-        in out Body ExternalAuth
-    }
+	// Updates the external authentication.
+	method Update {
+		in out Body ExternalAuth
+	}
 
-    // Deletes the external authentication.
-    method Delete {
-    }
+	// Deletes the external authentication.
+	method Delete {
+	}
 }

--- a/model/clusters_mgmt/v1/external_auth_status_type.model
+++ b/model/clusters_mgmt/v1/external_auth_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,19 @@ limitations under the License.
 
 // Representation of the status of an external authentication provider.
 struct ExternalAuthStatus {
-    // The current state of the external authentication provider.
-    State ExternalAuthState
+	// The current state of the external authentication provider.
+	State ExternalAuthState
 
-    // A descriptive message providing additional context about the current 
-    // state of the external authentication provider.
-    Message String
+	// A descriptive message providing additional context about the current 
+	// state of the external authentication provider.
+	Message String
 }
 
 // Representation of the state of an external authentication provider.
 struct ExternalAuthState {
-    // A string value representing the external authentication provider's current state.
-    Value String
+	// A string value representing the external authentication provider's current state.
+	Value String
 
-    // The date and time when the external authentication provider state was last updated.
-    LastUpdatedTimestamp Date
+	// The date and time when the external authentication provider state was last updated.
+	LastUpdatedTimestamp Date
 }

--- a/model/clusters_mgmt/v1/external_auth_type.model
+++ b/model/clusters_mgmt/v1/external_auth_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,7 +44,7 @@ struct TokenIssuer {
 	// "aud" claim.
 	// Must have at least one audience and a maximum of ten.
 	// Any clients defined for this external authentication must have their id included here.
-  Audiences []String
+	Audiences []String
 
 	// Certificate bundle to use to validate server certificates for the configured URL.
 	CA String
@@ -110,7 +110,7 @@ struct TokenClaimMappings {
 	UserName UsernameClaim
 
 	// Groups is a name of the claim that should be used to construct groups for the cluster identity.
-  Groups GroupsClaim
+	Groups GroupsClaim
 }
 
 // The username claim mapping.

--- a/model/clusters_mgmt/v1/external_auths_resource.model
+++ b/model/clusters_mgmt/v1/external_auths_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Manages the collection of external authentication defined for a ROSA HCP cluster.
 resource ExternalAuths {
-    method List {
+	method List {
 		// Index of the requested page, where one corresponds to the first page.
 		in out Page Integer = 1
 
@@ -28,7 +28,7 @@ resource ExternalAuths {
 
 		// Retrieved list of external authentications.
 		out Items []ExternalAuth
-    }
+	}
 
 	// Adds a new authentication to the cluster.
 	method Add {

--- a/model/clusters_mgmt/v1/external_configuration_resource.model
+++ b/model/clusters_mgmt/v1/external_configuration_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,8 +21,8 @@ resource ExternalConfiguration {
 		// Retreived log.
 		out Body ExternalConfiguration
 	}
-    
-    // Reference to the resource that manages the collection of syncsets.
+	
+	// Reference to the resource that manages the collection of syncsets.
 	locator Syncsets {
 		target Syncsets
 	}
@@ -32,7 +32,7 @@ resource ExternalConfiguration {
 		target Manifests
 	}
 
-    // Reference to the resource that manages the collection of labels.
+	// Reference to the resource that manages the collection of labels.
 	locator Labels {
 		target Labels
 	}

--- a/model/clusters_mgmt/v1/external_configuration_type.model
+++ b/model/clusters_mgmt/v1/external_configuration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/flavour_nodes_type.model
+++ b/model/clusters_mgmt/v1/flavour_nodes_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/flavour_resource.model
+++ b/model/clusters_mgmt/v1/flavour_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/flavour_type.model
+++ b/model/clusters_mgmt/v1/flavour_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/flavours_resource.model
+++ b/model/clusters_mgmt/v1/flavours_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_authentication_type.model
+++ b/model/clusters_mgmt/v1/gcp_authentication_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Google cloud platform authentication method of a cluster.
 struct GcpAuthentication {
-    // Indicates the type of this object
-    Kind String
+	// Indicates the type of this object
+	Kind String
 
-    // Unique identifier of the object
-    Id String
+	// Unique identifier of the object
+	Id String
 
-    // Self link
-    Href String
+	// Self link
+	Href String
 }

--- a/model/clusters_mgmt/v1/gcp_dns_domain_type.model
+++ b/model/clusters_mgmt/v1/gcp_dns_domain_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,12 +19,12 @@ limitations under the License.
 // used in cluster DNS configuration for GCP-hosted clusters.
 struct GcpDnsDomain {
 	// DomainPrefix specifies the DNS domain prefix that will be used for cluster DNS resolution.
-  // This prefix is combined with the base domain to form the full DNS domain for the cluster.
+	// This prefix is combined with the base domain to form the full DNS domain for the cluster.
 	DomainPrefix String
 
 	// ProjectId is the Google Cloud Platform project identifier where the DNS zone is hosted.
 	ProjectId String
 
-  // NetworkId is the GCP VPC Network identifier where the DNS configuration will be applied.
-  NetworkId String
+	// NetworkId is the GCP VPC Network identifier where the DNS configuration will be applied.
+	NetworkId String
 }

--- a/model/clusters_mgmt/v1/gcp_encryption_key_type.model
+++ b/model/clusters_mgmt/v1/gcp_encryption_key_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_flavour_type.model
+++ b/model/clusters_mgmt/v1/gcp_flavour_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_image_override_type.model
+++ b/model/clusters_mgmt/v1/gcp_image_override_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // GcpImageOverride specifies what a GCP VM Image should be used for a particular product and billing model
 class GCPImageOverride {
-    // Link to the product type.
-    link Product Product
+	// Link to the product type.
+	link Product Product
 
-    // Link to the billing model.
-    link BillingModel BillingModelItem
+	// Link to the billing model.
+	link BillingModel BillingModelItem
 
-    // ImageID is the id of the Google Cloud Platform image.
-    ImageID String
+	// ImageID is the id of the Google Cloud Platform image.
+	ImageID String
 
-    // ProjectID is the id of the Google Cloud Platform project that hosts the image.
-    ProjectID String
+	// ProjectID is the id of the Google Cloud Platform project that hosts the image.
+	ProjectID String
 }

--- a/model/clusters_mgmt/v1/gcp_inquiries_resource.model
+++ b/model/clusters_mgmt/v1/gcp_inquiries_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,25 +16,25 @@ limitations under the License.
 
 // Manages the collection of gcp inquiries.
 resource GCPInquiries {
-    // Reference to the resource that manages a collection of vpcs.
-    locator Vpcs {
-        target VpcsInquiry
-    }
-    // Reference to the resource that manages a collection of key rings.
-    locator KeyRings {
-        target KeyRingsInquiry
-    }
-    // Reference to the resource that manages a collection of encryption keys.
-    locator EncryptionKeys {
-        target EncryptionKeysInquiry
-    }
-    // Reference to the resource that manages a collection of regions.
-    locator Regions {
-        target AvailableRegionsInquiry
-    }
-    // Reference to the resource that manages gcp machine types by regions.
-    locator MachineTypes {
-        target GCPRegionMachineTypesInquiry
-    }
+	// Reference to the resource that manages a collection of vpcs.
+	locator Vpcs {
+		target VpcsInquiry
+	}
+	// Reference to the resource that manages a collection of key rings.
+	locator KeyRings {
+		target KeyRingsInquiry
+	}
+	// Reference to the resource that manages a collection of encryption keys.
+	locator EncryptionKeys {
+		target EncryptionKeysInquiry
+	}
+	// Reference to the resource that manages a collection of regions.
+	locator Regions {
+		target AvailableRegionsInquiry
+	}
+	// Reference to the resource that manages gcp machine types by regions.
+	locator MachineTypes {
+		target GCPRegionMachineTypesInquiry
+	}
 }
 

--- a/model/clusters_mgmt/v1/gcp_machine_pool_type.model
+++ b/model/clusters_mgmt/v1/gcp_machine_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_network_type.model
+++ b/model/clusters_mgmt/v1/gcp_network_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // GCP Network configuration of a cluster.
 struct GCPNetwork {
-    // VPC mame used by the cluster.
-    VPCName  String
+	// VPC mame used by the cluster.
+	VPCName  String
 
-    // The name of the host project where the shared VPC exists.
-    VPCProjectID String
+	// The name of the host project where the shared VPC exists.
+	VPCProjectID String
 
-    // Control plane subnet used by the cluster.
-    ControlPlaneSubnet String
+	// Control plane subnet used by the cluster.
+	ControlPlaneSubnet String
 
-    // Compute subnet used by the cluster.
-    ComputeSubnet   String
+	// Compute subnet used by the cluster.
+	ComputeSubnet   String
 }

--- a/model/clusters_mgmt/v1/gcp_private_service_connect_type.model
+++ b/model/clusters_mgmt/v1/gcp_private_service_connect_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Google cloud platform private service connect configuration of a cluster.
 struct GcpPrivateServiceConnect {
-    // The name of the subnet where the PSC service attachment is created
-    ServiceAttachmentSubnet String
+	// The name of the subnet where the PSC service attachment is created
+	ServiceAttachmentSubnet String
 }

--- a/model/clusters_mgmt/v1/gcp_region_machine_types_resource.model
+++ b/model/clusters_mgmt/v1/gcp_region_machine_types_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_resource.model
+++ b/model/clusters_mgmt/v1/gcp_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_security_type.model
+++ b/model/clusters_mgmt/v1/gcp_security_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_type.model
+++ b/model/clusters_mgmt/v1/gcp_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/gcp_volume_type.model
+++ b/model/clusters_mgmt/v1/gcp_volume_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/group_resource.model
+++ b/model/clusters_mgmt/v1/group_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/group_type.model
+++ b/model/clusters_mgmt/v1/group_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/groups_resource.model
+++ b/model/clusters_mgmt/v1/groups_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/htpasswd_user_resource.model
+++ b/model/clusters_mgmt/v1/htpasswd_user_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,8 +25,8 @@ resource HTPasswdUser {
 	method Delete {
 	}
 
-    // Updates the user's password. The username is not editable
+	// Updates the user's password. The username is not editable
 	method Update {
-	    in out Body HTPasswdUser
+		in out Body HTPasswdUser
 	}
 }

--- a/model/clusters_mgmt/v1/htpasswd_user_type.model
+++ b/model/clusters_mgmt/v1/htpasswd_user_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,17 +15,17 @@ limitations under the License.
 */
 
 struct HTPasswdUser {
-    // ID for a secondary user in the _HTPasswd_ data file.
-    ID String
+	// ID for a secondary user in the _HTPasswd_ data file.
+	ID String
 
-    // Username for a secondary user in the _HTPasswd_ data file.
-    Username String
+	// Username for a secondary user in the _HTPasswd_ data file.
+	Username String
 
-    // Password in plain-text for a  user in the _HTPasswd_ data file.
-    // The value of this field is hashed before setting it in the  _HTPasswd_ data file for the HTPasswd IDP
-    Password String
+	// Password in plain-text for a  user in the _HTPasswd_ data file.
+	// The value of this field is hashed before setting it in the  _HTPasswd_ data file for the HTPasswd IDP
+	Password String
 
-   // HTPasswd Hashed Password for a user in the _HTPasswd_ data file.
-   // The value of this field is set as-is in the _HTPasswd_ data file for the HTPasswd IDP
-    HashedPassword String
+	// HTPasswd Hashed Password for a user in the _HTPasswd_ data file.
+	// The value of this field is set as-is in the _HTPasswd_ data file for the HTPasswd IDP
+	HashedPassword String
 }

--- a/model/clusters_mgmt/v1/htpasswd_users_resource.model
+++ b/model/clusters_mgmt/v1/htpasswd_users_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,21 +39,21 @@ resource HTPasswdUsers {
 
 	// Adds multiple new users to the _HTPasswd_ file.
 	method Import {
-	  // List of users to add to the IDP.
-      in Items []HTPasswdUser
+		// List of users to add to the IDP.
+		in Items []HTPasswdUser
 
-      // Index of the requested page, where one corresponds to the first page.
-      in out Page Integer = 1
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-      // Number of items contained in the returned page.
-      in out Size Integer = 100
+		// Number of items contained in the returned page.
+		in out Size Integer = 100
 
-      // Total number of items of the collection.
-      out Total Integer
+		// Total number of items of the collection.
+		out Total Integer
 
-      // Updated list of users of the IDP.
-      out Items []HTPasswdUser
-    }
+		// Updated list of users of the IDP.
+		out Items []HTPasswdUser
+	}
 
 	// Reference to the service that manages a specific _HTPasswd_ user.
 	locator HtpasswdUser {

--- a/model/clusters_mgmt/v1/hypershift_config_type.model
+++ b/model/clusters_mgmt/v1/hypershift_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/hypershift_resource.model
+++ b/model/clusters_mgmt/v1/hypershift_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/hypershift_type.model
+++ b/model/clusters_mgmt/v1/hypershift_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/identity_provider_resource.model
+++ b/model/clusters_mgmt/v1/identity_provider_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,12 +26,12 @@ resource IdentityProvider {
 	}
 
 	//Update identity provider in the cluster.
-    method Update {
-        in out Body IdentityProvider
-    }
+	method Update {
+		in out Body IdentityProvider
+	}
 
-    // Reference to the resource that manages the collection of _HTPasswd_ IDP users
-    locator HtpasswdUsers {
-        target HTPasswdUsers
-    }
+	// Reference to the resource that manages the collection of _HTPasswd_ IDP users
+	locator HtpasswdUsers {
+		target HTPasswdUsers
+	}
 }

--- a/model/clusters_mgmt/v1/identity_provider_type.model
+++ b/model/clusters_mgmt/v1/identity_provider_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -144,8 +144,8 @@ struct HTPasswdIdentityProvider {
 	// Password to be used in the _HTPasswd_ data file.
 	Password String
 
-    // Link to the collection of _HTPasswd_ users.
-    link Users []HTPasswdUser
+	// Link to the collection of _HTPasswd_ users.
+	link Users []HTPasswdUser
 }
 
 // Details for `ldap` identity providers.

--- a/model/clusters_mgmt/v1/identity_providers_resource.model
+++ b/model/clusters_mgmt/v1/identity_providers_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/image_mirror_resource.model
+++ b/model/clusters_mgmt/v1/image_mirror_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/image_mirror_type.model
+++ b/model/clusters_mgmt/v1/image_mirror_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/image_mirrors_resource.model
+++ b/model/clusters_mgmt/v1/image_mirrors_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/image_overrides_type.model
+++ b/model/clusters_mgmt/v1/image_overrides_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // ImageOverrides holds the lists of available images per cloud provider.
 class ImageOverrides {
-    AWS []AMIOverride
-    GCP []GCPImageOverride
+	AWS []AMIOverride
+	GCP []GCPImageOverride
 }

--- a/model/clusters_mgmt/v1/image_type.model
+++ b/model/clusters_mgmt/v1/image_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,11 +16,11 @@ limitations under the License.
 
 // Image Type (AMI) to use for running the associated NodePool
 enum ImageType {
-    // EC2 instances run as standard On-Demand instances.
+	// EC2 instances run as standard On-Demand instances.
 	@json(name = "Default")
-    Default
+	Default
 
-    // Scheduled pre-purchased compute capacity.
+	// Scheduled pre-purchased compute capacity.
 	@json(name = "Windows")
 	Windows
 } 

--- a/model/clusters_mgmt/v1/inflight_check_resource.model
+++ b/model/clusters_mgmt/v1/inflight_check_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/inflight_check_state_type.model
+++ b/model/clusters_mgmt/v1/inflight_check_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/inflight_check_type.model
+++ b/model/clusters_mgmt/v1/inflight_check_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,22 @@ limitations under the License.
 
 // Representation of check running before the cluster is provisioned.
 class InflightCheck {
-    // The name of the inflight check.
-    Name String
+	// The name of the inflight check.
+	Name String
 
-    // State of the inflight check.
-    State InflightCheckState
+	// State of the inflight check.
+	State InflightCheckState
 
-    // Details regarding the state of the inflight check.
-    Details Interface
+	// Details regarding the state of the inflight check.
+	Details Interface
 
-    // The time the check started running.
-    StartedAt Date
+	// The time the check started running.
+	StartedAt Date
 
-    // The time the check finished running.
-    EndedAt Date
+	// The time the check finished running.
+	EndedAt Date
 
-    // The number of times the inflight check restarted.
-    Restarts Integer
+	// The number of times the inflight check restarted.
+	Restarts Integer
 }
 

--- a/model/clusters_mgmt/v1/inflight_checks_resource.model
+++ b/model/clusters_mgmt/v1/inflight_checks_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/ingress_resource.model
+++ b/model/clusters_mgmt/v1/ingress_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/ingress_type.model
+++ b/model/clusters_mgmt/v1/ingress_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/ingresses_resource.model
+++ b/model/clusters_mgmt/v1/ingresses_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,7 +40,7 @@ resource Ingresses {
 	// Updates all ingresses
 	method Update {
 		in out Body []Ingress
-    }
+	}
 
 	// Reference to the service that manages a specific ingress.
 	locator Ingress {

--- a/model/clusters_mgmt/v1/instance_iam_roles.model
+++ b/model/clusters_mgmt/v1/instance_iam_roles.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/key_ring_inquiry_type.model
+++ b/model/clusters_mgmt/v1/key_ring_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/key_rings_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/key_rings_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ resource KeyRingsInquiry {
 		out Total Integer
 
 		// Retrieved list of key rings.
-   		out Items []KeyRing
+			out Items []KeyRing
 
 		// Cloud provider data needed for the inquiry
 		in Body CloudProviderData

--- a/model/clusters_mgmt/v1/kubelet_config_resource.model
+++ b/model/clusters_mgmt/v1/kubelet_config_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/kubelet_config_type.model
+++ b/model/clusters_mgmt/v1/kubelet_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/kubelet_configs_resource.model
+++ b/model/clusters_mgmt/v1/kubelet_configs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/label_resource.model
+++ b/model/clusters_mgmt/v1/label_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/label_type.model
+++ b/model/clusters_mgmt/v1/label_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/labels_resource.model
+++ b/model/clusters_mgmt/v1/labels_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/limited_support_reason_override_type.model
+++ b/model/clusters_mgmt/v1/limited_support_reason_override_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/limited_support_reason_resource.model
+++ b/model/clusters_mgmt/v1/limited_support_reason_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/limited_support_reason_template_resource.model
+++ b/model/clusters_mgmt/v1/limited_support_reason_template_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/limited_support_reason_template_type.model
+++ b/model/clusters_mgmt/v1/limited_support_reason_template_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/limited_support_reason_templates_resource.model
+++ b/model/clusters_mgmt/v1/limited_support_reason_templates_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/limited_support_reason_type.model
+++ b/model/clusters_mgmt/v1/limited_support_reason_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 enum DetectionType {
-    Manual
-    Auto
+	Manual
+	Auto
 }
 
 // A reason that a cluster is in limited support.

--- a/model/clusters_mgmt/v1/limited_support_reasons_resource.model
+++ b/model/clusters_mgmt/v1/limited_support_reasons_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/listening_method_type.model
+++ b/model/clusters_mgmt/v1/listening_method_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/load_balancer_flavor_type.model
+++ b/model/clusters_mgmt/v1/load_balancer_flavor_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/load_balancer_quota_values_resource.model
+++ b/model/clusters_mgmt/v1/load_balancer_quota_values_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,16 +18,16 @@ limitations under the License.
 resource LoadBalancerQuotaValues {
 	// Retrieves the list of Load Balancer Quota Values.
 	method List {
-            // Index of the requested page, where one corresponds to the first page.
-            in out Page Integer = 1
+			// Index of the requested page, where one corresponds to the first page.
+			in out Page Integer = 1
 
-            // Number of items contained in the returned page.
-            in out Size Integer = 100
+			// Number of items contained in the returned page.
+			in out Size Integer = 100
 
-            // Total number of items of the collection.
-            out Total Integer
+			// Total number of items of the collection.
+			out Total Integer
 
-            // Retrieved list of values.
-            out Items []Integer
+			// Retrieved list of values.
+			out Items []Integer
 	}
 }

--- a/model/clusters_mgmt/v1/log_forwarder_application_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_application_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Represents an application that can be configured for log forwarding.
 struct LogForwarderApplication {
-    // The name of the application.
-    Name String
+	// The name of the application.
+	Name String
 
-    // Indicates whether this application is available for use for log forwarding.
-    Enabled Boolean
+	// Indicates whether this application is available for use for log forwarding.
+	Enabled Boolean
 }
 

--- a/model/clusters_mgmt/v1/log_forwarder_cloudwatch_config_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_cloudwatch_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // CloudWatch configuration for log forwarding.
 struct LogForwarderCloudWatchConfig {
-    // The ARN of the IAM role for log distribution.
-    LogDistributionRoleArn String
+	// The ARN of the IAM role for log distribution.
+	LogDistributionRoleArn String
 
-    // The name of the CloudWatch log group.
-    LogGroupName String
+	// The name of the CloudWatch log group.
+	LogGroupName String
 }

--- a/model/clusters_mgmt/v1/log_forwarder_group_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_group_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Represents a log forwarder group.
 struct LogForwarderGroup {
-    // The identifier of the log forwarder group.
-    ID String
+	// The identifier of the log forwarder group.
+	ID String
 
-    // The version of the log forwarder group.
-    Version String
+	// The version of the log forwarder group.
+	Version String
 }

--- a/model/clusters_mgmt/v1/log_forwarder_group_version_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_group_version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Represents a version of a log forwarder group.
 struct LogForwarderGroupVersion {
-    // The version identifier.
-    ID String
+	// The version identifier.
+	ID String
 
-    // List of applications included in this version of the group.
-    Applications []String
+	// List of applications included in this version of the group.
+	Applications []String
 }

--- a/model/clusters_mgmt/v1/log_forwarder_group_versions_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_group_versions_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Represents a log forwarder group versions configuration.
 struct LogForwarderGroupVersions {
-    // The name of the log forwarder group.
-    Name String
+	// The name of the log forwarder group.
+	Name String
 
-    // Indicates whether this group is available for use for log forwarding.
-    Enabled Boolean
+	// Indicates whether this group is available for use for log forwarding.
+	Enabled Boolean
 
-    // List of available versions for this group.
-    Versions []LogForwarderGroupVersion
+	// List of available versions for this group.
+	Versions []LogForwarderGroupVersion
 }

--- a/model/clusters_mgmt/v1/log_forwarder_resource.model
+++ b/model/clusters_mgmt/v1/log_forwarder_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/log_forwarder_s3_config_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_s3_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // S3 configuration for log forwarding.
 struct LogForwarderS3Config {
-    // The name of the S3 bucket.
-    BucketName String
+	// The name of the S3 bucket.
+	BucketName String
 
-    // The prefix to use for objects stored in the S3 bucket.
-    BucketPrefix String
+	// The prefix to use for objects stored in the S3 bucket.
+	BucketPrefix String
 }

--- a/model/clusters_mgmt/v1/log_forwarder_status_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Represents the status of a log forwarder.
 struct LogForwarderStatus {
-    // The current state of the log forwarder.
-    State String
+	// The current state of the log forwarder.
+	State String
 
-    // A descriptive message providing additional context about the current
-    // state of the log forwarder.
-    Message String
+	// A descriptive message providing additional context about the current
+	// state of the log forwarder.
+	Message String
 
-    // The list of applications that are resolved for log forwarding,
-    // including the explicitly specified applications and any default applications.
-    ResolvedApplications []String
+	// The list of applications that are resolved for log forwarding,
+	// including the explicitly specified applications and any default applications.
+	ResolvedApplications []String
 }

--- a/model/clusters_mgmt/v1/log_forwarder_type.model
+++ b/model/clusters_mgmt/v1/log_forwarder_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Representation of a log forwarder configuration for a cluster.
 class LogForwarder {
-    // Identifier of the cluster.
-    ClusterID String
+	// Identifier of the cluster.
+	ClusterID String
 
-    // S3 configuration for log forwarding destination.
-    S3 LogForwarderS3Config
+	// S3 configuration for log forwarding destination.
+	S3 LogForwarderS3Config
 
-    // CloudWatch configuration for log forwarding destination.
-    Cloudwatch LogForwarderCloudWatchConfig
+	// CloudWatch configuration for log forwarding destination.
+	Cloudwatch LogForwarderCloudWatchConfig
 
-    // List of additional applications to forward logs for.
-    Applications []String
+	// List of additional applications to forward logs for.
+	Applications []String
 
-    // List of log forwarder groups.
-    Groups []LogForwarderGroup
+	// List of log forwarder groups.
+	Groups []LogForwarderGroup
 
-    // Status of the log forwarder.
-    Status LogForwarderStatus
+	// Status of the log forwarder.
+	Status LogForwarderStatus
 }

--- a/model/clusters_mgmt/v1/log_forwarders_resource.model
+++ b/model/clusters_mgmt/v1/log_forwarders_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/log_forwarding_applications_resource.model
+++ b/model/clusters_mgmt/v1/log_forwarding_applications_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/log_forwarding_groups_resource.model
+++ b/model/clusters_mgmt/v1/log_forwarding_groups_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/log_forwarding_resource.model
+++ b/model/clusters_mgmt/v1/log_forwarding_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/log_resource.model
+++ b/model/clusters_mgmt/v1/log_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/log_type.model
+++ b/model/clusters_mgmt/v1/log_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/logs_resource.model
+++ b/model/clusters_mgmt/v1/logs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,20 +17,20 @@ limitations under the License.
 // Manages a collection of log links.
 resource Logs {
 
-    // Retrieves the list of log links.
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	// Retrieves the list of log links.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Number of items contained in the returned page.
-        in out Size Integer = 100
+		// Number of items contained in the returned page.
+		in out Size Integer = 100
 
-        // Total number of items of the collection.
-        out Total Integer
+		// Total number of items of the collection.
+		out Total Integer
 
-        // Retrieved list of log links.
-        out Items []Log
-    }
+		// Retrieved list of log links.
+		out Items []Log
+	}
 
 	locator Install {
 		target Log

--- a/model/clusters_mgmt/v1/machine_pool_autoscaling_type.model
+++ b/model/clusters_mgmt/v1/machine_pool_autoscaling_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a autoscaling in a machine pool.
 class MachinePoolAutoscaling {
-    // The minimum number of replicas for the machine pool.
+	// The minimum number of replicas for the machine pool.
 	MinReplicas Integer
 
-    // The maximum number of replicas for the machine pool.
+	// The maximum number of replicas for the machine pool.
 	MaxReplicas Integer
 }

--- a/model/clusters_mgmt/v1/machine_pool_aws_security_group_filter_type.model
+++ b/model/clusters_mgmt/v1/machine_pool_aws_security_group_filter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Security Group Filter object, containing name of the filter tag and value of the filter tag
 struct MachinePoolSecurityGroupFilter {
-  Name String
-  Value String
+	Name String
+	Value String
 } 

--- a/model/clusters_mgmt/v1/machine_pool_resource.model
+++ b/model/clusters_mgmt/v1/machine_pool_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_pool_type.model
+++ b/model/clusters_mgmt/v1/machine_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_pools_resource.model
+++ b/model/clusters_mgmt/v1/machine_pools_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_type_category_type.model
+++ b/model/clusters_mgmt/v1/machine_type_category_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_type_features_type.model
+++ b/model/clusters_mgmt/v1/machine_type_features_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_type_resource.model
+++ b/model/clusters_mgmt/v1/machine_type_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_type_size_type.model
+++ b/model/clusters_mgmt/v1/machine_type_size_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_type_type.model
+++ b/model/clusters_mgmt/v1/machine_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/machine_types_resource.model
+++ b/model/clusters_mgmt/v1/machine_types_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/managedservice_type.model
+++ b/model/clusters_mgmt/v1/managedservice_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/manifest_resource.model
+++ b/model/clusters_mgmt/v1/manifest_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/manifest_type.model
+++ b/model/clusters_mgmt/v1/manifest_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/manifests_resource.model
+++ b/model/clusters_mgmt/v1/manifests_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/market_type.model
+++ b/model/clusters_mgmt/v1/market_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,11 +16,11 @@ limitations under the License.
 
 // Market type for AWS Capacity Reservations.
 enum MarketType {
-    // EC2 instances run as standard On-Demand instances.
+	// EC2 instances run as standard On-Demand instances.
 	@json(name = "OnDemand")
-    OnDemand
+	OnDemand
 
-    // Scheduled pre-purchased compute capacity.
+	// Scheduled pre-purchased compute capacity.
 	@json(name = "CapacityBlocks")
-    CapacityBlocks
+	CapacityBlocks
 } 

--- a/model/clusters_mgmt/v1/metric_queries_resource.model
+++ b/model/clusters_mgmt/v1/metric_queries_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -38,8 +38,8 @@ resource MetricQueries {
 		target ClusterOperatorsMetricQuery
 	}
 
-    // Reference to the resource that retrieves the nodes in the cluster.
-    locator Nodes {
-        target NodesMetricQuery
-    }
+	// Reference to the resource that retrieves the nodes in the cluster.
+	locator Nodes {
+		target NodesMetricQuery
+	}
 }

--- a/model/clusters_mgmt/v1/namespace_ownership_policy_type.model
+++ b/model/clusters_mgmt/v1/namespace_ownership_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/namespace_selector_type.model
+++ b/model/clusters_mgmt/v1/namespace_selector_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/network_type.model
+++ b/model/clusters_mgmt/v1/network_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/network_verification_resource.model
+++ b/model/clusters_mgmt/v1/network_verification_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/network_verification_type.model
+++ b/model/clusters_mgmt/v1/network_verification_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/network_verifications_resource.model
+++ b/model/clusters_mgmt/v1/network_verifications_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_info_type.model
+++ b/model/clusters_mgmt/v1/node_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_pool_autoscaling_type.model
+++ b/model/clusters_mgmt/v1/node_pool_autoscaling_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a autoscaling in a node pool.
 class NodePoolAutoscaling {
-    // The minimum number of replicas for the node pool.
-    MinReplica Integer
+	// The minimum number of replicas for the node pool.
+	MinReplica Integer
 
-    // The maximum number of replicas for the node pool.
-    MaxReplica Integer
+	// The maximum number of replicas for the node pool.
+	MaxReplica Integer
 }

--- a/model/clusters_mgmt/v1/node_pool_management_upgrade_type.model
+++ b/model/clusters_mgmt/v1/node_pool_management_upgrade_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Representation of node pool management.
 class NodePoolManagementUpgrade {
-    // Type of strategy for handling upgrades.
-    Type String
+	// Type of strategy for handling upgrades.
+	Type String
 
-    // Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be unavailable during the upgrade.
-    MaxUnavailable String
+	// Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be unavailable during the upgrade.
+	MaxUnavailable String
 
-    // Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be scheduled above the desired number of nodes during the upgrade.
-    MaxSurge String
+	// Maximum number of nodes in the NodePool of a ROSA HCP cluster that can be scheduled above the desired number of nodes during the upgrade.
+	MaxSurge String
 }

--- a/model/clusters_mgmt/v1/node_pool_resource.model
+++ b/model/clusters_mgmt/v1/node_pool_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,22 @@ limitations under the License.
 
 // Manages a specific nodepool.
 resource NodePool {
-    // Retrieves the details of the node pool.
-    method Get {
-        out Body NodePool
-    }
+	// Retrieves the details of the node pool.
+	method Get {
+		out Body NodePool
+	}
 
-    // Updates the node pool.
-    method Update {
-        in out Body NodePool
-    }
+	// Updates the node pool.
+	method Update {
+		in out Body NodePool
+	}
 
-    // Deletes the node pool.
-    method Delete {
-    }
+	// Deletes the node pool.
+	method Delete {
+	}
 
-    // Reference to the state of the upgrade policy.
-    locator UpgradePolicies {
-        target NodePoolUpgradePolicies
-    }
+	// Reference to the state of the upgrade policy.
+	locator UpgradePolicies {
+		target NodePoolUpgradePolicies
+	}
 }

--- a/model/clusters_mgmt/v1/node_pool_state_type.model
+++ b/model/clusters_mgmt/v1/node_pool_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_pool_status_type.model
+++ b/model/clusters_mgmt/v1/node_pool_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,12 +16,12 @@ limitations under the License.
 
 // Representation of the status of a node pool.
 class NodePoolStatus {
-    // The current state of the node pool
-    State NodePoolState
-    
-    // The current number of replicas for the node pool.
-    CurrentReplicas Integer
+	// The current state of the node pool
+	State NodePoolState
+	
+	// The current number of replicas for the node pool.
+	CurrentReplicas Integer
 
-    // Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas.
-    Message String
+	// Adds additional information about the NodePool status when the node pool doesn't reach the desired replicas.
+	Message String
 }

--- a/model/clusters_mgmt/v1/node_pool_type.model
+++ b/model/clusters_mgmt/v1/node_pool_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,52 +16,52 @@ limitations under the License.
 
 // Representation of a node pool in a cluster.
 class NodePool {
-    // The number of Machines (and Nodes) to create.
-    // Replicas and autoscaling cannot be used together.
-    Replicas Integer
+	// The number of Machines (and Nodes) to create.
+	// Replicas and autoscaling cannot be used together.
+	Replicas Integer
 
-    // Details for auto-scaling the machine pool.
-    // Replicas and autoscaling cannot be used together.
-    Autoscaling NodePoolAutoscaling
+	// Details for auto-scaling the machine pool.
+	// Replicas and autoscaling cannot be used together.
+	Autoscaling NodePoolAutoscaling
 
-    // Specifies whether health checks should be enabled for machines in the NodePool.
-    AutoRepair Boolean
+	// Specifies whether health checks should be enabled for machines in the NodePool.
+	AutoRepair Boolean
 
-    // AWS specific parameters (Optional).
-    AWSNodePool AWSNodePool
+	// AWS specific parameters (Optional).
+	AWSNodePool AWSNodePool
 
-    // Azure specific parameters.
-    AzureNodePool AzureNodePool
+	// Azure specific parameters.
+	AzureNodePool AzureNodePool
 
-    // The availability zone upon which the node is created.
-    AvailabilityZone String
+	// The availability zone upon which the node is created.
+	AvailabilityZone String
 
-    // The subnet upon which the nodes are created.
-    Subnet String
+	// The subnet upon which the nodes are created.
+	Subnet String
 
-    // NodePool status.
-    Status NodePoolStatus
+	// NodePool status.
+	Status NodePoolStatus
 
-    // Version of the node pool.
-    Version Version
+	// Version of the node pool.
+	Version Version
 
-    // The labels set on the Nodes created.
-    Labels [String]String
+	// The labels set on the Nodes created.
+	Labels [String]String
 
-    // The taints set on the Nodes created.
-    Taints []Taint
+	// The taints set on the Nodes created.
+	Taints []Taint
 
-    // The names of the tuning configs for this node pool.
-    TuningConfigs []String
+	// The names of the tuning configs for this node pool.
+	TuningConfigs []String
 
-    // The names of the KubeletConfigs for this node pool.
-    KubeletConfigs []String
+	// The names of the KubeletConfigs for this node pool.
+	KubeletConfigs []String
 
-    // Time to wait for a NodePool to drain when it is upgraded or replaced before it is forcibly removed.
-    NodeDrainGracePeriod Value
+	// Time to wait for a NodePool to drain when it is upgraded or replaced before it is forcibly removed.
+	NodeDrainGracePeriod Value
 
-    // Management parameters (Optional).
-    ManagementUpgrade NodePoolManagementUpgrade
+	// Management parameters (Optional).
+	ManagementUpgrade NodePoolManagementUpgrade
 
 	// Type of Image used to run the nodes (i.e. Windows or Default/Linux)
 	ImageType ImageType

--- a/model/clusters_mgmt/v1/node_pool_upgrade_policies_resource.model
+++ b/model/clusters_mgmt/v1/node_pool_upgrade_policies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_pool_upgrade_policy_resource.model
+++ b/model/clusters_mgmt/v1/node_pool_upgrade_policy_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_pool_upgrade_policy_type.model
+++ b/model/clusters_mgmt/v1/node_pool_upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_pools_resource.model
+++ b/model/clusters_mgmt/v1/node_pools_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/node_type.model
+++ b/model/clusters_mgmt/v1/node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/nodes_info_type.model
+++ b/model/clusters_mgmt/v1/nodes_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/nodes_metric_query_resource.model
+++ b/model/clusters_mgmt/v1/nodes_metric_query_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/oidc_config_resource.model
+++ b/model/clusters_mgmt/v1/oidc_config_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/oidc_config_type.model
+++ b/model/clusters_mgmt/v1/oidc_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ struct OidcConfig {
 	ID String
 
 	// HREF for the oidc config, filled in response.
-  	HREF String
+		HREF String
 
 	// Organization ID, filled in response respecting token provided.
 	OrganizationId String

--- a/model/clusters_mgmt/v1/oidc_configs_resource.model
+++ b/model/clusters_mgmt/v1/oidc_configs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,7 +34,7 @@ resource OidcConfigs {
 	
 	// Creates a hosting under Red Hat's S3 bucket for byo oidc configuration.
 	method Add {
-	    in out Body OidcConfig
+		in out Body OidcConfig
 	}
 
 	// Reference to the service that manages an specific identity provider.

--- a/model/clusters_mgmt/v1/oidc_thumbprint_input_type.model
+++ b/model/clusters_mgmt/v1/oidc_thumbprint_input_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/oidc_thumbprint_resource.model
+++ b/model/clusters_mgmt/v1/oidc_thumbprint_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,7 +18,7 @@ limitations under the License.
 resource OidcThumbprint {
 	// Fetches/creates an OIDC Config Thumbprint from either a cluster ID, or an oidc config ID.
 	method Post {
-	    out Body OidcThumbprint
-	    in Body OidcThumbprintInput
+		out Body OidcThumbprint
+		in Body OidcThumbprintInput
 	}
 }

--- a/model/clusters_mgmt/v1/oidc_thumbprint_type.model
+++ b/model/clusters_mgmt/v1/oidc_thumbprint_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,8 +27,8 @@ struct OidcThumbprint {
 	Thumbprint String
 
 	// HREF for the oidc config thumbprint, filled in response.
-  	HREF String
+		HREF String
 
-  	// Kind is the resource type, filled in response.
-  	Kind String
+		// Kind is the resource type, filled in response.
+		Kind String
 }

--- a/model/clusters_mgmt/v1/operator_iam_role_resource.model
+++ b/model/clusters_mgmt/v1/operator_iam_role_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/operator_iam_role_type.model
+++ b/model/clusters_mgmt/v1/operator_iam_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/operator_iam_roles_resource.model
+++ b/model/clusters_mgmt/v1/operator_iam_roles_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/organization_link_type.model
+++ b/model/clusters_mgmt/v1/organization_link_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/pending_delete_cluster_resource.model
+++ b/model/clusters_mgmt/v1/pending_delete_cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/pending_delete_cluster_type.model
+++ b/model/clusters_mgmt/v1/pending_delete_cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/pending_delete_clusters_resource.model
+++ b/model/clusters_mgmt/v1/pending_delete_clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/platform_type.model
+++ b/model/clusters_mgmt/v1/platform_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an platform type field.
 enum Platform {
-    @json(name = "aws")
-    Aws
+	@json(name = "aws")
+	Aws
 
-    @json(name = "gcp")
-    Gcp
+	@json(name = "gcp")
+	Gcp
 
-    @json(name = "hostedcluster")
-    HostedCluster
+	@json(name = "hostedcluster")
+	HostedCluster
 
-    @json(name = "aws-classic")
-    AwsClassic
+	@json(name = "aws-classic")
+	AwsClassic
 
-    @json(name = "aws-hosted-cp")
-    AwsHostedCp
+	@json(name = "aws-hosted-cp")
+	AwsHostedCp
 }

--- a/model/clusters_mgmt/v1/private_link_cluster_configuration_type.model
+++ b/model/clusters_mgmt/v1/private_link_cluster_configuration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Manages the configuration for the Private Links.
 struct PrivateLinkClusterConfiguration {
-    // List of additional principals for the Private Link
-    Principals []PrivateLinkPrincipal
+	// List of additional principals for the Private Link
+	Principals []PrivateLinkPrincipal
 }
 
 

--- a/model/clusters_mgmt/v1/private_link_configuration_principal_resource.model
+++ b/model/clusters_mgmt/v1/private_link_configuration_principal_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/private_link_configuration_principal_type.model
+++ b/model/clusters_mgmt/v1/private_link_configuration_principal_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 class PrivateLinkPrincipal {
-    // ARN for a principal that is allowed for this Private Link.
-    Principal String
+	// ARN for a principal that is allowed for this Private Link.
+	Principal String
 }

--- a/model/clusters_mgmt/v1/private_link_configuration_principals_resource.model
+++ b/model/clusters_mgmt/v1/private_link_configuration_principals_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/private_link_configuration_principals_type.model
+++ b/model/clusters_mgmt/v1/private_link_configuration_principals_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Contains a list of principals for the Private Link.
 class PrivateLinkPrincipals {
-    // List of additional principals for the Private Link
-    Principals []PrivateLinkPrincipal
+	// List of additional principals for the Private Link
+	Principals []PrivateLinkPrincipal
 }

--- a/model/clusters_mgmt/v1/private_link_configuration_resource.model
+++ b/model/clusters_mgmt/v1/private_link_configuration_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/private_link_configuration_type.model
+++ b/model/clusters_mgmt/v1/private_link_configuration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Manages the configuration for the Private Links.
 struct PrivateLinkConfiguration {
-	  // List of additional principals for the Private Link
-    link Principals PrivateLinkPrincipals
+		// List of additional principals for the Private Link
+	link Principals PrivateLinkPrincipals
 }
 
 

--- a/model/clusters_mgmt/v1/processor_type_type.model
+++ b/model/clusters_mgmt/v1/processor_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_minimal_version_resource.model
+++ b/model/clusters_mgmt/v1/product_minimal_version_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_minimal_version_type.model
+++ b/model/clusters_mgmt/v1/product_minimal_version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_minimal_versions_resource.model
+++ b/model/clusters_mgmt/v1/product_minimal_versions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_resource.model
+++ b/model/clusters_mgmt/v1/product_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_technology_preview_resource.model
+++ b/model/clusters_mgmt/v1/product_technology_preview_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_technology_preview_type.model
+++ b/model/clusters_mgmt/v1/product_technology_preview_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_technology_previews_resource.model
+++ b/model/clusters_mgmt/v1/product_technology_previews_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/product_type.model
+++ b/model/clusters_mgmt/v1/product_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/products_resource.model
+++ b/model/clusters_mgmt/v1/products_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/provider_data_inquiry_type.model
+++ b/model/clusters_mgmt/v1/provider_data_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,30 +16,30 @@ limitations under the License.
 
 // Description of a cloud provider data used for cloud provider inquiries.
 struct CloudProviderData {
-    // Amazon Web Services settings.
-    AWS AWS
+	// Amazon Web Services settings.
+	AWS AWS
 
-    // Google cloud platform settings.
-    GCP GCP
+	// Google cloud platform settings.
+	GCP GCP
 
-    // Region
-    Region CloudRegion
+	// Region
+	Region CloudRegion
 
-    // Key location
-    KeyLocation String
+	// Key location
+	KeyLocation String
 
-    // Key ring name
-    KeyRingName  String
+	// Key ring name
+	KeyRingName  String
 
-    // Openshift version
-    Version Version
+	// Openshift version
+	Version Version
 
-    // Availability zone
-    AvailabilityZones []String
+	// Availability zone
+	AvailabilityZones []String
 
-    // Subnets
-    Subnets []String
+	// Subnets
+	Subnets []String
 
-    // VPC ids
-    VpcIds []string
+	// VPC ids
+	VpcIds []string
 }

--- a/model/clusters_mgmt/v1/provision_shard_resource.model
+++ b/model/clusters_mgmt/v1/provision_shard_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/provision_shard_topology_type.model
+++ b/model/clusters_mgmt/v1/provision_shard_topology_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 enum ProvisionShardTopology {
 
-    // Provision shard for hosted clusters is configured in a "dedicated" topology.
-    @json(name = "dedicated")
-    Dedicated
+	// Provision shard for hosted clusters is configured in a "dedicated" topology.
+	@json(name = "dedicated")
+	Dedicated
 }

--- a/model/clusters_mgmt/v1/provision_shard_type.model
+++ b/model/clusters_mgmt/v1/provision_shard_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/provision_shards_resource.model
+++ b/model/clusters_mgmt/v1/provision_shards_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/proxy_type.model
+++ b/model/clusters_mgmt/v1/proxy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/register_cluster_resource.model
+++ b/model/clusters_mgmt/v1/register_cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/registry_allowlist_resource.model
+++ b/model/clusters_mgmt/v1/registry_allowlist_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/registry_allowlist_type.model
+++ b/model/clusters_mgmt/v1/registry_allowlist_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/registry_allowlists_resource.model
+++ b/model/clusters_mgmt/v1/registry_allowlists_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/release_image_details_type.model
+++ b/model/clusters_mgmt/v1/release_image_details_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/release_images_type.model
+++ b/model/clusters_mgmt/v1/release_images_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 struct ReleaseImages {
-    // Arm64 will contain the reference for the arm64 image which will be used for cluster deployments
-    ARM64 ReleaseImageDetails
+	// Arm64 will contain the reference for the arm64 image which will be used for cluster deployments
+	ARM64 ReleaseImageDetails
 
-    // Multi will contain the reference for the multi image which will be used for cluster deployments
-    Multi ReleaseImageDetails
+	// Multi will contain the reference for the multi image which will be used for cluster deployments
+	Multi ReleaseImageDetails
 }

--- a/model/clusters_mgmt/v1/resource_range_type.model
+++ b/model/clusters_mgmt/v1/resource_range_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/resource_resource.model
+++ b/model/clusters_mgmt/v1/resource_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages currently available cluster resources 
 resource ClusterResources {
-    // Retrieves currently available cluster resources
-    method Get {
-        // List of cluster resources
-        out Body ClusterResources
-    }
+	// Retrieves currently available cluster resources
+	method Get {
+		// List of cluster resources
+		out Body ClusterResources
+	}
 }

--- a/model/clusters_mgmt/v1/resource_type.model
+++ b/model/clusters_mgmt/v1/resource_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // Cluster Resource which belongs to a cluster, example Cluster Deployment.
 class ClusterResources {
-    // Cluster ID for the fetched resources
-    ClusterID String
-    // Returned map of cluster resources fetched.
-    Resources [String]String
-    // Date and time when the resources were fetched.
-    CreationTimestamp Date
+	// Cluster ID for the fetched resources
+	ClusterID String
+	// Returned map of cluster resources fetched.
+	Resources [String]String
+	// Date and time when the resources were fetched.
+	CreationTimestamp Date
 }

--- a/model/clusters_mgmt/v1/resources_resource.model
+++ b/model/clusters_mgmt/v1/resources_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Manages a collection of resources for a cluster
 resource Resources {
-    // Retrieves a list of resources for a cluster in error state
-    method Get {
-        // List of cluster resources
-        out Body ClusterResources
-    }
+	// Retrieves a list of resources for a cluster in error state
+	method Get {
+		// List of cluster resources
+		out Body ClusterResources
+	}
 
-    // Retrieves a list of currently available resources for a cluster
-    locator Live {
-        // Retrieved list of currently available resources for a cluster
-        target ClusterResources
-    }
+	// Retrieves a list of currently available resources for a cluster
+	locator Live {
+		// Retrieved list of currently available resources for a cluster
+		target ClusterResources
+	}
 }

--- a/model/clusters_mgmt/v1/role_policy_binding_status_type.model
+++ b/model/clusters_mgmt/v1/role_policy_binding_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/role_policy_binding_type.model
+++ b/model/clusters_mgmt/v1/role_policy_binding_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/role_policy_bindings_resource.model
+++ b/model/clusters_mgmt/v1/role_policy_bindings_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/role_policy_type.model
+++ b/model/clusters_mgmt/v1/role_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/root_resource.model
+++ b/model/clusters_mgmt/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -84,12 +84,12 @@ resource Root {
 
 	// Reference to limited support reason templates.
 	locator LimitedSupportReasonTemplates {
-	    target LimitedSupportReasonTemplates
+		target LimitedSupportReasonTemplates
 	}
 
 	// Reference to version gates.
 	locator VersionGates {
-	    target VersionGates
+		target VersionGates
 	}
 
 	// Reference to the resource that manages the environment.
@@ -108,13 +108,13 @@ resource Root {
 	}
 
 	// Reference to the resource that manages the collection of deleted clusters.
-    locator DeletedClusters {
-        target DeletedClusters
-    }
+	locator DeletedClusters {
+		target DeletedClusters
+	}
 
 	//Reference to the resource that manages dns domains.
 	locator DNSDomains {
-	    target DNSDomains
+		target DNSDomains
 	}
 
 	// Reference to the resource that manages network verifications.

--- a/model/clusters_mgmt/v1/sdn_to_ovn_cluster_migration_type.model
+++ b/model/clusters_mgmt/v1/sdn_to_ovn_cluster_migration_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Details for `SdnToOvn` cluster migrations.
 struct SdnToOvnClusterMigration {
-    // The IP address range to use for the internalTransSwitchSubnet parameter of OVN-Kubernetes
-    // upon migration.
-    @json(name = "transit_ipv4")
-    TransitIpv4 String
+	// The IP address range to use for the internalTransSwitchSubnet parameter of OVN-Kubernetes
+	// upon migration.
+	@json(name = "transit_ipv4")
+	TransitIpv4 String
 
-    // The IP address range to use for the internalJoinSubnet parameter of OVN-Kubernetes
-    // upon migration.
-    @json(name = "join_ipv4")
-    JoinIpv4 String
+	// The IP address range to use for the internalJoinSubnet parameter of OVN-Kubernetes
+	// upon migration.
+	@json(name = "join_ipv4")
+	JoinIpv4 String
 
-    // The IP address range to us for the internalMasqueradeSubnet parameter of OVN-Kubernetes
-    // upon migration.
-    @json(name = "masquerade_ipv4")
-    MasqueradeIpv4 String
+	// The IP address range to us for the internalMasqueradeSubnet parameter of OVN-Kubernetes
+	// upon migration.
+	@json(name = "masquerade_ipv4")
+	MasqueradeIpv4 String
 }

--- a/model/clusters_mgmt/v1/server_config_type.model
+++ b/model/clusters_mgmt/v1/server_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/socket_total_by_node_roles_os_metric_query_resource.model
+++ b/model/clusters_mgmt/v1/socket_total_by_node_roles_os_metric_query_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/socket_total_node_role_os_metric_node_type.model
+++ b/model/clusters_mgmt/v1/socket_total_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/socket_totals_node_role_os_metric_node_type.model
+++ b/model/clusters_mgmt/v1/socket_totals_node_role_os_metric_node_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/storage_quota_type.model
+++ b/model/clusters_mgmt/v1/storage_quota_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/storage_quota_values_resource.model
+++ b/model/clusters_mgmt/v1/storage_quota_values_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,16 +18,16 @@ limitations under the License.
 resource StorageQuotaValues {
 	// Retrieves the list of Storage Quota Values.
 	method List {
-            // Index of the requested page, where one corresponds to the first page.
-            in out Page Integer = 1
+			// Index of the requested page, where one corresponds to the first page.
+			in out Page Integer = 1
 
-            // Number of items contained in the returned page.
-            in out Size Integer = 100
+			// Number of items contained in the returned page.
+			in out Size Integer = 100
 
-            // Total number of items of the collection.
-            out Total Integer
+			// Total number of items of the collection.
+			out Total Integer
 
-            // Retrieved list of values.
-            out Items []StorageQuota
+			// Retrieved list of values.
+			out Items []StorageQuota
 	}
 }

--- a/model/clusters_mgmt/v1/sts_credential_request_type.model
+++ b/model/clusters_mgmt/v1/sts_credential_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,10 +17,10 @@ limitations under the License.
 // Representation of an credRequest
 struct STSCredentialRequest {
 
-    //Name of CredRequest
-    Name String
+	//Name of CredRequest
+	Name String
 
-    //Operator Details
-    link Operator STSOperator
+	//Operator Details
+	link Operator STSOperator
 
 }

--- a/model/clusters_mgmt/v1/sts_credential_requests_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/sts_credential_requests_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,19 @@ limitations under the License.
 
 // Manages STS Credential Request
 resource STSCredentialRequestsInquiry {
-    // Retrieves the list of policies.
-    method List {
-        // Index of the requested page, where one corresponds to the first page.
-        in out Page Integer = 1
+	// Retrieves the list of policies.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
 
-        // Maximum number of items that will be contained in the returned page.
-        in out Size Integer = 100
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
 
-        // Total number of items of the collection that match the search criteria,
-        // regardless of the size of the page.
-        out Total Integer
+		// Total number of items of the collection that match the search criteria,
+		// regardless of the size of the page.
+		out Total Integer
 
-        // Retrieved list of CredRequest.
-        out Items []STSCredentialRequest
-    }
+		// Retrieved list of CredRequest.
+		out Items []STSCredentialRequest
+	}
 }

--- a/model/clusters_mgmt/v1/sts_operator_type.model
+++ b/model/clusters_mgmt/v1/sts_operator_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Representation of an sts operator
 struct STSOperator {
-    //Operator Name
-    Name                String
+	//Operator Name
+	Name                String
 
-    //Operator Namespace
-    Namespace           String
+	//Operator Namespace
+	Namespace           String
 
-    //Service Accounts
-    ServiceAccounts []String
+	//Service Accounts
+	ServiceAccounts []String
 
-    //Minimum ocp version supported
-    MinVersion          String
+	//Minimum ocp version supported
+	MinVersion          String
 
-    //Maximum ocp version supported
-    MaxVersion          String
+	//Maximum ocp version supported
+	MaxVersion          String
 }

--- a/model/clusters_mgmt/v1/sts_support_jump_role_resource.model
+++ b/model/clusters_mgmt/v1/sts_support_jump_role_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/sts_support_jump_role_type.model
+++ b/model/clusters_mgmt/v1/sts_support_jump_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/sts_type.model
+++ b/model/clusters_mgmt/v1/sts_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/subnet_network_verification_type.model
+++ b/model/clusters_mgmt/v1/subnet_network_verification_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,15 +15,15 @@ limitations under the License.
 */
 
 class SubnetNetworkVerification {
-  // Slice of failures that happened during a subnet network verification.
-  Details []String
-  
-  // State of the subnet network verification.
-  State String
+	// Slice of failures that happened during a subnet network verification.
+	Details []String
+	
+	// State of the subnet network verification.
+	State String
 
-  // Tags supplied to the network verifier for this subnet.
-  Tags [String]String
+	// Tags supplied to the network verifier for this subnet.
+	Tags [String]String
 
-  // Platform supplied to the network verifier for this subnet.
-  Platform Platform
+	// Platform supplied to the network verifier for this subnet.
+	Platform Platform
 }

--- a/model/clusters_mgmt/v1/subscription_type.model
+++ b/model/clusters_mgmt/v1/subscription_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/syncset_resource.model
+++ b/model/clusters_mgmt/v1/syncset_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/syncset_type.model
+++ b/model/clusters_mgmt/v1/syncset_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/syncsets_resource.model
+++ b/model/clusters_mgmt/v1/syncsets_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/taint_type.model
+++ b/model/clusters_mgmt/v1/taint_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,12 +17,12 @@ limitations under the License.
 
 // Representation of a Taint set on a MachinePool in a cluster.
 struct Taint {
-    // The key for the taint
-    Key String
+	// The key for the taint
+	Key String
 
-    // The value for the taint.
-    Value String
-    
-    // The effect on the node for the pods matching the taint, i.e: NoSchedule, NoExecute, PreferNoSchedule.
-    Effect String
+	// The value for the taint.
+	Value String
+	
+	// The effect on the node for the pods matching the taint, i.e: NoSchedule, NoExecute, PreferNoSchedule.
+	Effect String
 }

--- a/model/clusters_mgmt/v1/trusted_ip_resource.model
+++ b/model/clusters_mgmt/v1/trusted_ip_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/trusted_ips_resource.model
+++ b/model/clusters_mgmt/v1/trusted_ips_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/trusted_ips_type.model
+++ b/model/clusters_mgmt/v1/trusted_ips_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/tuning_config_resource.model
+++ b/model/clusters_mgmt/v1/tuning_config_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Manages a specific tuning config.
 resource TuningConfig {
-  // Retrieves the details of the tuning config.
-  method Get {
-    out Body TuningConfig
-  }
+	// Retrieves the details of the tuning config.
+	method Get {
+	out Body TuningConfig
+	}
 
-  // Updates the tuning config.
-  method Update {
-    in out Body TuningConfig
-  }
+	// Updates the tuning config.
+	method Update {
+	in out Body TuningConfig
+	}
 
-  // Deletes the tuning config.
-  method Delete {
-  }
+	// Deletes the tuning config.
+	method Delete {
+	}
 }

--- a/model/clusters_mgmt/v1/tuning_config_type.model
+++ b/model/clusters_mgmt/v1/tuning_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Representation of a tuning config.
 class TuningConfig {
-  // Name of the tuning config.
-  Name String
+	// Name of the tuning config.
+	Name String
 
-  // Spec of the tuning config.
-  Spec Interface
+	// Spec of the tuning config.
+	Spec Interface
 }

--- a/model/clusters_mgmt/v1/tuning_configs_resource.model
+++ b/model/clusters_mgmt/v1/tuning_configs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policies_resource.model
+++ b/model/clusters_mgmt/v1/upgrade_policies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policy_resource.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policy_schedule_type.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_schedule_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policy_state_resource.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_state_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policy_state_type.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_state_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policy_type.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/upgrade_policy_upgrade_type.model
+++ b/model/clusters_mgmt/v1/upgrade_policy_upgrade_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/user_resource.model
+++ b/model/clusters_mgmt/v1/user_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/user_type.model
+++ b/model/clusters_mgmt/v1/user_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/users_resource.model
+++ b/model/clusters_mgmt/v1/users_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/value_type.model
+++ b/model/clusters_mgmt/v1/value_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_gate_agreement_resource.model
+++ b/model/clusters_mgmt/v1/version_gate_agreement_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_gate_agreement_type.model
+++ b/model/clusters_mgmt/v1/version_gate_agreement_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_gate_agreements_resource.model
+++ b/model/clusters_mgmt/v1/version_gate_agreements_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_gate_resource.model
+++ b/model/clusters_mgmt/v1/version_gate_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_gate_type.model
+++ b/model/clusters_mgmt/v1/version_gate_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,33 +16,33 @@ limitations under the License.
 
 // Representation of an _OpenShift_ version gate.
 class VersionGate {
-  // VersionRawIDPrefix represents the versions prefix that the gate applies to.
-  VersionRawIDPrefix String
+	// VersionRawIDPrefix represents the versions prefix that the gate applies to.
+	VersionRawIDPrefix String
 
-  // Label representing the version gate in OpenShift.
-  Label String
+	// Label representing the version gate in OpenShift.
+	Label String
 
-  // Value represents the required value of the label.
-  Value String
+	// Value represents the required value of the label.
+	Value String
 
-  // WarningMessage is a warning that will be displayed to the user before they acknowledge the gate
-  WarningMessage String
+	// WarningMessage is a warning that will be displayed to the user before they acknowledge the gate
+	WarningMessage String
 
-  // Description of the version gate.
-  Description String
+	// Description of the version gate.
+	Description String
 
-  // DocumentationURL is the URL for the documentation of the version gate.
-  DocumentationURL String
+	// DocumentationURL is the URL for the documentation of the version gate.
+	DocumentationURL String
 
-  // STSOnly indicates if this version gate is for STS clusters only,
-  // deprecated: to be replaced with ClusterCondition
-  STSOnly Boolean
+	// STSOnly indicates if this version gate is for STS clusters only,
+	// deprecated: to be replaced with ClusterCondition
+	STSOnly Boolean
 
-  // ClusterCondition aims at selecting the clusters targeted by this version gate,
-  // ignored if STSOnly is true
-  ClusterCondition String
+	// ClusterCondition aims at selecting the clusters targeted by this version gate,
+	// ignored if STSOnly is true
+	ClusterCondition String
 
-  // CreationTimestamp is the date and time when the version gate was created,
-  // format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].
-  CreationTimestamp Date
+	// CreationTimestamp is the date and time when the version gate was created,
+	// format defined in https://www.ietf.org/rfc/rfc3339.txt[RC3339].
+	CreationTimestamp Date
 }

--- a/model/clusters_mgmt/v1/version_gates_resource.model
+++ b/model/clusters_mgmt/v1/version_gates_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_resource.model
+++ b/model/clusters_mgmt/v1/version_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/version_type.model
+++ b/model/clusters_mgmt/v1/version_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/versions_resource.model
+++ b/model/clusters_mgmt/v1/versions_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/vpc_inquiry_type.model
+++ b/model/clusters_mgmt/v1/vpc_inquiry_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/vpcs_inquiry_resource.model
+++ b/model/clusters_mgmt/v1/vpcs_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ resource VpcsInquiry {
 		out Total Integer
 
 		// Retrieved list of cloud VPC.
-   		out Items []CloudVPC
+			out Items []CloudVPC
 
 		// Cloud provider data needed for the inquiry
 		in Body CloudProviderData

--- a/model/clusters_mgmt/v1/wif_config_resource.model
+++ b/model/clusters_mgmt/v1/wif_config_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wif_config_status_resource.model
+++ b/model/clusters_mgmt/v1/wif_config_status_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wif_config_status_type.model
+++ b/model/clusters_mgmt/v1/wif_config_status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wif_config_type.model
+++ b/model/clusters_mgmt/v1/wif_config_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wif_configs_resources.model
+++ b/model/clusters_mgmt/v1/wif_configs_resources.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wif_service_account_type.model
+++ b/model/clusters_mgmt/v1/wif_service_account_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wif_support_type.model
+++ b/model/clusters_mgmt/v1/wif_support_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/wildcard_policy_type.model
+++ b/model/clusters_mgmt/v1/wildcard_policy_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/clusters_mgmt/v1/zero_egress_type.model
+++ b/model/clusters_mgmt/v1/zero_egress_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/job_queue/v1/job_resource.model
+++ b/model/job_queue/v1/job_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Manages status of jobs on a job queue.
 resource Job {
-    // Mark a job as Successful. This method returns '204 No Content'
-    method Success {
-        // A unique ID of a pop'ed job
-        in ReceiptId String
-    }
+	// Mark a job as Successful. This method returns '204 No Content'
+	method Success {
+		// A unique ID of a pop'ed job
+		in ReceiptId String
+	}
 
-    // Mark a job as Failed. This method returns '204 No Content'
-    method Failure {
-        // A unique ID of a pop'ed job
-        in ReceiptId String
-        in FailureReason String
-    }
+	// Mark a job as Failed. This method returns '204 No Content'
+	method Failure {
+		// A unique ID of a pop'ed job
+		in ReceiptId String
+		in FailureReason String
+	}
 }

--- a/model/job_queue/v1/job_type.model
+++ b/model/job_queue/v1/job_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // This struct is a job in a Job Queue.
 class Job {
-    // Arguments to run Job with.
-    Arguments String
-    // Number of retries.
-    Attempts Integer
-    // DLQ sent timestamp
-    AbandonedAt Date
-    // Each time a specific job is pop'd, the receiptId will change, while the ID stays the same.
-    ReceiptId String
-    CreatedAt Date
-    UpdatedAt Date
+	// Arguments to run Job with.
+	Arguments String
+	// Number of retries.
+	Attempts Integer
+	// DLQ sent timestamp
+	AbandonedAt Date
+	// Each time a specific job is pop'd, the receiptId will change, while the ID stays the same.
+	ReceiptId String
+	CreatedAt Date
+	UpdatedAt Date
 }

--- a/model/job_queue/v1/jobs_resource.model
+++ b/model/job_queue/v1/jobs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Manages status of jobs on a job queue.
 resource Jobs {
-    // jobs' operations (success, failure)
-    locator Job {
-        target Job
-        variable ID
-    }
+	// jobs' operations (success, failure)
+	locator Job {
+		target Job
+		variable ID
+	}
 }

--- a/model/job_queue/v1/queue_resource.model
+++ b/model/job_queue/v1/queue_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -21,34 +21,34 @@ resource Queue {
 		out Body Queue
 	}
 
-    // PUSH a new job into job queue
-    method Push {
-        out ID String
-        out Kind String
-        out HREF String
-        in out Arguments String
-        in out Attempts Integer
-        in out AbandonedAt Date
-        out ReceiptId String
-        in out CreatedAt Date
-        out UpdatedAt Date
-    }
+	// PUSH a new job into job queue
+	method Push {
+		out ID String
+		out Kind String
+		out HREF String
+		in out Arguments String
+		in out Attempts Integer
+		in out AbandonedAt Date
+		out ReceiptId String
+		in out CreatedAt Date
+		out UpdatedAt Date
+	}
 
-    // POP new job from a job queue
-    method Pop {
-        out ID String
-        out Kind String
-        out HREF String
-        out Arguments String
-        out Attempts Integer
-        out AbandonedAt Date
-        out ReceiptId String
-        out CreatedAt Date
-        out UpdatedAt Date
-    }
+	// POP new job from a job queue
+	method Pop {
+		out ID String
+		out Kind String
+		out HREF String
+		out Arguments String
+		out Attempts Integer
+		out AbandonedAt Date
+		out ReceiptId String
+		out CreatedAt Date
+		out UpdatedAt Date
+	}
 
-    // jobs' operations (success, failure)
-    locator Jobs {
-        target Jobs
-    }
+	// jobs' operations (success, failure)
+	locator Jobs {
+		target Jobs
+	}
 }

--- a/model/job_queue/v1/queue_type.model
+++ b/model/job_queue/v1/queue_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 
 class Queue {
- 	CreatedAt Date
- 	UpdatedAt Date
-    Name String
-    MaxRunTime Integer  // SQS Visibility Timeout
-    MaxAttempts Integer // SQS DLQ Max Receive Count
+		CreatedAt Date
+		UpdatedAt Date
+	Name String
+	MaxRunTime Integer  // SQS Visibility Timeout
+	MaxAttempts Integer // SQS DLQ Max Receive Count
 }

--- a/model/job_queue/v1/queues_resource.model
+++ b/model/job_queue/v1/queues_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -33,8 +33,8 @@ resource Queues {
 	}
 
 	// Returns a reference to the service that manages a specific job queue.
-    locator Queue {
-            target Queue
-            variable ID
-    }
+	locator Queue {
+			target Queue
+			variable ID
+	}
 }

--- a/model/job_queue/v1/root_resource.model
+++ b/model/job_queue/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Root of the tree of resources of the job queue service.
 resource Root {
-    // Reference to the resource that manages the collection of job queues.
+	// Reference to the resource that manages the collection of job queues.
 	locator Queues {
 		target Queues
 	}

--- a/model/osd_fleet_mgmt/v1/cluster_management_reference_type.model
+++ b/model/osd_fleet_mgmt/v1/cluster_management_reference_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/dns_type.model
+++ b/model/osd_fleet_mgmt/v1/dns_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/label_reference_type.model
+++ b/model/osd_fleet_mgmt/v1/label_reference_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // label reference settings of the cluster.
 struct LabelReference {
-  // Id of the Label associated to the OSD FM managed cluster
-  Id String
-  // link to the Label associated to the OSD FM managed cluster
-  Href String
+	// Id of the Label associated to the OSD FM managed cluster
+	Id String
+	// link to the Label associated to the OSD FM managed cluster
+	Href String
 }

--- a/model/osd_fleet_mgmt/v1/label_request_payload.model
+++ b/model/osd_fleet_mgmt/v1/label_request_payload.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 struct LabelRequestPayload {
-  Key String
-  Value String
+	Key String
+	Value String
 }

--- a/model/osd_fleet_mgmt/v1/label_resource.model
+++ b/model/osd_fleet_mgmt/v1/label_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/label_type.model
+++ b/model/osd_fleet_mgmt/v1/label_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // label settings of the cluster.
 class Label {
-    // Label key associated to the OSD FM managed cluster
-    Key String
-    // Label value associated to the OSD FM managed cluster
-    Value String
+	// Label key associated to the OSD FM managed cluster
+	Key String
+	// Label value associated to the OSD FM managed cluster
+	Value String
 }

--- a/model/osd_fleet_mgmt/v1/labels_resource.model
+++ b/model/osd_fleet_mgmt/v1/labels_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/management_cluster_parent_type.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_parent_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/management_cluster_request_payload.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_request_payload.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/management_cluster_resource.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/management_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/management_cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/management_clusters_resource.model
+++ b/model/osd_fleet_mgmt/v1/management_clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/provision_shard_reference_type.model
+++ b/model/osd_fleet_mgmt/v1/provision_shard_reference_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,8 +16,8 @@ limitations under the License.
 
 // Provision Shard Reference of the cluster.
 struct ProvisionShardReference {
-  // Id of the Provision Shards associated to the Ocluster
-  Id String
-  // link to the Provision Shards associated to the cluster
-  Href String
+	// Id of the Provision Shards associated to the Ocluster
+	Id String
+	// link to the Provision Shards associated to the cluster
+	Href String
 }

--- a/model/osd_fleet_mgmt/v1/root_resource.model
+++ b/model/osd_fleet_mgmt/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/service_cluster_request_payload.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_request_payload.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/service_cluster_resource.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/service_cluster_type.model
+++ b/model/osd_fleet_mgmt/v1/service_cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/osd_fleet_mgmt/v1/service_clusters_resource.model
+++ b/model/osd_fleet_mgmt/v1/service_clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_logs/v1/cluster_log_resource.model
+++ b/model/service_logs/v1/cluster_log_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_logs/v1/cluster_log_type.model
+++ b/model/service_logs/v1/cluster_log_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_logs/v1/cluster_logs_resource.model
+++ b/model/service_logs/v1/cluster_logs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,7 +49,7 @@ resource ClusterLogs {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the cluster logs
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve cluster logs with service_name starting with my:
+			// retrieve cluster logs with service_name starting with my:
 		//
 		// ```sql
 		// service_name like 'my%'

--- a/model/service_logs/v1/cluster_logs_uuid_resource.model
+++ b/model/service_logs/v1/cluster_logs_uuid_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,7 +47,7 @@ resource ClusterLogsUUID {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the cluster logs
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve cluster logs with service_name starting with my:
+			// retrieve cluster logs with service_name starting with my:
 		//
 		// ```sql
 		// service_name like 'my%'

--- a/model/service_logs/v1/cluster_resource.model
+++ b/model/service_logs/v1/cluster_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_logs/v1/clusters_cluster_logs_resource.model
+++ b/model/service_logs/v1/clusters_cluster_logs_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,7 +49,7 @@ resource ClustersClusterLogs {
 		// The syntax of this parameter is similar to the syntax of the _where_ clause
 		// of an SQL statement, but using the names of the attributes of the cluster logs
 		// instead of the names of the columns of a table. For example, in order to
-	        // retrieve cluster logs with service_name starting with my:
+			// retrieve cluster logs with service_name starting with my:
 		//
 		// ```sql
 		// service_name like 'my%'

--- a/model/service_logs/v1/clusters_resource.model
+++ b/model/service_logs/v1/clusters_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_logs/v1/log_type_type.model
+++ b/model/service_logs/v1/log_type_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_logs/v1/root_resource.model
+++ b/model/service_logs/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/aws_type.model
+++ b/model/service_mgmt/v1/aws_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/cloud_region_type.model
+++ b/model/service_mgmt/v1/cloud_region_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/cluster_api_type.model
+++ b/model/service_mgmt/v1/cluster_api_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/cluster_nodes_type.model
+++ b/model/service_mgmt/v1/cluster_nodes_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/cluster_type.model
+++ b/model/service_mgmt/v1/cluster_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,10 +16,10 @@ limitations under the License.
 
 // This represents the parameters needed by Managed Service to create a cluster.
 struct Cluster {
-  id String
-  href String
+	id String
+	href String
 	Name String
-  State String
+	State String
 	// DisplayName is the name of the cluster for display purposes.
 	// It can contain spaces.
 	DisplayName String

--- a/model/service_mgmt/v1/instance_iam_roles_type.model
+++ b/model/service_mgmt/v1/instance_iam_roles_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/listening_method_type.model
+++ b/model/service_mgmt/v1/listening_method_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/managed_service_type.model
+++ b/model/service_mgmt/v1/managed_service_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,13 @@ limitations under the License.
 
 // Represents data about a running Managed Service.
 class ManagedService {
-  Service String
-  ServiceState String
-  Parameters []ServiceParameter
-  Cluster Cluster
-  Resources []StatefulObject
-  Addon StatefulObject
-  CreatedAt  Date
-  UpdatedAt  Date
-  ExpiredAt  Date
+	Service String
+	ServiceState String
+	Parameters []ServiceParameter
+	Cluster Cluster
+	Resources []StatefulObject
+	Addon StatefulObject
+	CreatedAt  Date
+	UpdatedAt  Date
+	ExpiredAt  Date
 }

--- a/model/service_mgmt/v1/network_type.model
+++ b/model/service_mgmt/v1/network_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/operator_iam_role_type.model
+++ b/model/service_mgmt/v1/operator_iam_role_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/root_resource.model
+++ b/model/service_mgmt/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/service_parameter_type.model
+++ b/model/service_mgmt/v1/service_parameter_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/model/service_mgmt/v1/service_resource.model
+++ b/model/service_mgmt/v1/service_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Manages a Managed Service.
 resource ManagedService {
-  // Gets information on the Managed Service
-  method Get {
-    out Body ManagedService
-  }
+	// Gets information on the Managed Service
+	method Get {
+	out Body ManagedService
+	}
 
-  method Update {
-    in out Body ManagedService
-  }
+	method Update {
+	in out Body ManagedService
+	}
 
-  // Deletes the Managed Service
-  method Delete {
-  }
+	// Deletes the Managed Service
+	method Delete {
+	}
 }

--- a/model/service_mgmt/v1/services_resource.model
+++ b/model/service_mgmt/v1/services_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,7 +43,7 @@ resource Services {
 		variable ID
 	}
 
-  locator VersionInquiry {
-    target VersionInquiry
-  }
+	locator VersionInquiry {
+	target VersionInquiry
+	}
 }

--- a/model/service_mgmt/v1/stateful_object_type.model
+++ b/model/service_mgmt/v1/stateful_object_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 struct StatefulObject {
-  ID string
-  Kind string
-  Href string
-  State String
+	ID string
+	Kind string
+	Href string
+	State String
 }

--- a/model/service_mgmt/v1/version_inquiry_request_type.model
+++ b/model/service_mgmt/v1/version_inquiry_request_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 struct VersionInquiryRequest {
-  ServiceType String
+	ServiceType String
 }

--- a/model/service_mgmt/v1/version_inquiry_resource.model
+++ b/model/service_mgmt/v1/version_inquiry_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Used to check the Openshift version a service will use.
 resource VersionInquiry {
-  // Returns the Openshift version a service of this type will use.
-  method Post {
-    in Body VersionInquiryRequest
-    out Body VersionInquiryResponse
-  }
+	// Returns the Openshift version a service of this type will use.
+	method Post {
+	in Body VersionInquiryRequest
+	out Body VersionInquiryResponse
+	}
 }

--- a/model/service_mgmt/v1/version_inquiry_response_type.model
+++ b/model/service_mgmt/v1/version_inquiry_response_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 struct VersionInquiryResponse {
-  Version String
+	Version String
 }

--- a/model/status_board/v1/application_dependencies_resource.model
+++ b/model/status_board/v1/application_dependencies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Manages the collection of applications.
 resource ApplicationDependencies {
-  // Retrieves the list of application dependencies.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    out Total Integer
-    out Items []ApplicationDependency
-  }
+	// Retrieves the list of application dependencies.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	out Total Integer
+	out Items []ApplicationDependency
+	}
 
-  method Add {
-    in out Body ApplicationDependency
-  }
+	method Add {
+	in out Body ApplicationDependency
+	}
 
-  locator ApplicationDependency {
-    target ApplicationDependency
-    variable ID
-  }
+	locator ApplicationDependency {
+	target ApplicationDependency
+	variable ID
+	}
 }

--- a/model/status_board/v1/application_dependency_resource.model
+++ b/model/status_board/v1/application_dependency_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about the specified application dependency.
 resource ApplicationDependency {
-  method Get {
-    out Body ApplicationDependency
-  }
+	method Get {
+	out Body ApplicationDependency
+	}
 
-  method Update {
-    in out Body ApplicationDependency
-  }
+	method Update {
+	in out Body ApplicationDependency
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/status_board/v1/application_dependency_type.model
+++ b/model/status_board/v1/application_dependency_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,27 @@ limitations under the License.
 
 // Definition of a Status Board application dependency.
 class ApplicationDependency {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The name of the application. 
-  Name String
+	// The name of the application. 
+	Name String
 
-  // Miscellaneous metadata about the application.
-  Metadata Interface
+	// Miscellaneous metadata about the application.
+	Metadata Interface
 
-  // The type of application dependency, e.g. soft or hard.
-  Type String
+	// The type of application dependency, e.g. soft or hard.
+	Type String
 
-  // The Service associated with the dependency.
-  Service Service
+	// The Service associated with the dependency.
+	Service Service
 
-  // The parent Application of the dependency.
-  Application Application
+	// The parent Application of the dependency.
+	Application Application
 
-  // The application dependency owners (name and email)
-  Owners []Owner
+	// The application dependency owners (name and email)
+	Owners []Owner
 }

--- a/model/status_board/v1/application_resource.model
+++ b/model/status_board/v1/application_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Provides detailed information about the specified application.
 resource Application {
-  method Get {
-    out Body Application
-  }
+	method Get {
+	out Body Application
+	}
 
-  method Update {
-    in out Body Application
-  }
+	method Update {
+	in out Body Application
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 
-  locator Services {
-    target Services
-  }
+	locator Services {
+	target Services
+	}
 }

--- a/model/status_board/v1/application_type.model
+++ b/model/status_board/v1/application_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,24 +16,24 @@ limitations under the License.
 
 // Definition of a Status Board application.
 class Application {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The name of the application. 
-  Name String
+	// The name of the application. 
+	Name String
 
-  // The group ID that the application belongs to. 
-  Product Product
+	// The group ID that the application belongs to. 
+	Product Product
 
-  // Miscellaneous metadata about the application.
-  Metadata Interface
+	// Miscellaneous metadata about the application.
+	Metadata Interface
 
-  // The full name of the application. 
-  Fullname String
+	// The full name of the application. 
+	Fullname String
 
-  // The application owners (name and email)
-  Owners []Owner
+	// The application owners (name and email)
+	Owners []Owner
 }

--- a/model/status_board/v1/applications_resource.model
+++ b/model/status_board/v1/applications_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,22 @@ limitations under the License.
 
 // Manages the collection of applications.
 resource Applications {
-  // Retrieves the list of applications.
-  method List {
-    in OrderBy String
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in Search String
-    out Total Integer
-    out Items []Application
-  }
+	// Retrieves the list of applications.
+	method List {
+	in OrderBy String
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in Search String
+	out Total Integer
+	out Items []Application
+	}
 
-  method Add {
-    in out Body Application
-  }
+	method Add {
+	in out Body Application
+	}
 
-  locator Application {
-    target Application
-    variable ID
-  }
+	locator Application {
+	target Application
+	variable ID
+	}
 }

--- a/model/status_board/v1/error_resource.model
+++ b/model/status_board/v1/error_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Provides detailed information about a specific error.
 resource Error {
-  method Get {
-    out Body Error
-  }
+	method Get {
+	out Body Error
+	}
 }

--- a/model/status_board/v1/error_type.model
+++ b/model/status_board/v1/error_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Definition of a Status Board error.
 class Error {
-  Code String
-  Reason String
+	Code String
+	Reason String
 }

--- a/model/status_board/v1/errors_resource.model
+++ b/model/status_board/v1/errors_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Manages the collection of errors.
 resource Errors {
-  // Retrieves the list of errors.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    out Total Integer
-    out Items []Error
-  }
+	// Retrieves the list of errors.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	out Total Integer
+	out Items []Error
+	}
 
-  locator Error {
-    target Error
-    variable ID
-  }
+	locator Error {
+	target Error
+	variable ID
+	}
 }

--- a/model/status_board/v1/owner_type.model
+++ b/model/status_board/v1/owner_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Definition of a Status Board owner.
 class Owner {
-  // The owner's username.
-  Username String
+	// The owner's username.
+	Username String
 
-  // The owner's email address.
-  Email String
+	// The owner's email address.
+	Email String
 }

--- a/model/status_board/v1/peer_dependencies_resource.model
+++ b/model/status_board/v1/peer_dependencies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Manages the collection of peer dependencies.
 resource PeerDependencies {
-  // Retrieves the list of peer dependencies.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    out Total Integer
-    out Items []PeerDependency
-  }
+	// Retrieves the list of peer dependencies.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	out Total Integer
+	out Items []PeerDependency
+	}
 
-  method Add {
-    in out Body PeerDependency
-  }
+	method Add {
+	in out Body PeerDependency
+	}
 
-  locator PeerDependency {
-    target PeerDependency
-    variable ID
-  }
+	locator PeerDependency {
+	target PeerDependency
+	variable ID
+	}
 }

--- a/model/status_board/v1/peer_dependency_resource.model
+++ b/model/status_board/v1/peer_dependency_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about the specified peer dependency.
 resource PeerDependency  {
-  method Get {
-    out Body Service
-  }
+	method Get {
+	out Body Service
+	}
 
-  method Update {
-    in out Body PeerDependency
-  }
+	method Update {
+	in out Body PeerDependency
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/status_board/v1/peer_dependency_type.model
+++ b/model/status_board/v1/peer_dependency_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Definition of a Status Board peer dependency.
 class PeerDependency {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The name of the peer dependency.
-  Name String
+	// The name of the peer dependency.
+	Name String
 
-  // Miscellaneous metadata about the peer dependency.
-  Metadata Interface
+	// Miscellaneous metadata about the peer dependency.
+	Metadata Interface
 
-  // Services associated with the peer dependency.
-  Services []Service
+	// Services associated with the peer dependency.
+	Services []Service
 
-  // The peer dependency owners (name and email)
-  Owners []Owner
+	// The peer dependency owners (name and email)
+	Owners []Owner
 }

--- a/model/status_board/v1/product_resource.model
+++ b/model/status_board/v1/product_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,22 @@ limitations under the License.
 
 // Provides detailed information about a specific product.
 resource Product {
-  method Get {
-    out Body Product
-  }
+	method Get {
+	out Body Product
+	}
 
-  method Update {
-    in out Body Product
-  }
+	method Update {
+	in out Body Product
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 
-  locator Applications {
-    target Applications
-  }
+	locator Applications {
+	target Applications
+	}
 
-  locator Updates {
-    target Statuses
-  }
+	locator Updates {
+	target Statuses
+	}
 }

--- a/model/status_board/v1/product_type.model
+++ b/model/status_board/v1/product_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Definition of a Status Board product.
 class Product {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The name of the product.
-  Name String
+	// The name of the product.
+	Name String
 
-  // Miscellaneous data about the product.
-  Metadata Interface
+	// Miscellaneous data about the product.
+	Metadata Interface
 
-  // The fullname of the product.
-  Fullname String
+	// The fullname of the product.
+	Fullname String
 
-  // The product owners (name and email).
-  Owners []Owner
+	// The product owners (name and email).
+	Owners []Owner
 }

--- a/model/status_board/v1/products_resource.model
+++ b/model/status_board/v1/products_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,22 @@ limitations under the License.
 
 // Manages the collection of products.
 resource Products {
-  // Retrieves the list of products.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    in Search String
-    out Total Integer
-    out Items []Product
-  }
+	// Retrieves the list of products.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	in Search String
+	out Total Integer
+	out Items []Product
+	}
 
-  method Add {
-    in out Body Product
-  }
+	method Add {
+	in out Body Product
+	}
 
-  locator Product {
-    target Product
-    variable ID
-  }
+	locator Product {
+	target Product
+	variable ID
+	}
 }

--- a/model/status_board/v1/root_resource.model
+++ b/model/status_board/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,35 +16,35 @@ limitations under the License.
 
 // Root of the tree of resources for applications.
 resource Root {
-  locator Applications {
-    target Applications
-  }
+	locator Applications {
+	target Applications
+	}
 
-  locator ApplicationDependencies {
-    target ApplicationDependencies
-  }
+	locator ApplicationDependencies {
+	target ApplicationDependencies
+	}
 
-  locator PeerDependencies {
-    target PeerDependencies
-  }
+	locator PeerDependencies {
+	target PeerDependencies
+	}
 
-  locator Products {
-    target Products 
-  }
+	locator Products {
+	target Products 
+	}
 
-  locator Services {
-    target Services 
-  }
+	locator Services {
+	target Services 
+	}
 
-  locator Statuses {
-    target Statuses
-  }
+	locator Statuses {
+	target Statuses
+	}
 
-  locator StatusUpdates {
-    target Statuses
-  }
+	locator StatusUpdates {
+	target Statuses
+	}
 
-  locator Errors {
-    target Errors
-  }
+	locator Errors {
+	target Errors
+	}
 }

--- a/model/status_board/v1/service_dependencies_resource.model
+++ b/model/status_board/v1/service_dependencies_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Manages the collection of service dependencies.
 resource ServiceDependencies {
-  // Retrieves the list of service dependencies.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    out Total Integer
-    out Items []ServiceDependency
-  }
+	// Retrieves the list of service dependencies.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	out Total Integer
+	out Items []ServiceDependency
+	}
 
-  method Add {
-    in out Body ServiceDependency
-  }
+	method Add {
+	in out Body ServiceDependency
+	}
 
-  locator ServiceDependency {
-    target ServiceDependency
-    variable ID
-  }
+	locator ServiceDependency {
+	target ServiceDependency
+	variable ID
+	}
 }

--- a/model/status_board/v1/service_dependency_resource.model
+++ b/model/status_board/v1/service_dependency_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about the specified application dependency.
 resource ServiceDependency {
-  method Get {
-    out Body ServiceDependency
-  }
+	method Get {
+	out Body ServiceDependency
+	}
 
-  method Update {
-    in out Body ServiceDependency
-  }
+	method Update {
+	in out Body ServiceDependency
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/status_board/v1/service_dependency_type.model
+++ b/model/status_board/v1/service_dependency_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,27 @@ limitations under the License.
 
 // Definition of a Status Board service dependency.
 class ServiceDependency {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The name of the service dependency.
-  Name String
+	// The name of the service dependency.
+	Name String
 
-  // The type of service dependency, e.g. soft or hard.
-  Type String
+	// The type of service dependency, e.g. soft or hard.
+	Type String
 
-  // Miscellaneous metadata about the service dependency.
-  Metadata Interface
+	// Miscellaneous metadata about the service dependency.
+	Metadata Interface
 
-  // The service dependency's parent service
-  ParentService Service
+	// The service dependency's parent service
+	ParentService Service
 
-  // The service dependency's child service
-  ChildService Service
+	// The service dependency's child service
+	ChildService Service
 
-  // The service dependency owners (name and email)
-  Owners []Owner
+	// The service dependency owners (name and email)
+	Owners []Owner
 }

--- a/model/status_board/v1/service_info_type.model
+++ b/model/status_board/v1/service_info_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,9 +16,9 @@ limitations under the License.
 
 // Definition of a Status Board service info.
 struct ServiceInfo {
-  // Full name of the service
-  Fullname String
+	// Full name of the service
+	Fullname String
 
-  // Type of the service status
-  StatusType String
+	// Type of the service status
+	StatusType String
 }

--- a/model/status_board/v1/service_resource.model
+++ b/model/status_board/v1/service_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Provides detailed information about the specified service.
 resource Service  {
-  method Get {
-    out Body Service
-  }
+	method Get {
+	out Body Service
+	}
 
-  method Update {
-    in out Body Service
-  }
+	method Update {
+	in out Body Service
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 
-  locator Statuses {
-    target Statuses
-  }
+	locator Statuses {
+	target Statuses
+	}
 }

--- a/model/status_board/v1/service_type.model
+++ b/model/status_board/v1/service_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,35 +16,35 @@ limitations under the License.
 
 // Definition of a Status Board Service.
 class Service {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The Application associated with the Service
-  Application Application
+	// The Application associated with the Service
+	Application Application
 
-  // The name of the Service
-  Name String
+	// The name of the Service
+	Name String
 
-  ServiceEndpoint String
+	ServiceEndpoint String
 
-  StatusType String
+	StatusType String
 
-  LastPingAt Date
+	LastPingAt Date
 
-  CurrentStatus String
+	CurrentStatus String
 
-  StatusUpdatedAt Date
+	StatusUpdatedAt Date
 
-  Metadata Interface
+	Metadata Interface
 
-  Private Boolean
+	Private Boolean
 
-  Token String
+	Token String
 
-  Fullname String
+	Fullname String
 
-  Owners []Owner
+	Owners []Owner
 }

--- a/model/status_board/v1/services_resource.model
+++ b/model/status_board/v1/services_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,23 +16,23 @@ limitations under the License.
 
 // Manages the collection of services.
 resource Services {
-  // Retrieves the list of services.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    in Mine Boolean
-    in Search String
-    out Total Integer
-    out Items []Service
-  }
+	// Retrieves the list of services.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	in Mine Boolean
+	in Search String
+	out Total Integer
+	out Items []Service
+	}
 
-  method Add {
-    in out Body Service
-  }
+	method Add {
+	in out Body Service
+	}
 
-  locator Service {
-    target Service
-    variable ID
-  }
+	locator Service {
+	target Service
+	variable ID
+	}
 }

--- a/model/status_board/v1/status_resource.model
+++ b/model/status_board/v1/status_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about the specified status.
 resource Status {
-  method Get {
-    out Body Status
-  }
+	method Get {
+	out Body Status
+	}
 
-  method Update {
-    in out Body Status
-  }
+	method Update {
+	in out Body Status
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/status_board/v1/status_type.model
+++ b/model/status_board/v1/status_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,21 +16,21 @@ limitations under the License.
 
 // Definition of a Status Board status.
 class Status {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The associated service ID.
-  Service Service
+	// The associated service ID.
+	Service Service
 
-  // Additional Service related data.
-  ServiceInfo ServiceInfo
+	// Additional Service related data.
+	ServiceInfo ServiceInfo
 
-  // A status message for the given service.
-  Status String
+	// A status message for the given service.
+	Status String
 
-  // Miscellaneous metadata about the application.
-  Metadata Interface
+	// Miscellaneous metadata about the application.
+	Metadata Interface
 }

--- a/model/status_board/v1/status_update_resource.model
+++ b/model/status_board/v1/status_update_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about the specified status.
 resource StatusUpdate {
-  method Get {
-    out Body Status
-  }
+	method Get {
+	out Body Status
+	}
 
-  method Update {
-    in out Body Status
-  }
+	method Update {
+	in out Body Status
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/status_board/v1/status_update_type.model
+++ b/model/status_board/v1/status_update_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,21 +18,21 @@ limitations under the License.
 // its own endpoint.
 
 class StatusUpdate {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // The associated service ID.
-  Service Service
+	// The associated service ID.
+	Service Service
 
-  // Additional Service related data.
-  ServiceInfo ServiceInfo
+	// Additional Service related data.
+	ServiceInfo ServiceInfo
 
-  // A status message for the given service.
-  Status String
+	// A status message for the given service.
+	Status String
 
-  // Miscellaneous metadata about the application.
-  Metadata Interface
+	// Miscellaneous metadata about the application.
+	Metadata Interface
 }

--- a/model/status_board/v1/status_updates_resource.model
+++ b/model/status_board/v1/status_updates_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,27 +16,27 @@ limitations under the License.
 
 // Manages the collection of statuses
 resource StatusUpdates {
-  // Retrieves the list of statuses.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in CreatedAfter Date
-    in CreatedBefore Date
-    in LimitScope Date
-    in ProductIds String
-    in FullNames String
-    in Search String
-    in FlapDetection Boolean
-    out Total Integer
-    out Items []Status
-  }
+	// Retrieves the list of statuses.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in CreatedAfter Date
+	in CreatedBefore Date
+	in LimitScope Date
+	in ProductIds String
+	in FullNames String
+	in Search String
+	in FlapDetection Boolean
+	out Total Integer
+	out Items []Status
+	}
 
-  method Add {
-    in out Body Status
-  }
+	method Add {
+	in out Body Status
+	}
 
-  locator Status {
-    target Status
-    variable ID
-  }
+	locator Status {
+	target Status
+	variable ID
+	}
 }

--- a/model/status_board/v1/statuses_resource.model
+++ b/model/status_board/v1/statuses_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,26 +16,26 @@ limitations under the License.
 
 // Manages the collection of statuses
 resource Statuses {
-  // Retrieves the list of statuses.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in CreatedAfter Date
-    in CreatedBefore Date
-    in LimitScope Date
-    in ProductIds String
-    in FullNames String
-    in FlapDetection Boolean
-    out Total Integer
-    out Items []Status
-  }
+	// Retrieves the list of statuses.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in CreatedAfter Date
+	in CreatedBefore Date
+	in LimitScope Date
+	in ProductIds String
+	in FullNames String
+	in FlapDetection Boolean
+	out Total Integer
+	out Items []Status
+	}
 
-  method Add {
-    in out Body Status
-  }
+	method Add {
+	in out Body Status
+	}
 
-  locator Status {
-    target Status
-    variable ID
-  }
+	locator Status {
+	target Status
+	variable ID
+	}
 }

--- a/model/web_rca/v1/attachment_resource.model
+++ b/model/web_rca/v1/attachment_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about a specific attachment.
 resource Attachment {
-  method Get {
-    out Body Attachment
-  }
+	method Get {
+	out Body Attachment
+	}
 
-  method Update {
-    in out Body Attachment
-  }
+	method Update {
+	in out Body Attachment
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/web_rca/v1/attachment_type.model
+++ b/model/web_rca/v1/attachment_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Definition of a Web RCA attachment.
 class Attachment {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  Creator User
-  Event Event
-  FileSize Integer
-  Name String
-  ContentType String
+	Creator User
+	Event Event
+	FileSize Integer
+	Name String
+	ContentType String
 }

--- a/model/web_rca/v1/attachments_resource.model
+++ b/model/web_rca/v1/attachments_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Manages the collection of attachments.
 resource Attachments {
-  // Retrieves the list of attachments
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    out Total Integer
-    out Items []Attachment
-  }
+	// Retrieves the list of attachments
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	out Total Integer
+	out Items []Attachment
+	}
 
-  locator Attachment {
-    target Attachment
-    variable ID
-  }
+	locator Attachment {
+	target Attachment
+	variable ID
+	}
 }

--- a/model/web_rca/v1/error_resource.model
+++ b/model/web_rca/v1/error_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Provides detailed information about a specific error.
 resource Error {
-  method Get {
-    out Body Error
-  }
+	method Get {
+	out Body Error
+	}
 }

--- a/model/web_rca/v1/error_type.model
+++ b/model/web_rca/v1/error_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@ limitations under the License.
 
 // Definition of a Web RCA error.
 class Error {
-  Code String
-  Reason String
+	Code String
+	Reason String
 }

--- a/model/web_rca/v1/errors_resource.model
+++ b/model/web_rca/v1/errors_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Manages the collection of errors.
 resource Errors {
-  // Retrieves the list of errors.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    out Total Integer
-    out Items []Error
-  }
+	// Retrieves the list of errors.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	out Total Integer
+	out Items []Error
+	}
 
-  locator Error {
-    target Error
-    variable ID
-  }
+	locator Error {
+	target Error
+	variable ID
+	}
 }

--- a/model/web_rca/v1/escalation_type.model
+++ b/model/web_rca/v1/escalation_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Definition of a Web RCA escalation.
 class Escalation {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  User User
+	User User
 }

--- a/model/web_rca/v1/event_resource.model
+++ b/model/web_rca/v1/event_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Provides detailed information about a specific event.
 resource Event {
-  method Get {
-    out Body Event
-  }
+	method Get {
+	out Body Event
+	}
 
-  method Update {
-    in out Body Event
-  }
+	method Update {
+	in out Body Event
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 
-  locator Attachments {
-    target Attachments
-  }
+	locator Attachments {
+	target Attachments
+	}
 }

--- a/model/web_rca/v1/event_type.model
+++ b/model/web_rca/v1/event_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,23 +16,23 @@ limitations under the License.
 
 // Definition of a Web RCA event.
 class Event {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  Incident Incident
-  Note String
-  EventType String
-  FollowUp FollowUp
-  ExternalReferenceUrl String
-  Creator User
-  Handoff Handoff
-  StatusChange StatusChange
-  FollowUpChange FollowUpChange
-  Escalation Escalation
+	Incident Incident
+	Note String
+	EventType String
+	FollowUp FollowUp
+	ExternalReferenceUrl String
+	Creator User
+	Handoff Handoff
+	StatusChange StatusChange
+	FollowUpChange FollowUpChange
+	Escalation Escalation
 }

--- a/model/web_rca/v1/events_resource.model
+++ b/model/web_rca/v1/events_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,22 +16,22 @@ limitations under the License.
 
 // Manages the collection of events.
 resource Events {
-  // Retrieves the list of events
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    in Note String
-    in CreatedAfter Date
-    in CreatedBefore Date
-    in ShowSystemEvents Boolean
-    in EventType String
-    out Total Integer
-    out Items []Event
-  }
+	// Retrieves the list of events
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	in Note String
+	in CreatedAfter Date
+	in CreatedBefore Date
+	in ShowSystemEvents Boolean
+	in EventType String
+	out Total Integer
+	out Items []Event
+	}
 
-  locator Event {
-    target Event
-    variable ID
-  }
+	locator Event {
+	target Event
+	variable ID
+	}
 }

--- a/model/web_rca/v1/follow_up_change_type.model
+++ b/model/web_rca/v1/follow_up_change_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Definition of a Web RCA event.
 class FollowUpChange {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  FollowUp FollowUp
-  Status  Interface
+	FollowUp FollowUp
+	Status  Interface
 }

--- a/model/web_rca/v1/follow_up_resource.model
+++ b/model/web_rca/v1/follow_up_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about a specific follow-up.
 resource FollowUp {
-  method Get {
-    out Body FollowUp
-  }
+	method Get {
+	out Body FollowUp
+	}
 
-  method Update {
-    in out Body FollowUp
-  }
+	method Update {
+	in out Body FollowUp
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/web_rca/v1/follow_up_type.model
+++ b/model/web_rca/v1/follow_up_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,23 +16,23 @@ limitations under the License.
 
 // Definition of a Web RCA event.
 class FollowUp {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  Incident Incident
-  Url String
-  FollowUpType String
-  Status String
-  Done Boolean
-  Title String
-  Priority String
-  Owner String
-  WorkedAt Date
-  Archived Boolean
+	Incident Incident
+	Url String
+	FollowUpType String
+	Status String
+	Done Boolean
+	Title String
+	Priority String
+	Owner String
+	WorkedAt Date
+	Archived Boolean
 }

--- a/model/web_rca/v1/follow_ups_resource.model
+++ b/model/web_rca/v1/follow_ups_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,19 +17,19 @@ limitations under the License.
 // Manages the collection of follow-ups.
 resource FollowUps {
 // Retrieves the list of follow-ups
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    in CreatedAfter Date
-    in CreatedBefore Date
-    in FollowUpStatus String
-    out Total Integer
-    out Items []FollowUp
-  }
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	in CreatedAfter Date
+	in CreatedBefore Date
+	in FollowUpStatus String
+	out Total Integer
+	out Items []FollowUp
+	}
 
-  locator FollowUp {
-    target FollowUp
-    variable ID
-  }
+	locator FollowUp {
+	target FollowUp
+	variable ID
+	}
 }

--- a/model/web_rca/v1/handoff_type.model
+++ b/model/web_rca/v1/handoff_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Definition of a Web RCA handoff.
 class Handoff {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  HandoffFrom User
-  HandoffTo User
-  HandoffType String
+	HandoffFrom User
+	HandoffTo User
+	HandoffType String
 }

--- a/model/web_rca/v1/incident_resource.model
+++ b/model/web_rca/v1/incident_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,26 +16,26 @@ limitations under the License.
 
 // Provides detailed information about a specific incident.
 resource Incident {
-  method Get {
-    out Body Incident
-  }
+	method Get {
+	out Body Incident
+	}
 
-  method Update {
-    in out Body Incident
-  }
+	method Update {
+	in out Body Incident
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 
-  locator Events {
-    target Events
-  }
+	locator Events {
+	target Events
+	}
 
-  locator FollowUps {
-    target FollowUps
-  }
+	locator FollowUps {
+	target FollowUps
+	}
 
-  locator Notifications {
-    target Notifications
-  }
+	locator Notifications {
+	target Notifications
+	}
 }

--- a/model/web_rca/v1/incident_type.model
+++ b/model/web_rca/v1/incident_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,24 +16,24 @@ limitations under the License.
 
 // Definition of a Web RCA incident.
 class Incident {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  IncidentType String
-  Summary String
-  IncidentId String
-  Status String
-  Severity String
-  PrimaryTeam String
-  CreatorId String
-  LastUpdated Date
-  Description String
-  ExternalCoordination []String
-  WorkedAt Date
+	IncidentType String
+	Summary String
+	IncidentId String
+	Status String
+	Severity String
+	PrimaryTeam String
+	CreatorId String
+	LastUpdated Date
+	Description String
+	ExternalCoordination []String
+	WorkedAt Date
 }

--- a/model/web_rca/v1/incidents_resource.model
+++ b/model/web_rca/v1/incidents_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,31 +16,31 @@ limitations under the License.
 
 // Manages the collection of incidents.
 resource Incidents {
-  // Retrieves the list of incidents.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    in PublicId String
-    in CreatorId String
-    in IncidentCommanderId String
-    in ProductId String
-    in OnCallId String
-    in ResponsibleManagerId String
-    in ParticipantId String
-    in Mine Boolean
-    in Status String
-    in IncidentName String
-    out Total Integer
-    out Items []Incident
-  }
+	// Retrieves the list of incidents.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	in PublicId String
+	in CreatorId String
+	in IncidentCommanderId String
+	in ProductId String
+	in OnCallId String
+	in ResponsibleManagerId String
+	in ParticipantId String
+	in Mine Boolean
+	in Status String
+	in IncidentName String
+	out Total Integer
+	out Items []Incident
+	}
 
-  method Add {
-    in out Body Incident
-  }
+	method Add {
+	in out Body Incident
+	}
 
-  locator Incident {
-    target Incident
-    variable ID
-  }
+	locator Incident {
+	target Incident
+	variable ID
+	}
 }

--- a/model/web_rca/v1/notification_resource.model
+++ b/model/web_rca/v1/notification_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,14 +16,14 @@ limitations under the License.
 
 // Provides detailed information about a specific notification.
 resource Notification {
-  method Get {
-    out Body Notification
-  }
+	method Get {
+	out Body Notification
+	}
 
-  method Update {
-    in out Body Notification
-  }
+	method Update {
+	in out Body Notification
+	}
 
-  method Delete {
-  }
+	method Delete {
+	}
 }

--- a/model/web_rca/v1/notification_type.model
+++ b/model/web_rca/v1/notification_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Definition of a Web RCA notification.
 class Notification {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  Name String
-  Incident Incident
-  Checked Boolean
-  Rank Integer
+	Name String
+	Incident Incident
+	Checked Boolean
+	Rank Integer
 }

--- a/model/web_rca/v1/notifications_resource.model
+++ b/model/web_rca/v1/notifications_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Manages the collection of notifications.
 resource Notifications {
-  // Retrieves the list of notifications
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in Checked Boolean
-    out Total Integer
-    out Items []Notification
-  }
+	// Retrieves the list of notifications
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in Checked Boolean
+	out Total Integer
+	out Items []Notification
+	}
 
-  locator Notification {
-    target Notification
-    variable ID
-  }
+	locator Notification {
+	target Notification
+	variable ID
+	}
 }

--- a/model/web_rca/v1/product_type.model
+++ b/model/web_rca/v1/product_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +16,18 @@ limitations under the License.
 
 // Definition of a Web RCA product.
 class Product {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  // The name of the product from status-board.
-  ProductName String
+	// The name of the product from status-board.
+	ProductName String
 
-  // The product ID from status board
-  ProductId String
+	// The product ID from status board
+	ProductId String
 }

--- a/model/web_rca/v1/root_resource.model
+++ b/model/web_rca/v1/root_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,15 +16,15 @@ limitations under the License.
 
 // Root of the tree of resources for applications.
 resource Root {
-  locator Incidents {
-    target Incidents 
-  }
+	locator Incidents {
+	target Incidents 
+	}
 
-  locator Users {
-    target Users
-  }
+	locator Users {
+	target Users
+	}
 
-  locator Errors {
-    target Errors
-  }
+	locator Errors {
+	target Errors
+	}
 }

--- a/model/web_rca/v1/status_change_type.model
+++ b/model/web_rca/v1/status_change_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,16 +16,16 @@ limitations under the License.
 
 // Definition of a Web RCA event.
 class StatusChange {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  StatusId String
+	StatusId String
 
-  Status Interface 
+	Status Interface 
 }

--- a/model/web_rca/v1/user_resource.model
+++ b/model/web_rca/v1/user_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Provides detailed information about a specific user.
 resource User {
-  method Get {
-    out Body User
-  }
+	method Get {
+	out Body User
+	}
 }

--- a/model/web_rca/v1/user_type.model
+++ b/model/web_rca/v1/user_type.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Definition of a Web RCA user.
 class User {
-  // Object creation timestamp.
-  CreatedAt Date
+	// Object creation timestamp.
+	CreatedAt Date
 
-  // Object modification timestamp.
-  UpdatedAt Date
+	// Object modification timestamp.
+	UpdatedAt Date
 
-  // Object deletion timestamp.
-  DeletedAt Date
+	// Object deletion timestamp.
+	DeletedAt Date
 
-  Username String
-  Name String
-  Email String
-  FromAuth Boolean
+	Username String
+	Name String
+	Email String
+	FromAuth Boolean
 }

--- a/model/web_rca/v1/users_resource.model
+++ b/model/web_rca/v1/users_resource.model
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,17 +16,17 @@ limitations under the License.
 
 // Manages the collection of users.
 resource Users {
-  // Retrieves the list of users.
-  method List {
-    in out Page Integer = 1
-    in out Size Integer = 100
-    in OrderBy String
-    out Total Integer
-    out Items []User
-  }
+	// Retrieves the list of users.
+	method List {
+	in out Page Integer = 1
+	in out Size Integer = 100
+	in OrderBy String
+	out Total Integer
+	out Items []User
+	}
 
-  locator User {
-    target User
-    variable ID
-  }
+	locator User {
+	target User
+	variable ID
+	}
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -4920,6 +4920,10 @@
             "description": "Network settings of the cluster.",
             "$ref": "#/components/schemas/Network"
           },
+          "node_ssh_public_key": {
+            "description": "The SSH public key used for secure access to cluster nodes. When set, this key\nis distributed to all nodes, enabling SSH access for debugging\nand maintenance purposes.\nThis is currently only supported for ARO HCP",
+            "type": "string"
+          },
           "node_drain_grace_period": {
             "description": "Node drain grace period.",
             "$ref": "#/components/schemas/Value"


### PR DESCRIPTION
## Description

To get `make lint` produce no errors (on MacOs / BSD), I had to change a lot of whitespaces. Not sure if this is right, maybe instead the `make lint` implementation should be updated?

Merge after https://github.com/openshift-online/ocm-api-model/pull/1180 (as it's based on that branch)

## Type of Change

- [ ] Model change (new or modified types, resources, methods, or parameters)
- [ ] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [ ] CI/CD or tooling change
- [x] Chores (make linter happy)

## Verification

- [x] `make check` passes (model syntax validation)
- [x] `make verify` passes (generated code matches model)
- [x] `make lint` passes (indentation enforcement)

## Checklist

- [x] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [x] Documentation comments use Markdown format
- [x] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)
