### PR TITLE
ROSAENG-61162 | feat: API changes for BYO firewall workflow for OSD-GCP

### DIFF
--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_builder.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Allowed protocol and ports for a GCP firewall rule.
+type GcpFirewallRuleAllowedBuilder struct {
+	fieldSet_  []bool
+	ipProtocol string
+	ports      []string
+}
+
+// NewGcpFirewallRuleAllowed creates a new builder of 'gcp_firewall_rule_allowed' objects.
+func NewGcpFirewallRuleAllowed() *GcpFirewallRuleAllowedBuilder {
+	return &GcpFirewallRuleAllowedBuilder{
+		fieldSet_: make([]bool, 2),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleAllowedBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// IPProtocol sets the value of the 'IP_protocol' attribute to the given value.
+func (b *GcpFirewallRuleAllowedBuilder) IPProtocol(value string) *GcpFirewallRuleAllowedBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.ipProtocol = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Ports sets the value of the 'ports' attribute to the given values.
+func (b *GcpFirewallRuleAllowedBuilder) Ports(values ...string) *GcpFirewallRuleAllowedBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.ports = make([]string, len(values))
+	copy(b.ports, values)
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleAllowedBuilder) Copy(object *GcpFirewallRuleAllowed) *GcpFirewallRuleAllowedBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.ipProtocol = object.ipProtocol
+	if object.ports != nil {
+		b.ports = make([]string, len(object.ports))
+		copy(b.ports, object.ports)
+	} else {
+		b.ports = nil
+	}
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule_allowed' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleAllowedBuilder) Build() (object *GcpFirewallRuleAllowed, err error) {
+	object = new(GcpFirewallRuleAllowed)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.ipProtocol = b.ipProtocol
+	if b.ports != nil {
+		object.ports = make([]string, len(b.ports))
+		copy(object.ports, b.ports)
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleAllowedListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule_allowed' objects.
+type GcpFirewallRuleAllowedListBuilder struct {
+	items []*GcpFirewallRuleAllowedBuilder
+}
+
+// NewGcpFirewallRuleAllowedList creates a new builder of 'gcp_firewall_rule_allowed' objects.
+func NewGcpFirewallRuleAllowedList() *GcpFirewallRuleAllowedListBuilder {
+	return new(GcpFirewallRuleAllowedListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleAllowedListBuilder) Items(values ...*GcpFirewallRuleAllowedBuilder) *GcpFirewallRuleAllowedListBuilder {
+	b.items = make([]*GcpFirewallRuleAllowedBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleAllowedListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleAllowedListBuilder) Copy(list *GcpFirewallRuleAllowedList) *GcpFirewallRuleAllowedListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleAllowedBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRuleAllowed().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule_allowed' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleAllowedListBuilder) Build() (list *GcpFirewallRuleAllowedList, err error) {
+	items := make([]*GcpFirewallRuleAllowed, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleAllowedList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleAllowedList writes a list of values of the 'gcp_firewall_rule_allowed' type to
+// the given writer.
+func MarshalGcpFirewallRuleAllowedList(list []*GcpFirewallRuleAllowed, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleAllowedList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleAllowedList writes a list of value of the 'gcp_firewall_rule_allowed' type to
+// the given stream.
+func WriteGcpFirewallRuleAllowedList(list []*GcpFirewallRuleAllowed, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRuleAllowed(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleAllowedList reads a list of values of the 'gcp_firewall_rule_allowed' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleAllowedList(source interface{}) (items []*GcpFirewallRuleAllowed, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleAllowedList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleAllowedList reads list of values of the ”gcp_firewall_rule_allowed' type from
+// the given iterator.
+func ReadGcpFirewallRuleAllowedList(iterator *jsoniter.Iterator) []*GcpFirewallRuleAllowed {
+	list := []*GcpFirewallRuleAllowed{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRuleAllowed(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_type.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleAllowed represents the values of the 'gcp_firewall_rule_allowed' type.
+//
+// Allowed protocol and ports for a GCP firewall rule.
+type GcpFirewallRuleAllowed struct {
+	fieldSet_  []bool
+	ipProtocol string
+	ports      []string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRuleAllowed) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// IPProtocol returns the value of the 'IP_protocol' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// IP protocol (e.g. "tcp", "udp", "icmp").
+func (o *GcpFirewallRuleAllowed) IPProtocol() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.ipProtocol
+	}
+	return ""
+}
+
+// GetIPProtocol returns the value of the 'IP_protocol' attribute and
+// a flag indicating if the attribute has a value.
+//
+// IP protocol (e.g. "tcp", "udp", "icmp").
+func (o *GcpFirewallRuleAllowed) GetIPProtocol() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.ipProtocol
+	}
+	return
+}
+
+// Ports returns the value of the 'ports' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Ports to allow (e.g. "6443", "10250").
+func (o *GcpFirewallRuleAllowed) Ports() []string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.ports
+	}
+	return nil
+}
+
+// GetPorts returns the value of the 'ports' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Ports to allow (e.g. "6443", "10250").
+func (o *GcpFirewallRuleAllowed) GetPorts() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.ports
+	}
+	return
+}
+
+// GcpFirewallRuleAllowedListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule_allowed'.
+const GcpFirewallRuleAllowedListKind = "GcpFirewallRuleAllowedList"
+
+// GcpFirewallRuleAllowedListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule_allowed'.
+const GcpFirewallRuleAllowedListLinkKind = "GcpFirewallRuleAllowedListLink"
+
+// GcpFirewallRuleAllowedNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule_allowed'.
+const GcpFirewallRuleAllowedListNilKind = "GcpFirewallRuleAllowedListNil"
+
+// GcpFirewallRuleAllowedList is a list of values of the 'gcp_firewall_rule_allowed' type.
+type GcpFirewallRuleAllowedList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRuleAllowed
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleAllowedList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleAllowedList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleAllowedList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleAllowedList) SetItems(items []*GcpFirewallRuleAllowed) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleAllowedList) Items() []*GcpFirewallRuleAllowed {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleAllowedList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleAllowedList) Get(i int) *GcpFirewallRuleAllowed {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleAllowedList) Slice() []*GcpFirewallRuleAllowed {
+	var slice []*GcpFirewallRuleAllowed
+	if l == nil {
+		slice = make([]*GcpFirewallRuleAllowed, 0)
+	} else {
+		slice = make([]*GcpFirewallRuleAllowed, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleAllowedList) Each(f func(item *GcpFirewallRuleAllowed) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleAllowedList) Range(f func(index int, item *GcpFirewallRuleAllowed) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_allowed_type_json.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleAllowed writes a value of the 'gcp_firewall_rule_allowed' type to the given writer.
+func MarshalGcpFirewallRuleAllowed(object *GcpFirewallRuleAllowed, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleAllowed(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleAllowed writes a value of the 'gcp_firewall_rule_allowed' type to the given stream.
+func WriteGcpFirewallRuleAllowed(object *GcpFirewallRuleAllowed, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("ip_protocol")
+		stream.WriteString(object.ipProtocol)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1] && object.ports != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("ports")
+		WriteStringList(object.ports, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalGcpFirewallRuleAllowed reads a value of the 'gcp_firewall_rule_allowed' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleAllowed(source interface{}) (object *GcpFirewallRuleAllowed, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadGcpFirewallRuleAllowed(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleAllowed reads a value of the 'gcp_firewall_rule_allowed' type from the given iterator.
+func ReadGcpFirewallRuleAllowed(iterator *jsoniter.Iterator) *GcpFirewallRuleAllowed {
+	object := &GcpFirewallRuleAllowed{
+		fieldSet_: make([]bool, 2),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "ip_protocol":
+			value := iterator.ReadString()
+			object.ipProtocol = value
+			object.fieldSet_[0] = true
+		case "ports":
+			value := ReadStringList(iterator)
+			object.ports = value
+			object.fieldSet_[1] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_builder.go
@@ -1,0 +1,271 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GCP firewall rule configuration for BYO (Bring Your Own) firewall workflow.
+// These are organization-level resources that can be created before cluster
+// provisioning and reused after cluster deletion.
+type GcpFirewallRuleBuilder struct {
+	fieldSet_    []bool
+	id           string
+	href         string
+	gcpNetwork   *GcpFirewallRuleGcpNetworkBuilder
+	name         string
+	organization *OrganizationLinkBuilder
+	profile      string
+	status       *GcpFirewallRuleStatusBuilder
+	template     *GcpFirewallRuleTemplateRefBuilder
+	wifConfig    *WifConfigBuilder
+}
+
+// NewGcpFirewallRule creates a new builder of 'gcp_firewall_rule' objects.
+func NewGcpFirewallRule() *GcpFirewallRuleBuilder {
+	return &GcpFirewallRuleBuilder{
+		fieldSet_: make([]bool, 10),
+	}
+}
+
+// Link sets the flag that indicates if this is a link.
+func (b *GcpFirewallRuleBuilder) Link(value bool) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.fieldSet_[0] = true
+	return b
+}
+
+// ID sets the identifier of the object.
+func (b *GcpFirewallRuleBuilder) ID(value string) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.id = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// HREF sets the link to the object.
+func (b *GcpFirewallRuleBuilder) HREF(value string) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.href = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(b.fieldSet_); i++ {
+		if b.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// GcpNetwork sets the value of the 'gcp_network' attribute to the given value.
+//
+// GCP network configuration for a firewall rule.
+func (b *GcpFirewallRuleBuilder) GcpNetwork(value *GcpFirewallRuleGcpNetworkBuilder) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.gcpNetwork = value
+	if value != nil {
+		b.fieldSet_[3] = true
+	} else {
+		b.fieldSet_[3] = false
+	}
+	return b
+}
+
+// Name sets the value of the 'name' attribute to the given value.
+func (b *GcpFirewallRuleBuilder) Name(value string) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.name = value
+	b.fieldSet_[4] = true
+	return b
+}
+
+// Organization sets the value of the 'organization' attribute to the given value.
+//
+// Definition of an organization link.
+func (b *GcpFirewallRuleBuilder) Organization(value *OrganizationLinkBuilder) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.organization = value
+	if value != nil {
+		b.fieldSet_[5] = true
+	} else {
+		b.fieldSet_[5] = false
+	}
+	return b
+}
+
+// Profile sets the value of the 'profile' attribute to the given value.
+func (b *GcpFirewallRuleBuilder) Profile(value string) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.profile = value
+	b.fieldSet_[6] = true
+	return b
+}
+
+// Status sets the value of the 'status' attribute to the given value.
+//
+// Status of a GCP firewall rule set, containing the rendered rules.
+func (b *GcpFirewallRuleBuilder) Status(value *GcpFirewallRuleStatusBuilder) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.status = value
+	if value != nil {
+		b.fieldSet_[7] = true
+	} else {
+		b.fieldSet_[7] = false
+	}
+	return b
+}
+
+// Template sets the value of the 'template' attribute to the given value.
+//
+// Template version and profile reference for a firewall rule.
+func (b *GcpFirewallRuleBuilder) Template(value *GcpFirewallRuleTemplateRefBuilder) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.template = value
+	if value != nil {
+		b.fieldSet_[8] = true
+	} else {
+		b.fieldSet_[8] = false
+	}
+	return b
+}
+
+// WifConfig sets the value of the 'wif_config' attribute to the given value.
+//
+// Definition of an wif_config resource.
+func (b *GcpFirewallRuleBuilder) WifConfig(value *WifConfigBuilder) *GcpFirewallRuleBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 10)
+	}
+	b.wifConfig = value
+	if value != nil {
+		b.fieldSet_[9] = true
+	} else {
+		b.fieldSet_[9] = false
+	}
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleBuilder) Copy(object *GcpFirewallRule) *GcpFirewallRuleBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.id = object.id
+	b.href = object.href
+	if object.gcpNetwork != nil {
+		b.gcpNetwork = NewGcpFirewallRuleGcpNetwork().Copy(object.gcpNetwork)
+	} else {
+		b.gcpNetwork = nil
+	}
+	b.name = object.name
+	if object.organization != nil {
+		b.organization = NewOrganizationLink().Copy(object.organization)
+	} else {
+		b.organization = nil
+	}
+	b.profile = object.profile
+	if object.status != nil {
+		b.status = NewGcpFirewallRuleStatus().Copy(object.status)
+	} else {
+		b.status = nil
+	}
+	if object.template != nil {
+		b.template = NewGcpFirewallRuleTemplateRef().Copy(object.template)
+	} else {
+		b.template = nil
+	}
+	if object.wifConfig != nil {
+		b.wifConfig = NewWifConfig().Copy(object.wifConfig)
+	} else {
+		b.wifConfig = nil
+	}
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleBuilder) Build() (object *GcpFirewallRule, err error) {
+	object = new(GcpFirewallRule)
+	object.id = b.id
+	object.href = b.href
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.gcpNetwork != nil {
+		object.gcpNetwork, err = b.gcpNetwork.Build()
+		if err != nil {
+			return
+		}
+	}
+	object.name = b.name
+	if b.organization != nil {
+		object.organization, err = b.organization.Build()
+		if err != nil {
+			return
+		}
+	}
+	object.profile = b.profile
+	if b.status != nil {
+		object.status, err = b.status.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.template != nil {
+		object.template, err = b.template.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.wifConfig != nil {
+		object.wifConfig, err = b.wifConfig.Build()
+		if err != nil {
+			return
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_builder.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GCP network configuration for a firewall rule.
+type GcpFirewallRuleGcpNetworkBuilder struct {
+	fieldSet_   []bool
+	machineCidr string
+	projectId   string
+	vpcName     string
+}
+
+// NewGcpFirewallRuleGcpNetwork creates a new builder of 'gcp_firewall_rule_gcp_network' objects.
+func NewGcpFirewallRuleGcpNetwork() *GcpFirewallRuleGcpNetworkBuilder {
+	return &GcpFirewallRuleGcpNetworkBuilder{
+		fieldSet_: make([]bool, 3),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleGcpNetworkBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// MachineCidr sets the value of the 'machine_cidr' attribute to the given value.
+func (b *GcpFirewallRuleGcpNetworkBuilder) MachineCidr(value string) *GcpFirewallRuleGcpNetworkBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 3)
+	}
+	b.machineCidr = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// ProjectId sets the value of the 'project_id' attribute to the given value.
+func (b *GcpFirewallRuleGcpNetworkBuilder) ProjectId(value string) *GcpFirewallRuleGcpNetworkBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 3)
+	}
+	b.projectId = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// VpcName sets the value of the 'vpc_name' attribute to the given value.
+func (b *GcpFirewallRuleGcpNetworkBuilder) VpcName(value string) *GcpFirewallRuleGcpNetworkBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 3)
+	}
+	b.vpcName = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleGcpNetworkBuilder) Copy(object *GcpFirewallRuleGcpNetwork) *GcpFirewallRuleGcpNetworkBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.machineCidr = object.machineCidr
+	b.projectId = object.projectId
+	b.vpcName = object.vpcName
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule_gcp_network' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleGcpNetworkBuilder) Build() (object *GcpFirewallRuleGcpNetwork, err error) {
+	object = new(GcpFirewallRuleGcpNetwork)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.machineCidr = b.machineCidr
+	object.projectId = b.projectId
+	object.vpcName = b.vpcName
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleGcpNetworkListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule_gcp_network' objects.
+type GcpFirewallRuleGcpNetworkListBuilder struct {
+	items []*GcpFirewallRuleGcpNetworkBuilder
+}
+
+// NewGcpFirewallRuleGcpNetworkList creates a new builder of 'gcp_firewall_rule_gcp_network' objects.
+func NewGcpFirewallRuleGcpNetworkList() *GcpFirewallRuleGcpNetworkListBuilder {
+	return new(GcpFirewallRuleGcpNetworkListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleGcpNetworkListBuilder) Items(values ...*GcpFirewallRuleGcpNetworkBuilder) *GcpFirewallRuleGcpNetworkListBuilder {
+	b.items = make([]*GcpFirewallRuleGcpNetworkBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleGcpNetworkListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleGcpNetworkListBuilder) Copy(list *GcpFirewallRuleGcpNetworkList) *GcpFirewallRuleGcpNetworkListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleGcpNetworkBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRuleGcpNetwork().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule_gcp_network' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleGcpNetworkListBuilder) Build() (list *GcpFirewallRuleGcpNetworkList, err error) {
+	items := make([]*GcpFirewallRuleGcpNetwork, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleGcpNetworkList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleGcpNetworkList writes a list of values of the 'gcp_firewall_rule_gcp_network' type to
+// the given writer.
+func MarshalGcpFirewallRuleGcpNetworkList(list []*GcpFirewallRuleGcpNetwork, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleGcpNetworkList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleGcpNetworkList writes a list of value of the 'gcp_firewall_rule_gcp_network' type to
+// the given stream.
+func WriteGcpFirewallRuleGcpNetworkList(list []*GcpFirewallRuleGcpNetwork, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRuleGcpNetwork(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleGcpNetworkList reads a list of values of the 'gcp_firewall_rule_gcp_network' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleGcpNetworkList(source interface{}) (items []*GcpFirewallRuleGcpNetwork, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleGcpNetworkList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleGcpNetworkList reads list of values of the ”gcp_firewall_rule_gcp_network' type from
+// the given iterator.
+func ReadGcpFirewallRuleGcpNetworkList(iterator *jsoniter.Iterator) []*GcpFirewallRuleGcpNetwork {
+	list := []*GcpFirewallRuleGcpNetwork{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRuleGcpNetwork(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_type.go
@@ -1,0 +1,221 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleGcpNetwork represents the values of the 'gcp_firewall_rule_gcp_network' type.
+//
+// GCP network configuration for a firewall rule.
+type GcpFirewallRuleGcpNetwork struct {
+	fieldSet_   []bool
+	machineCidr string
+	projectId   string
+	vpcName     string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRuleGcpNetwork) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// MachineCidr returns the value of the 'machine_cidr' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Machine CIDR block.
+func (o *GcpFirewallRuleGcpNetwork) MachineCidr() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.machineCidr
+	}
+	return ""
+}
+
+// GetMachineCidr returns the value of the 'machine_cidr' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Machine CIDR block.
+func (o *GcpFirewallRuleGcpNetwork) GetMachineCidr() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.machineCidr
+	}
+	return
+}
+
+// ProjectId returns the value of the 'project_id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// GCP project ID.
+func (o *GcpFirewallRuleGcpNetwork) ProjectId() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.projectId
+	}
+	return ""
+}
+
+// GetProjectId returns the value of the 'project_id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// GCP project ID.
+func (o *GcpFirewallRuleGcpNetwork) GetProjectId() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.projectId
+	}
+	return
+}
+
+// VpcName returns the value of the 'vpc_name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// VPC network name.
+func (o *GcpFirewallRuleGcpNetwork) VpcName() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.vpcName
+	}
+	return ""
+}
+
+// GetVpcName returns the value of the 'vpc_name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// VPC network name.
+func (o *GcpFirewallRuleGcpNetwork) GetVpcName() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.vpcName
+	}
+	return
+}
+
+// GcpFirewallRuleGcpNetworkListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule_gcp_network'.
+const GcpFirewallRuleGcpNetworkListKind = "GcpFirewallRuleGcpNetworkList"
+
+// GcpFirewallRuleGcpNetworkListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule_gcp_network'.
+const GcpFirewallRuleGcpNetworkListLinkKind = "GcpFirewallRuleGcpNetworkListLink"
+
+// GcpFirewallRuleGcpNetworkNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule_gcp_network'.
+const GcpFirewallRuleGcpNetworkListNilKind = "GcpFirewallRuleGcpNetworkListNil"
+
+// GcpFirewallRuleGcpNetworkList is a list of values of the 'gcp_firewall_rule_gcp_network' type.
+type GcpFirewallRuleGcpNetworkList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRuleGcpNetwork
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleGcpNetworkList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleGcpNetworkList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleGcpNetworkList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleGcpNetworkList) SetItems(items []*GcpFirewallRuleGcpNetwork) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleGcpNetworkList) Items() []*GcpFirewallRuleGcpNetwork {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleGcpNetworkList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleGcpNetworkList) Get(i int) *GcpFirewallRuleGcpNetwork {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleGcpNetworkList) Slice() []*GcpFirewallRuleGcpNetwork {
+	var slice []*GcpFirewallRuleGcpNetwork
+	if l == nil {
+		slice = make([]*GcpFirewallRuleGcpNetwork, 0)
+	} else {
+		slice = make([]*GcpFirewallRuleGcpNetwork, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleGcpNetworkList) Each(f func(item *GcpFirewallRuleGcpNetwork) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleGcpNetworkList) Range(f func(index int, item *GcpFirewallRuleGcpNetwork) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_gcp_network_type_json.go
@@ -26,10 +26,10 @@ import (
 	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
 )
 
-// MarshalGCPNetwork writes a value of the 'GCP_network' type to the given writer.
-func MarshalGCPNetwork(object *GCPNetwork, writer io.Writer) error {
+// MarshalGcpFirewallRuleGcpNetwork writes a value of the 'gcp_firewall_rule_gcp_network' type to the given writer.
+func MarshalGcpFirewallRuleGcpNetwork(object *GcpFirewallRuleGcpNetwork, writer io.Writer) error {
 	stream := helpers.NewStream(writer)
-	WriteGCPNetwork(object, stream)
+	WriteGcpFirewallRuleGcpNetwork(object, stream)
 	err := stream.Flush()
 	if err != nil {
 		return err
@@ -37,8 +37,8 @@ func MarshalGCPNetwork(object *GCPNetwork, writer io.Writer) error {
 	return stream.Error
 }
 
-// WriteGCPNetwork writes a value of the 'GCP_network' type to the given stream.
-func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
+// WriteGcpFirewallRuleGcpNetwork writes a value of the 'gcp_firewall_rule_gcp_network' type to the given stream.
+func WriteGcpFirewallRuleGcpNetwork(object *GcpFirewallRuleGcpNetwork, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
 	var present_ bool
@@ -47,8 +47,8 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("vpc_name")
-		stream.WriteString(object.vpcName)
+		stream.WriteObjectField("machine_cidr")
+		stream.WriteString(object.machineCidr)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
@@ -56,8 +56,8 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("vpc_project_id")
-		stream.WriteString(object.vpcProjectID)
+		stream.WriteObjectField("project_id")
+		stream.WriteString(object.projectId)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
@@ -65,46 +65,28 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("compute_subnet")
-		stream.WriteString(object.computeSubnet)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("control_plane_subnet")
-		stream.WriteString(object.controlPlaneSubnet)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("firewall_rules_id")
-		stream.WriteString(object.firewallRulesId)
+		stream.WriteObjectField("vpc_name")
+		stream.WriteString(object.vpcName)
 	}
 	stream.WriteObjectEnd()
 }
 
-// UnmarshalGCPNetwork reads a value of the 'GCP_network' type from the given
+// UnmarshalGcpFirewallRuleGcpNetwork reads a value of the 'gcp_firewall_rule_gcp_network' type from the given
 // source, which can be an slice of bytes, a string or a reader.
-func UnmarshalGCPNetwork(source interface{}) (object *GCPNetwork, err error) {
+func UnmarshalGcpFirewallRuleGcpNetwork(source interface{}) (object *GcpFirewallRuleGcpNetwork, err error) {
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return
 	}
-	object = ReadGCPNetwork(iterator)
+	object = ReadGcpFirewallRuleGcpNetwork(iterator)
 	err = iterator.Error
 	return
 }
 
-// ReadGCPNetwork reads a value of the 'GCP_network' type from the given iterator.
-func ReadGCPNetwork(iterator *jsoniter.Iterator) *GCPNetwork {
-	object := &GCPNetwork{
-		fieldSet_: make([]bool, 5),
+// ReadGcpFirewallRuleGcpNetwork reads a value of the 'gcp_firewall_rule_gcp_network' type from the given iterator.
+func ReadGcpFirewallRuleGcpNetwork(iterator *jsoniter.Iterator) *GcpFirewallRuleGcpNetwork {
+	object := &GcpFirewallRuleGcpNetwork{
+		fieldSet_: make([]bool, 3),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -112,26 +94,18 @@ func ReadGCPNetwork(iterator *jsoniter.Iterator) *GCPNetwork {
 			break
 		}
 		switch field {
+		case "machine_cidr":
+			value := iterator.ReadString()
+			object.machineCidr = value
+			object.fieldSet_[0] = true
+		case "project_id":
+			value := iterator.ReadString()
+			object.projectId = value
+			object.fieldSet_[1] = true
 		case "vpc_name":
 			value := iterator.ReadString()
 			object.vpcName = value
-			object.fieldSet_[0] = true
-		case "vpc_project_id":
-			value := iterator.ReadString()
-			object.vpcProjectID = value
-			object.fieldSet_[1] = true
-		case "compute_subnet":
-			value := iterator.ReadString()
-			object.computeSubnet = value
 			object.fieldSet_[2] = true
-		case "control_plane_subnet":
-			value := iterator.ReadString()
-			object.controlPlaneSubnet = value
-			object.fieldSet_[3] = true
-		case "firewall_rules_id":
-			value := iterator.ReadString()
-			object.firewallRulesId = value
-			object.fieldSet_[4] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule' objects.
+type GcpFirewallRuleListBuilder struct {
+	items []*GcpFirewallRuleBuilder
+}
+
+// NewGcpFirewallRuleList creates a new builder of 'gcp_firewall_rule' objects.
+func NewGcpFirewallRuleList() *GcpFirewallRuleListBuilder {
+	return new(GcpFirewallRuleListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleListBuilder) Items(values ...*GcpFirewallRuleBuilder) *GcpFirewallRuleListBuilder {
+	b.items = make([]*GcpFirewallRuleBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleListBuilder) Copy(list *GcpFirewallRuleList) *GcpFirewallRuleListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRule().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleListBuilder) Build() (list *GcpFirewallRuleList, err error) {
+	items := make([]*GcpFirewallRule, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleList writes a list of values of the 'gcp_firewall_rule' type to
+// the given writer.
+func MarshalGcpFirewallRuleList(list []*GcpFirewallRule, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleList writes a list of value of the 'gcp_firewall_rule' type to
+// the given stream.
+func WriteGcpFirewallRuleList(list []*GcpFirewallRule, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRule(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleList reads a list of values of the 'gcp_firewall_rule' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleList(source interface{}) (items []*GcpFirewallRule, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleList reads list of values of the ”gcp_firewall_rule' type from
+// the given iterator.
+func ReadGcpFirewallRuleList(iterator *jsoniter.Iterator) []*GcpFirewallRule {
+	list := []*GcpFirewallRule{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRule(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_builder.go
@@ -1,0 +1,214 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// A single rendered GCP firewall rule specification.
+type GcpFirewallRuleSpecBuilder struct {
+	fieldSet_             []bool
+	allowed               []*GcpFirewallRuleAllowedBuilder
+	direction             string
+	name                  string
+	network               string
+	priority              int
+	sourceRanges          []string
+	sourceServiceAccounts []string
+	targetServiceAccounts []string
+}
+
+// NewGcpFirewallRuleSpec creates a new builder of 'gcp_firewall_rule_spec' objects.
+func NewGcpFirewallRuleSpec() *GcpFirewallRuleSpecBuilder {
+	return &GcpFirewallRuleSpecBuilder{
+		fieldSet_: make([]bool, 8),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleSpecBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Allowed sets the value of the 'allowed' attribute to the given values.
+func (b *GcpFirewallRuleSpecBuilder) Allowed(values ...*GcpFirewallRuleAllowedBuilder) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.allowed = make([]*GcpFirewallRuleAllowedBuilder, len(values))
+	copy(b.allowed, values)
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Direction sets the value of the 'direction' attribute to the given value.
+func (b *GcpFirewallRuleSpecBuilder) Direction(value string) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.direction = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Name sets the value of the 'name' attribute to the given value.
+func (b *GcpFirewallRuleSpecBuilder) Name(value string) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.name = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Network sets the value of the 'network' attribute to the given value.
+func (b *GcpFirewallRuleSpecBuilder) Network(value string) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.network = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// Priority sets the value of the 'priority' attribute to the given value.
+func (b *GcpFirewallRuleSpecBuilder) Priority(value int) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.priority = value
+	b.fieldSet_[4] = true
+	return b
+}
+
+// SourceRanges sets the value of the 'source_ranges' attribute to the given values.
+func (b *GcpFirewallRuleSpecBuilder) SourceRanges(values ...string) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.sourceRanges = make([]string, len(values))
+	copy(b.sourceRanges, values)
+	b.fieldSet_[5] = true
+	return b
+}
+
+// SourceServiceAccounts sets the value of the 'source_service_accounts' attribute to the given values.
+func (b *GcpFirewallRuleSpecBuilder) SourceServiceAccounts(values ...string) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.sourceServiceAccounts = make([]string, len(values))
+	copy(b.sourceServiceAccounts, values)
+	b.fieldSet_[6] = true
+	return b
+}
+
+// TargetServiceAccounts sets the value of the 'target_service_accounts' attribute to the given values.
+func (b *GcpFirewallRuleSpecBuilder) TargetServiceAccounts(values ...string) *GcpFirewallRuleSpecBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 8)
+	}
+	b.targetServiceAccounts = make([]string, len(values))
+	copy(b.targetServiceAccounts, values)
+	b.fieldSet_[7] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleSpecBuilder) Copy(object *GcpFirewallRuleSpec) *GcpFirewallRuleSpecBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	if object.allowed != nil {
+		b.allowed = make([]*GcpFirewallRuleAllowedBuilder, len(object.allowed))
+		for i, v := range object.allowed {
+			b.allowed[i] = NewGcpFirewallRuleAllowed().Copy(v)
+		}
+	} else {
+		b.allowed = nil
+	}
+	b.direction = object.direction
+	b.name = object.name
+	b.network = object.network
+	b.priority = object.priority
+	if object.sourceRanges != nil {
+		b.sourceRanges = make([]string, len(object.sourceRanges))
+		copy(b.sourceRanges, object.sourceRanges)
+	} else {
+		b.sourceRanges = nil
+	}
+	if object.sourceServiceAccounts != nil {
+		b.sourceServiceAccounts = make([]string, len(object.sourceServiceAccounts))
+		copy(b.sourceServiceAccounts, object.sourceServiceAccounts)
+	} else {
+		b.sourceServiceAccounts = nil
+	}
+	if object.targetServiceAccounts != nil {
+		b.targetServiceAccounts = make([]string, len(object.targetServiceAccounts))
+		copy(b.targetServiceAccounts, object.targetServiceAccounts)
+	} else {
+		b.targetServiceAccounts = nil
+	}
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule_spec' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleSpecBuilder) Build() (object *GcpFirewallRuleSpec, err error) {
+	object = new(GcpFirewallRuleSpec)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.allowed != nil {
+		object.allowed = make([]*GcpFirewallRuleAllowed, len(b.allowed))
+		for i, v := range b.allowed {
+			object.allowed[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	object.direction = b.direction
+	object.name = b.name
+	object.network = b.network
+	object.priority = b.priority
+	if b.sourceRanges != nil {
+		object.sourceRanges = make([]string, len(b.sourceRanges))
+		copy(object.sourceRanges, b.sourceRanges)
+	}
+	if b.sourceServiceAccounts != nil {
+		object.sourceServiceAccounts = make([]string, len(b.sourceServiceAccounts))
+		copy(object.sourceServiceAccounts, b.sourceServiceAccounts)
+	}
+	if b.targetServiceAccounts != nil {
+		object.targetServiceAccounts = make([]string, len(b.targetServiceAccounts))
+		copy(object.targetServiceAccounts, b.targetServiceAccounts)
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleSpecListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule_spec' objects.
+type GcpFirewallRuleSpecListBuilder struct {
+	items []*GcpFirewallRuleSpecBuilder
+}
+
+// NewGcpFirewallRuleSpecList creates a new builder of 'gcp_firewall_rule_spec' objects.
+func NewGcpFirewallRuleSpecList() *GcpFirewallRuleSpecListBuilder {
+	return new(GcpFirewallRuleSpecListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleSpecListBuilder) Items(values ...*GcpFirewallRuleSpecBuilder) *GcpFirewallRuleSpecListBuilder {
+	b.items = make([]*GcpFirewallRuleSpecBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleSpecListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleSpecListBuilder) Copy(list *GcpFirewallRuleSpecList) *GcpFirewallRuleSpecListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleSpecBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRuleSpec().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule_spec' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleSpecListBuilder) Build() (list *GcpFirewallRuleSpecList, err error) {
+	items := make([]*GcpFirewallRuleSpec, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleSpecList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleSpecList writes a list of values of the 'gcp_firewall_rule_spec' type to
+// the given writer.
+func MarshalGcpFirewallRuleSpecList(list []*GcpFirewallRuleSpec, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleSpecList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleSpecList writes a list of value of the 'gcp_firewall_rule_spec' type to
+// the given stream.
+func WriteGcpFirewallRuleSpecList(list []*GcpFirewallRuleSpec, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRuleSpec(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleSpecList reads a list of values of the 'gcp_firewall_rule_spec' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleSpecList(source interface{}) (items []*GcpFirewallRuleSpec, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleSpecList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleSpecList reads list of values of the ”gcp_firewall_rule_spec' type from
+// the given iterator.
+func ReadGcpFirewallRuleSpecList(iterator *jsoniter.Iterator) []*GcpFirewallRuleSpec {
+	list := []*GcpFirewallRuleSpec{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRuleSpec(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_type.go
@@ -1,0 +1,341 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleSpec represents the values of the 'gcp_firewall_rule_spec' type.
+//
+// A single rendered GCP firewall rule specification.
+type GcpFirewallRuleSpec struct {
+	fieldSet_             []bool
+	allowed               []*GcpFirewallRuleAllowed
+	direction             string
+	name                  string
+	network               string
+	priority              int
+	sourceRanges          []string
+	sourceServiceAccounts []string
+	targetServiceAccounts []string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRuleSpec) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Allowed returns the value of the 'allowed' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Allowed protocols and ports.
+func (o *GcpFirewallRuleSpec) Allowed() []*GcpFirewallRuleAllowed {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.allowed
+	}
+	return nil
+}
+
+// GetAllowed returns the value of the 'allowed' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Allowed protocols and ports.
+func (o *GcpFirewallRuleSpec) GetAllowed() (value []*GcpFirewallRuleAllowed, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.allowed
+	}
+	return
+}
+
+// Direction returns the value of the 'direction' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Direction of traffic (INGRESS or EGRESS).
+func (o *GcpFirewallRuleSpec) Direction() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.direction
+	}
+	return ""
+}
+
+// GetDirection returns the value of the 'direction' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Direction of traffic (INGRESS or EGRESS).
+func (o *GcpFirewallRuleSpec) GetDirection() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.direction
+	}
+	return
+}
+
+// Name returns the value of the 'name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Name of the firewall rule.
+func (o *GcpFirewallRuleSpec) Name() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.name
+	}
+	return ""
+}
+
+// GetName returns the value of the 'name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Name of the firewall rule.
+func (o *GcpFirewallRuleSpec) GetName() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.name
+	}
+	return
+}
+
+// Network returns the value of the 'network' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// GCP network URL.
+func (o *GcpFirewallRuleSpec) Network() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.network
+	}
+	return ""
+}
+
+// GetNetwork returns the value of the 'network' attribute and
+// a flag indicating if the attribute has a value.
+//
+// GCP network URL.
+func (o *GcpFirewallRuleSpec) GetNetwork() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.network
+	}
+	return
+}
+
+// Priority returns the value of the 'priority' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Priority of the rule (0-65535).
+func (o *GcpFirewallRuleSpec) Priority() int {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
+		return o.priority
+	}
+	return 0
+}
+
+// GetPriority returns the value of the 'priority' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Priority of the rule (0-65535).
+func (o *GcpFirewallRuleSpec) GetPriority() (value int, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
+	if ok {
+		value = o.priority
+	}
+	return
+}
+
+// SourceRanges returns the value of the 'source_ranges' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Source IP CIDR ranges.
+func (o *GcpFirewallRuleSpec) SourceRanges() []string {
+	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+		return o.sourceRanges
+	}
+	return nil
+}
+
+// GetSourceRanges returns the value of the 'source_ranges' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Source IP CIDR ranges.
+func (o *GcpFirewallRuleSpec) GetSourceRanges() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	if ok {
+		value = o.sourceRanges
+	}
+	return
+}
+
+// SourceServiceAccounts returns the value of the 'source_service_accounts' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Source service accounts.
+func (o *GcpFirewallRuleSpec) SourceServiceAccounts() []string {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+		return o.sourceServiceAccounts
+	}
+	return nil
+}
+
+// GetSourceServiceAccounts returns the value of the 'source_service_accounts' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Source service accounts.
+func (o *GcpFirewallRuleSpec) GetSourceServiceAccounts() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	if ok {
+		value = o.sourceServiceAccounts
+	}
+	return
+}
+
+// TargetServiceAccounts returns the value of the 'target_service_accounts' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Target service accounts.
+func (o *GcpFirewallRuleSpec) TargetServiceAccounts() []string {
+	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+		return o.targetServiceAccounts
+	}
+	return nil
+}
+
+// GetTargetServiceAccounts returns the value of the 'target_service_accounts' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Target service accounts.
+func (o *GcpFirewallRuleSpec) GetTargetServiceAccounts() (value []string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	if ok {
+		value = o.targetServiceAccounts
+	}
+	return
+}
+
+// GcpFirewallRuleSpecListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule_spec'.
+const GcpFirewallRuleSpecListKind = "GcpFirewallRuleSpecList"
+
+// GcpFirewallRuleSpecListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule_spec'.
+const GcpFirewallRuleSpecListLinkKind = "GcpFirewallRuleSpecListLink"
+
+// GcpFirewallRuleSpecNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule_spec'.
+const GcpFirewallRuleSpecListNilKind = "GcpFirewallRuleSpecListNil"
+
+// GcpFirewallRuleSpecList is a list of values of the 'gcp_firewall_rule_spec' type.
+type GcpFirewallRuleSpecList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRuleSpec
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleSpecList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleSpecList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleSpecList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleSpecList) SetItems(items []*GcpFirewallRuleSpec) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleSpecList) Items() []*GcpFirewallRuleSpec {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleSpecList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleSpecList) Get(i int) *GcpFirewallRuleSpec {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleSpecList) Slice() []*GcpFirewallRuleSpec {
+	var slice []*GcpFirewallRuleSpec
+	if l == nil {
+		slice = make([]*GcpFirewallRuleSpec, 0)
+	} else {
+		slice = make([]*GcpFirewallRuleSpec, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleSpecList) Each(f func(item *GcpFirewallRuleSpec) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleSpecList) Range(f func(index int, item *GcpFirewallRuleSpec) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_spec_type_json.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleSpec writes a value of the 'gcp_firewall_rule_spec' type to the given writer.
+func MarshalGcpFirewallRuleSpec(object *GcpFirewallRuleSpec, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleSpec(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleSpec writes a value of the 'gcp_firewall_rule_spec' type to the given stream.
+func WriteGcpFirewallRuleSpec(object *GcpFirewallRuleSpec, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.allowed != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("allowed")
+		WriteGcpFirewallRuleAllowedList(object.allowed, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("direction")
+		stream.WriteString(object.direction)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("name")
+		stream.WriteString(object.name)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("network")
+		stream.WriteString(object.network)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("priority")
+		stream.WriteInt(object.priority)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.sourceRanges != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("source_ranges")
+		WriteStringList(object.sourceRanges, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6] && object.sourceServiceAccounts != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("source_service_accounts")
+		WriteStringList(object.sourceServiceAccounts, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7] && object.targetServiceAccounts != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("target_service_accounts")
+		WriteStringList(object.targetServiceAccounts, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalGcpFirewallRuleSpec reads a value of the 'gcp_firewall_rule_spec' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleSpec(source interface{}) (object *GcpFirewallRuleSpec, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadGcpFirewallRuleSpec(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleSpec reads a value of the 'gcp_firewall_rule_spec' type from the given iterator.
+func ReadGcpFirewallRuleSpec(iterator *jsoniter.Iterator) *GcpFirewallRuleSpec {
+	object := &GcpFirewallRuleSpec{
+		fieldSet_: make([]bool, 8),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "allowed":
+			value := ReadGcpFirewallRuleAllowedList(iterator)
+			object.allowed = value
+			object.fieldSet_[0] = true
+		case "direction":
+			value := iterator.ReadString()
+			object.direction = value
+			object.fieldSet_[1] = true
+		case "name":
+			value := iterator.ReadString()
+			object.name = value
+			object.fieldSet_[2] = true
+		case "network":
+			value := iterator.ReadString()
+			object.network = value
+			object.fieldSet_[3] = true
+		case "priority":
+			value := iterator.ReadInt()
+			object.priority = value
+			object.fieldSet_[4] = true
+		case "source_ranges":
+			value := ReadStringList(iterator)
+			object.sourceRanges = value
+			object.fieldSet_[5] = true
+		case "source_service_accounts":
+			value := ReadStringList(iterator)
+			object.sourceServiceAccounts = value
+			object.fieldSet_[6] = true
+		case "target_service_accounts":
+			value := ReadStringList(iterator)
+			object.targetServiceAccounts = value
+			object.fieldSet_[7] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_builder.go
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Status of a GCP firewall rule set, containing the rendered rules.
+type GcpFirewallRuleStatusBuilder struct {
+	fieldSet_ []bool
+	rules     []*GcpFirewallRuleSpecBuilder
+}
+
+// NewGcpFirewallRuleStatus creates a new builder of 'gcp_firewall_rule_status' objects.
+func NewGcpFirewallRuleStatus() *GcpFirewallRuleStatusBuilder {
+	return &GcpFirewallRuleStatusBuilder{
+		fieldSet_: make([]bool, 1),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleStatusBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Rules sets the value of the 'rules' attribute to the given values.
+func (b *GcpFirewallRuleStatusBuilder) Rules(values ...*GcpFirewallRuleSpecBuilder) *GcpFirewallRuleStatusBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 1)
+	}
+	b.rules = make([]*GcpFirewallRuleSpecBuilder, len(values))
+	copy(b.rules, values)
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleStatusBuilder) Copy(object *GcpFirewallRuleStatus) *GcpFirewallRuleStatusBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	if object.rules != nil {
+		b.rules = make([]*GcpFirewallRuleSpecBuilder, len(object.rules))
+		for i, v := range object.rules {
+			b.rules[i] = NewGcpFirewallRuleSpec().Copy(v)
+		}
+	} else {
+		b.rules = nil
+	}
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule_status' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleStatusBuilder) Build() (object *GcpFirewallRuleStatus, err error) {
+	object = new(GcpFirewallRuleStatus)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	if b.rules != nil {
+		object.rules = make([]*GcpFirewallRuleSpec, len(b.rules))
+		for i, v := range b.rules {
+			object.rules[i], err = v.Build()
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleStatusListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule_status' objects.
+type GcpFirewallRuleStatusListBuilder struct {
+	items []*GcpFirewallRuleStatusBuilder
+}
+
+// NewGcpFirewallRuleStatusList creates a new builder of 'gcp_firewall_rule_status' objects.
+func NewGcpFirewallRuleStatusList() *GcpFirewallRuleStatusListBuilder {
+	return new(GcpFirewallRuleStatusListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleStatusListBuilder) Items(values ...*GcpFirewallRuleStatusBuilder) *GcpFirewallRuleStatusListBuilder {
+	b.items = make([]*GcpFirewallRuleStatusBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleStatusListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleStatusListBuilder) Copy(list *GcpFirewallRuleStatusList) *GcpFirewallRuleStatusListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleStatusBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRuleStatus().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule_status' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleStatusListBuilder) Build() (list *GcpFirewallRuleStatusList, err error) {
+	items := make([]*GcpFirewallRuleStatus, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleStatusList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleStatusList writes a list of values of the 'gcp_firewall_rule_status' type to
+// the given writer.
+func MarshalGcpFirewallRuleStatusList(list []*GcpFirewallRuleStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleStatusList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleStatusList writes a list of value of the 'gcp_firewall_rule_status' type to
+// the given stream.
+func WriteGcpFirewallRuleStatusList(list []*GcpFirewallRuleStatus, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRuleStatus(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleStatusList reads a list of values of the 'gcp_firewall_rule_status' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleStatusList(source interface{}) (items []*GcpFirewallRuleStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleStatusList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleStatusList reads list of values of the ”gcp_firewall_rule_status' type from
+// the given iterator.
+func ReadGcpFirewallRuleStatusList(iterator *jsoniter.Iterator) []*GcpFirewallRuleStatus {
+	list := []*GcpFirewallRuleStatus{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRuleStatus(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_type.go
@@ -1,0 +1,173 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleStatus represents the values of the 'gcp_firewall_rule_status' type.
+//
+// Status of a GCP firewall rule set, containing the rendered rules.
+type GcpFirewallRuleStatus struct {
+	fieldSet_ []bool
+	rules     []*GcpFirewallRuleSpec
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRuleStatus) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Rules returns the value of the 'rules' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Rendered firewall rule specifications.
+func (o *GcpFirewallRuleStatus) Rules() []*GcpFirewallRuleSpec {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.rules
+	}
+	return nil
+}
+
+// GetRules returns the value of the 'rules' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Rendered firewall rule specifications.
+func (o *GcpFirewallRuleStatus) GetRules() (value []*GcpFirewallRuleSpec, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.rules
+	}
+	return
+}
+
+// GcpFirewallRuleStatusListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule_status'.
+const GcpFirewallRuleStatusListKind = "GcpFirewallRuleStatusList"
+
+// GcpFirewallRuleStatusListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule_status'.
+const GcpFirewallRuleStatusListLinkKind = "GcpFirewallRuleStatusListLink"
+
+// GcpFirewallRuleStatusNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule_status'.
+const GcpFirewallRuleStatusListNilKind = "GcpFirewallRuleStatusListNil"
+
+// GcpFirewallRuleStatusList is a list of values of the 'gcp_firewall_rule_status' type.
+type GcpFirewallRuleStatusList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRuleStatus
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleStatusList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleStatusList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleStatusList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleStatusList) SetItems(items []*GcpFirewallRuleStatus) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleStatusList) Items() []*GcpFirewallRuleStatus {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleStatusList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleStatusList) Get(i int) *GcpFirewallRuleStatus {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleStatusList) Slice() []*GcpFirewallRuleStatus {
+	var slice []*GcpFirewallRuleStatus
+	if l == nil {
+		slice = make([]*GcpFirewallRuleStatus, 0)
+	} else {
+		slice = make([]*GcpFirewallRuleStatus, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleStatusList) Each(f func(item *GcpFirewallRuleStatus) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleStatusList) Range(f func(index int, item *GcpFirewallRuleStatus) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_status_type_json.go
@@ -1,0 +1,88 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleStatus writes a value of the 'gcp_firewall_rule_status' type to the given writer.
+func MarshalGcpFirewallRuleStatus(object *GcpFirewallRuleStatus, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleStatus(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleStatus writes a value of the 'gcp_firewall_rule_status' type to the given stream.
+func WriteGcpFirewallRuleStatus(object *GcpFirewallRuleStatus, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0] && object.rules != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("rules")
+		WriteGcpFirewallRuleSpecList(object.rules, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalGcpFirewallRuleStatus reads a value of the 'gcp_firewall_rule_status' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleStatus(source interface{}) (object *GcpFirewallRuleStatus, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadGcpFirewallRuleStatus(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleStatus reads a value of the 'gcp_firewall_rule_status' type from the given iterator.
+func ReadGcpFirewallRuleStatus(iterator *jsoniter.Iterator) *GcpFirewallRuleStatus {
+	object := &GcpFirewallRuleStatus{
+		fieldSet_: make([]bool, 1),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "rules":
+			value := ReadGcpFirewallRuleSpecList(iterator)
+			object.rules = value
+			object.fieldSet_[0] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_builder.go
@@ -1,0 +1,121 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GCP firewall rule template definition.
+// Templates define the set of firewall rules that will be created for a cluster.
+// Each template has a version and one or more profiles (e.g. "public", "private").
+type GcpFirewallRuleTemplateBuilder struct {
+	fieldSet_   []bool
+	description string
+	href        string
+	profile     string
+	version     string
+}
+
+// NewGcpFirewallRuleTemplate creates a new builder of 'gcp_firewall_rule_template' objects.
+func NewGcpFirewallRuleTemplate() *GcpFirewallRuleTemplateBuilder {
+	return &GcpFirewallRuleTemplateBuilder{
+		fieldSet_: make([]bool, 4),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleTemplateBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Description sets the value of the 'description' attribute to the given value.
+func (b *GcpFirewallRuleTemplateBuilder) Description(value string) *GcpFirewallRuleTemplateBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.description = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Href sets the value of the 'href' attribute to the given value.
+func (b *GcpFirewallRuleTemplateBuilder) Href(value string) *GcpFirewallRuleTemplateBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.href = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Profile sets the value of the 'profile' attribute to the given value.
+func (b *GcpFirewallRuleTemplateBuilder) Profile(value string) *GcpFirewallRuleTemplateBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.profile = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Version sets the value of the 'version' attribute to the given value.
+func (b *GcpFirewallRuleTemplateBuilder) Version(value string) *GcpFirewallRuleTemplateBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.version = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleTemplateBuilder) Copy(object *GcpFirewallRuleTemplate) *GcpFirewallRuleTemplateBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.description = object.description
+	b.href = object.href
+	b.profile = object.profile
+	b.version = object.version
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule_template' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleTemplateBuilder) Build() (object *GcpFirewallRuleTemplate, err error) {
+	object = new(GcpFirewallRuleTemplate)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.description = b.description
+	object.href = b.href
+	object.profile = b.profile
+	object.version = b.version
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleTemplateListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule_template' objects.
+type GcpFirewallRuleTemplateListBuilder struct {
+	items []*GcpFirewallRuleTemplateBuilder
+}
+
+// NewGcpFirewallRuleTemplateList creates a new builder of 'gcp_firewall_rule_template' objects.
+func NewGcpFirewallRuleTemplateList() *GcpFirewallRuleTemplateListBuilder {
+	return new(GcpFirewallRuleTemplateListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleTemplateListBuilder) Items(values ...*GcpFirewallRuleTemplateBuilder) *GcpFirewallRuleTemplateListBuilder {
+	b.items = make([]*GcpFirewallRuleTemplateBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleTemplateListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleTemplateListBuilder) Copy(list *GcpFirewallRuleTemplateList) *GcpFirewallRuleTemplateListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleTemplateBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRuleTemplate().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule_template' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleTemplateListBuilder) Build() (list *GcpFirewallRuleTemplateList, err error) {
+	items := make([]*GcpFirewallRuleTemplate, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleTemplateList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleTemplateList writes a list of values of the 'gcp_firewall_rule_template' type to
+// the given writer.
+func MarshalGcpFirewallRuleTemplateList(list []*GcpFirewallRuleTemplate, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleTemplateList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleTemplateList writes a list of value of the 'gcp_firewall_rule_template' type to
+// the given stream.
+func WriteGcpFirewallRuleTemplateList(list []*GcpFirewallRuleTemplate, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRuleTemplate(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleTemplateList reads a list of values of the 'gcp_firewall_rule_template' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleTemplateList(source interface{}) (items []*GcpFirewallRuleTemplate, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleTemplateList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleTemplateList reads list of values of the ”gcp_firewall_rule_template' type from
+// the given iterator.
+func ReadGcpFirewallRuleTemplateList(iterator *jsoniter.Iterator) []*GcpFirewallRuleTemplate {
+	list := []*GcpFirewallRuleTemplate{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRuleTemplate(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_builder.go
@@ -1,0 +1,93 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Template version and profile reference for a firewall rule.
+type GcpFirewallRuleTemplateRefBuilder struct {
+	fieldSet_ []bool
+	href      string
+	version   string
+}
+
+// NewGcpFirewallRuleTemplateRef creates a new builder of 'gcp_firewall_rule_template_ref' objects.
+func NewGcpFirewallRuleTemplateRef() *GcpFirewallRuleTemplateRefBuilder {
+	return &GcpFirewallRuleTemplateRefBuilder{
+		fieldSet_: make([]bool, 2),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *GcpFirewallRuleTemplateRefBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Href sets the value of the 'href' attribute to the given value.
+func (b *GcpFirewallRuleTemplateRefBuilder) Href(value string) *GcpFirewallRuleTemplateRefBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.href = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Version sets the value of the 'version' attribute to the given value.
+func (b *GcpFirewallRuleTemplateRefBuilder) Version(value string) *GcpFirewallRuleTemplateRefBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 2)
+	}
+	b.version = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *GcpFirewallRuleTemplateRefBuilder) Copy(object *GcpFirewallRuleTemplateRef) *GcpFirewallRuleTemplateRefBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.href = object.href
+	b.version = object.version
+	return b
+}
+
+// Build creates a 'gcp_firewall_rule_template_ref' object using the configuration stored in the builder.
+func (b *GcpFirewallRuleTemplateRefBuilder) Build() (object *GcpFirewallRuleTemplateRef, err error) {
+	object = new(GcpFirewallRuleTemplateRef)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.href = b.href
+	object.version = b.version
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_list_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleTemplateRefListBuilder contains the data and logic needed to build
+// 'gcp_firewall_rule_template_ref' objects.
+type GcpFirewallRuleTemplateRefListBuilder struct {
+	items []*GcpFirewallRuleTemplateRefBuilder
+}
+
+// NewGcpFirewallRuleTemplateRefList creates a new builder of 'gcp_firewall_rule_template_ref' objects.
+func NewGcpFirewallRuleTemplateRefList() *GcpFirewallRuleTemplateRefListBuilder {
+	return new(GcpFirewallRuleTemplateRefListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *GcpFirewallRuleTemplateRefListBuilder) Items(values ...*GcpFirewallRuleTemplateRefBuilder) *GcpFirewallRuleTemplateRefListBuilder {
+	b.items = make([]*GcpFirewallRuleTemplateRefBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *GcpFirewallRuleTemplateRefListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *GcpFirewallRuleTemplateRefListBuilder) Copy(list *GcpFirewallRuleTemplateRefList) *GcpFirewallRuleTemplateRefListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*GcpFirewallRuleTemplateRefBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewGcpFirewallRuleTemplateRef().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'gcp_firewall_rule_template_ref' objects using the
+// configuration stored in the builder.
+func (b *GcpFirewallRuleTemplateRefListBuilder) Build() (list *GcpFirewallRuleTemplateRefList, err error) {
+	items := make([]*GcpFirewallRuleTemplateRef, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(GcpFirewallRuleTemplateRefList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleTemplateRefList writes a list of values of the 'gcp_firewall_rule_template_ref' type to
+// the given writer.
+func MarshalGcpFirewallRuleTemplateRefList(list []*GcpFirewallRuleTemplateRef, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleTemplateRefList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleTemplateRefList writes a list of value of the 'gcp_firewall_rule_template_ref' type to
+// the given stream.
+func WriteGcpFirewallRuleTemplateRefList(list []*GcpFirewallRuleTemplateRef, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteGcpFirewallRuleTemplateRef(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalGcpFirewallRuleTemplateRefList reads a list of values of the 'gcp_firewall_rule_template_ref' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleTemplateRefList(source interface{}) (items []*GcpFirewallRuleTemplateRef, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadGcpFirewallRuleTemplateRefList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleTemplateRefList reads list of values of the ”gcp_firewall_rule_template_ref' type from
+// the given iterator.
+func ReadGcpFirewallRuleTemplateRefList(iterator *jsoniter.Iterator) []*GcpFirewallRuleTemplateRef {
+	list := []*GcpFirewallRuleTemplateRef{}
+	for iterator.ReadArray() {
+		item := ReadGcpFirewallRuleTemplateRef(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_type.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleTemplateRef represents the values of the 'gcp_firewall_rule_template_ref' type.
+//
+// Template version and profile reference for a firewall rule.
+type GcpFirewallRuleTemplateRef struct {
+	fieldSet_ []bool
+	href      string
+	version   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRuleTemplateRef) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Href returns the value of the 'href' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Self link to the template resource.
+func (o *GcpFirewallRuleTemplateRef) Href() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.href
+	}
+	return ""
+}
+
+// GetHref returns the value of the 'href' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Self link to the template resource.
+func (o *GcpFirewallRuleTemplateRef) GetHref() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Version returns the value of the 'version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Template version identifier.
+func (o *GcpFirewallRuleTemplateRef) Version() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.version
+	}
+	return ""
+}
+
+// GetVersion returns the value of the 'version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Template version identifier.
+func (o *GcpFirewallRuleTemplateRef) GetVersion() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.version
+	}
+	return
+}
+
+// GcpFirewallRuleTemplateRefListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule_template_ref'.
+const GcpFirewallRuleTemplateRefListKind = "GcpFirewallRuleTemplateRefList"
+
+// GcpFirewallRuleTemplateRefListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule_template_ref'.
+const GcpFirewallRuleTemplateRefListLinkKind = "GcpFirewallRuleTemplateRefListLink"
+
+// GcpFirewallRuleTemplateRefNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule_template_ref'.
+const GcpFirewallRuleTemplateRefListNilKind = "GcpFirewallRuleTemplateRefListNil"
+
+// GcpFirewallRuleTemplateRefList is a list of values of the 'gcp_firewall_rule_template_ref' type.
+type GcpFirewallRuleTemplateRefList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRuleTemplateRef
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleTemplateRefList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleTemplateRefList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleTemplateRefList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleTemplateRefList) SetItems(items []*GcpFirewallRuleTemplateRef) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleTemplateRefList) Items() []*GcpFirewallRuleTemplateRef {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleTemplateRefList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleTemplateRefList) Get(i int) *GcpFirewallRuleTemplateRef {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleTemplateRefList) Slice() []*GcpFirewallRuleTemplateRef {
+	var slice []*GcpFirewallRuleTemplateRef
+	if l == nil {
+		slice = make([]*GcpFirewallRuleTemplateRef, 0)
+	} else {
+		slice = make([]*GcpFirewallRuleTemplateRef, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleTemplateRefList) Each(f func(item *GcpFirewallRuleTemplateRef) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleTemplateRefList) Range(f func(index int, item *GcpFirewallRuleTemplateRef) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_ref_type_json.go
@@ -1,0 +1,101 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRuleTemplateRef writes a value of the 'gcp_firewall_rule_template_ref' type to the given writer.
+func MarshalGcpFirewallRuleTemplateRef(object *GcpFirewallRuleTemplateRef, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRuleTemplateRef(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRuleTemplateRef writes a value of the 'gcp_firewall_rule_template_ref' type to the given stream.
+func WriteGcpFirewallRuleTemplateRef(object *GcpFirewallRuleTemplateRef, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("version")
+		stream.WriteString(object.version)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalGcpFirewallRuleTemplateRef reads a value of the 'gcp_firewall_rule_template_ref' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRuleTemplateRef(source interface{}) (object *GcpFirewallRuleTemplateRef, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadGcpFirewallRuleTemplateRef(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRuleTemplateRef reads a value of the 'gcp_firewall_rule_template_ref' type from the given iterator.
+func ReadGcpFirewallRuleTemplateRef(iterator *jsoniter.Iterator) *GcpFirewallRuleTemplateRef {
+	object := &GcpFirewallRuleTemplateRef{
+		fieldSet_: make([]bool, 2),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "href":
+			value := iterator.ReadString()
+			object.href = value
+			object.fieldSet_[0] = true
+		case "version":
+			value := iterator.ReadString()
+			object.version = value
+			object.fieldSet_[1] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_type.go
@@ -1,0 +1,247 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleTemplate represents the values of the 'gcp_firewall_rule_template' type.
+//
+// GCP firewall rule template definition.
+// Templates define the set of firewall rules that will be created for a cluster.
+// Each template has a version and one or more profiles (e.g. "public", "private").
+type GcpFirewallRuleTemplate struct {
+	fieldSet_   []bool
+	description string
+	href        string
+	profile     string
+	version     string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRuleTemplate) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// Description returns the value of the 'description' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Human-readable description of this template profile.
+func (o *GcpFirewallRuleTemplate) Description() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.description
+	}
+	return ""
+}
+
+// GetDescription returns the value of the 'description' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Human-readable description of this template profile.
+func (o *GcpFirewallRuleTemplate) GetDescription() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.description
+	}
+	return
+}
+
+// Href returns the value of the 'href' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Self link to the template resource.
+func (o *GcpFirewallRuleTemplate) Href() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.href
+	}
+	return ""
+}
+
+// GetHref returns the value of the 'href' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Self link to the template resource.
+func (o *GcpFirewallRuleTemplate) GetHref() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Profile returns the value of the 'profile' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Profile name (e.g. "public", "private").
+func (o *GcpFirewallRuleTemplate) Profile() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.profile
+	}
+	return ""
+}
+
+// GetProfile returns the value of the 'profile' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Profile name (e.g. "public", "private").
+func (o *GcpFirewallRuleTemplate) GetProfile() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.profile
+	}
+	return
+}
+
+// Version returns the value of the 'version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Template version identifier (e.g. "v1").
+func (o *GcpFirewallRuleTemplate) Version() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.version
+	}
+	return ""
+}
+
+// GetVersion returns the value of the 'version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Template version identifier (e.g. "v1").
+func (o *GcpFirewallRuleTemplate) GetVersion() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.version
+	}
+	return
+}
+
+// GcpFirewallRuleTemplateListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule_template'.
+const GcpFirewallRuleTemplateListKind = "GcpFirewallRuleTemplateList"
+
+// GcpFirewallRuleTemplateListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule_template'.
+const GcpFirewallRuleTemplateListLinkKind = "GcpFirewallRuleTemplateListLink"
+
+// GcpFirewallRuleTemplateNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule_template'.
+const GcpFirewallRuleTemplateListNilKind = "GcpFirewallRuleTemplateListNil"
+
+// GcpFirewallRuleTemplateList is a list of values of the 'gcp_firewall_rule_template' type.
+type GcpFirewallRuleTemplateList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRuleTemplate
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleTemplateList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleTemplateList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleTemplateList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleTemplateList) SetItems(items []*GcpFirewallRuleTemplate) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleTemplateList) Items() []*GcpFirewallRuleTemplate {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleTemplateList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleTemplateList) Get(i int) *GcpFirewallRuleTemplate {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleTemplateList) Slice() []*GcpFirewallRuleTemplate {
+	var slice []*GcpFirewallRuleTemplate
+	if l == nil {
+		slice = make([]*GcpFirewallRuleTemplate, 0)
+	} else {
+		slice = make([]*GcpFirewallRuleTemplate, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleTemplateList) Each(f func(item *GcpFirewallRuleTemplate) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleTemplateList) Range(f func(index int, item *GcpFirewallRuleTemplate) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_template_type_json.go
@@ -26,10 +26,10 @@ import (
 	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
 )
 
-// MarshalGCPNetwork writes a value of the 'GCP_network' type to the given writer.
-func MarshalGCPNetwork(object *GCPNetwork, writer io.Writer) error {
+// MarshalGcpFirewallRuleTemplate writes a value of the 'gcp_firewall_rule_template' type to the given writer.
+func MarshalGcpFirewallRuleTemplate(object *GcpFirewallRuleTemplate, writer io.Writer) error {
 	stream := helpers.NewStream(writer)
-	WriteGCPNetwork(object, stream)
+	WriteGcpFirewallRuleTemplate(object, stream)
 	err := stream.Flush()
 	if err != nil {
 		return err
@@ -37,8 +37,8 @@ func MarshalGCPNetwork(object *GCPNetwork, writer io.Writer) error {
 	return stream.Error
 }
 
-// WriteGCPNetwork writes a value of the 'GCP_network' type to the given stream.
-func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
+// WriteGcpFirewallRuleTemplate writes a value of the 'gcp_firewall_rule_template' type to the given stream.
+func WriteGcpFirewallRuleTemplate(object *GcpFirewallRuleTemplate, stream *jsoniter.Stream) {
 	count := 0
 	stream.WriteObjectStart()
 	var present_ bool
@@ -47,8 +47,8 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("vpc_name")
-		stream.WriteString(object.vpcName)
+		stream.WriteObjectField("description")
+		stream.WriteString(object.description)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
@@ -56,8 +56,8 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("vpc_project_id")
-		stream.WriteString(object.vpcProjectID)
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
@@ -65,8 +65,8 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("compute_subnet")
-		stream.WriteString(object.computeSubnet)
+		stream.WriteObjectField("profile")
+		stream.WriteString(object.profile)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
@@ -74,37 +74,28 @@ func WriteGCPNetwork(object *GCPNetwork, stream *jsoniter.Stream) {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("control_plane_subnet")
-		stream.WriteString(object.controlPlaneSubnet)
-		count++
-	}
-	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
-	if present_ {
-		if count > 0 {
-			stream.WriteMore()
-		}
-		stream.WriteObjectField("firewall_rules_id")
-		stream.WriteString(object.firewallRulesId)
+		stream.WriteObjectField("version")
+		stream.WriteString(object.version)
 	}
 	stream.WriteObjectEnd()
 }
 
-// UnmarshalGCPNetwork reads a value of the 'GCP_network' type from the given
+// UnmarshalGcpFirewallRuleTemplate reads a value of the 'gcp_firewall_rule_template' type from the given
 // source, which can be an slice of bytes, a string or a reader.
-func UnmarshalGCPNetwork(source interface{}) (object *GCPNetwork, err error) {
+func UnmarshalGcpFirewallRuleTemplate(source interface{}) (object *GcpFirewallRuleTemplate, err error) {
 	iterator, err := helpers.NewIterator(source)
 	if err != nil {
 		return
 	}
-	object = ReadGCPNetwork(iterator)
+	object = ReadGcpFirewallRuleTemplate(iterator)
 	err = iterator.Error
 	return
 }
 
-// ReadGCPNetwork reads a value of the 'GCP_network' type from the given iterator.
-func ReadGCPNetwork(iterator *jsoniter.Iterator) *GCPNetwork {
-	object := &GCPNetwork{
-		fieldSet_: make([]bool, 5),
+// ReadGcpFirewallRuleTemplate reads a value of the 'gcp_firewall_rule_template' type from the given iterator.
+func ReadGcpFirewallRuleTemplate(iterator *jsoniter.Iterator) *GcpFirewallRuleTemplate {
+	object := &GcpFirewallRuleTemplate{
+		fieldSet_: make([]bool, 4),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -112,26 +103,22 @@ func ReadGCPNetwork(iterator *jsoniter.Iterator) *GCPNetwork {
 			break
 		}
 		switch field {
-		case "vpc_name":
+		case "description":
 			value := iterator.ReadString()
-			object.vpcName = value
+			object.description = value
 			object.fieldSet_[0] = true
-		case "vpc_project_id":
+		case "href":
 			value := iterator.ReadString()
-			object.vpcProjectID = value
+			object.href = value
 			object.fieldSet_[1] = true
-		case "compute_subnet":
+		case "profile":
 			value := iterator.ReadString()
-			object.computeSubnet = value
+			object.profile = value
 			object.fieldSet_[2] = true
-		case "control_plane_subnet":
+		case "version":
 			value := iterator.ReadString()
-			object.controlPlaneSubnet = value
+			object.version = value
 			object.fieldSet_[3] = true
-		case "firewall_rules_id":
-			value := iterator.ReadString()
-			object.firewallRulesId = value
-			object.fieldSet_[4] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_type.go
@@ -1,0 +1,421 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// GcpFirewallRuleKind is the name of the type used to represent objects
+// of type 'gcp_firewall_rule'.
+const GcpFirewallRuleKind = "GcpFirewallRule"
+
+// GcpFirewallRuleLinkKind is the name of the type used to represent links
+// to objects of type 'gcp_firewall_rule'.
+const GcpFirewallRuleLinkKind = "GcpFirewallRuleLink"
+
+// GcpFirewallRuleNilKind is the name of the type used to nil references
+// to objects of type 'gcp_firewall_rule'.
+const GcpFirewallRuleNilKind = "GcpFirewallRuleNil"
+
+// GcpFirewallRule represents the values of the 'gcp_firewall_rule' type.
+//
+// GCP firewall rule configuration for BYO (Bring Your Own) firewall workflow.
+// These are organization-level resources that can be created before cluster
+// provisioning and reused after cluster deletion.
+type GcpFirewallRule struct {
+	fieldSet_    []bool
+	id           string
+	href         string
+	gcpNetwork   *GcpFirewallRuleGcpNetwork
+	name         string
+	organization *OrganizationLink
+	profile      string
+	status       *GcpFirewallRuleStatus
+	template     *GcpFirewallRuleTemplateRef
+	wifConfig    *WifConfig
+}
+
+// Kind returns the name of the type of the object.
+func (o *GcpFirewallRule) Kind() string {
+	if o == nil {
+		return GcpFirewallRuleNilKind
+	}
+	if len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return GcpFirewallRuleLinkKind
+	}
+	return GcpFirewallRuleKind
+}
+
+// Link returns true if this is a link.
+func (o *GcpFirewallRule) Link() bool {
+	return o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+}
+
+// ID returns the identifier of the object.
+func (o *GcpFirewallRule) ID() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.id
+	}
+	return ""
+}
+
+// GetID returns the identifier of the object and a flag indicating if the
+// identifier has a value.
+func (o *GcpFirewallRule) GetID() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.id
+	}
+	return
+}
+
+// HREF returns the link to the object.
+func (o *GcpFirewallRule) HREF() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the object and a flag indicating if the
+// link has a value.
+func (o *GcpFirewallRule) GetHREF() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.href
+	}
+	return
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *GcpFirewallRule) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+
+	// Check all fields except the link flag (index 0)
+	for i := 1; i < len(o.fieldSet_); i++ {
+		if o.fieldSet_[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// GcpNetwork returns the value of the 'gcp_network' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// GCP network configuration.
+func (o *GcpFirewallRule) GcpNetwork() *GcpFirewallRuleGcpNetwork {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.gcpNetwork
+	}
+	return nil
+}
+
+// GetGcpNetwork returns the value of the 'gcp_network' attribute and
+// a flag indicating if the attribute has a value.
+//
+// GCP network configuration.
+func (o *GcpFirewallRule) GetGcpNetwork() (value *GcpFirewallRuleGcpNetwork, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.gcpNetwork
+	}
+	return
+}
+
+// Name returns the value of the 'name' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Firewall rule name (unique per organization).
+func (o *GcpFirewallRule) Name() string {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
+		return o.name
+	}
+	return ""
+}
+
+// GetName returns the value of the 'name' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Firewall rule name (unique per organization).
+func (o *GcpFirewallRule) GetName() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
+	if ok {
+		value = o.name
+	}
+	return
+}
+
+// Organization returns the value of the 'organization' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Link to the organization that owns this firewall rule.
+func (o *GcpFirewallRule) Organization() *OrganizationLink {
+	if o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5] {
+		return o.organization
+	}
+	return nil
+}
+
+// GetOrganization returns the value of the 'organization' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Link to the organization that owns this firewall rule.
+func (o *GcpFirewallRule) GetOrganization() (value *OrganizationLink, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 5 && o.fieldSet_[5]
+	if ok {
+		value = o.organization
+	}
+	return
+}
+
+// Profile returns the value of the 'profile' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Profile type (e.g. "public", "private").
+func (o *GcpFirewallRule) Profile() string {
+	if o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6] {
+		return o.profile
+	}
+	return ""
+}
+
+// GetProfile returns the value of the 'profile' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Profile type (e.g. "public", "private").
+func (o *GcpFirewallRule) GetProfile() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 6 && o.fieldSet_[6]
+	if ok {
+		value = o.profile
+	}
+	return
+}
+
+// Status returns the value of the 'status' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Status containing the rendered firewall rules.
+func (o *GcpFirewallRule) Status() *GcpFirewallRuleStatus {
+	if o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7] {
+		return o.status
+	}
+	return nil
+}
+
+// GetStatus returns the value of the 'status' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Status containing the rendered firewall rules.
+func (o *GcpFirewallRule) GetStatus() (value *GcpFirewallRuleStatus, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 7 && o.fieldSet_[7]
+	if ok {
+		value = o.status
+	}
+	return
+}
+
+// Template returns the value of the 'template' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Template version and profile reference.
+func (o *GcpFirewallRule) Template() *GcpFirewallRuleTemplateRef {
+	if o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8] {
+		return o.template
+	}
+	return nil
+}
+
+// GetTemplate returns the value of the 'template' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Template version and profile reference.
+func (o *GcpFirewallRule) GetTemplate() (value *GcpFirewallRuleTemplateRef, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 8 && o.fieldSet_[8]
+	if ok {
+		value = o.template
+	}
+	return
+}
+
+// WifConfig returns the value of the 'wif_config' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Link to the WIF config used by this firewall rule.
+func (o *GcpFirewallRule) WifConfig() *WifConfig {
+	if o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9] {
+		return o.wifConfig
+	}
+	return nil
+}
+
+// GetWifConfig returns the value of the 'wif_config' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Link to the WIF config used by this firewall rule.
+func (o *GcpFirewallRule) GetWifConfig() (value *WifConfig, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 9 && o.fieldSet_[9]
+	if ok {
+		value = o.wifConfig
+	}
+	return
+}
+
+// GcpFirewallRuleListKind is the name of the type used to represent list of objects of
+// type 'gcp_firewall_rule'.
+const GcpFirewallRuleListKind = "GcpFirewallRuleList"
+
+// GcpFirewallRuleListLinkKind is the name of the type used to represent links to list
+// of objects of type 'gcp_firewall_rule'.
+const GcpFirewallRuleListLinkKind = "GcpFirewallRuleListLink"
+
+// GcpFirewallRuleNilKind is the name of the type used to nil lists of objects of
+// type 'gcp_firewall_rule'.
+const GcpFirewallRuleListNilKind = "GcpFirewallRuleListNil"
+
+// GcpFirewallRuleList is a list of values of the 'gcp_firewall_rule' type.
+type GcpFirewallRuleList struct {
+	href  string
+	link  bool
+	items []*GcpFirewallRule
+}
+
+// Kind returns the name of the type of the object.
+func (l *GcpFirewallRuleList) Kind() string {
+	if l == nil {
+		return GcpFirewallRuleListNilKind
+	}
+	if l.link {
+		return GcpFirewallRuleListLinkKind
+	}
+	return GcpFirewallRuleListKind
+}
+
+// Link returns true iif this is a link.
+func (l *GcpFirewallRuleList) Link() bool {
+	return l != nil && l.link
+}
+
+// HREF returns the link to the list.
+func (l *GcpFirewallRuleList) HREF() string {
+	if l != nil {
+		return l.href
+	}
+	return ""
+}
+
+// GetHREF returns the link of the list and a flag indicating if the
+// link has a value.
+func (l *GcpFirewallRuleList) GetHREF() (value string, ok bool) {
+	ok = l != nil && l.href != ""
+	if ok {
+		value = l.href
+	}
+	return
+}
+
+// Len returns the length of the list.
+func (l *GcpFirewallRuleList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *GcpFirewallRuleList) SetItems(items []*GcpFirewallRule) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *GcpFirewallRuleList) Items() []*GcpFirewallRule {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *GcpFirewallRuleList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *GcpFirewallRuleList) Get(i int) *GcpFirewallRule {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *GcpFirewallRuleList) Slice() []*GcpFirewallRule {
+	var slice []*GcpFirewallRule
+	if l == nil {
+		slice = make([]*GcpFirewallRule, 0)
+	} else {
+		slice = make([]*GcpFirewallRule, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *GcpFirewallRuleList) Each(f func(item *GcpFirewallRule) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *GcpFirewallRuleList) Range(f func(index int, item *GcpFirewallRule) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/gcp_firewall_rule_type_json.go
+++ b/clientapi/clustersmgmt/v1/gcp_firewall_rule_type_json.go
@@ -1,0 +1,200 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalGcpFirewallRule writes a value of the 'gcp_firewall_rule' type to the given writer.
+func MarshalGcpFirewallRule(object *GcpFirewallRule, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteGcpFirewallRule(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteGcpFirewallRule writes a value of the 'gcp_firewall_rule' type to the given stream.
+func WriteGcpFirewallRule(object *GcpFirewallRule, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	stream.WriteObjectField("kind")
+	if len(object.fieldSet_) > 0 && object.fieldSet_[0] {
+		stream.WriteString(GcpFirewallRuleLinkKind)
+	} else {
+		stream.WriteString(GcpFirewallRuleKind)
+	}
+	count++
+	if len(object.fieldSet_) > 1 && object.fieldSet_[1] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("id")
+		stream.WriteString(object.id)
+		count++
+	}
+	if len(object.fieldSet_) > 2 && object.fieldSet_[2] {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("href")
+		stream.WriteString(object.href)
+		count++
+	}
+	var present_ bool
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3] && object.gcpNetwork != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("gcp_network")
+		WriteGcpFirewallRuleGcpNetwork(object.gcpNetwork, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("name")
+		stream.WriteString(object.name)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 5 && object.fieldSet_[5] && object.organization != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("organization")
+		WriteOrganizationLink(object.organization, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 6 && object.fieldSet_[6]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("profile")
+		stream.WriteString(object.profile)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 7 && object.fieldSet_[7] && object.status != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("status")
+		WriteGcpFirewallRuleStatus(object.status, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 8 && object.fieldSet_[8] && object.template != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("template")
+		WriteGcpFirewallRuleTemplateRef(object.template, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 9 && object.fieldSet_[9] && object.wifConfig != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("wif_config")
+		WriteWifConfig(object.wifConfig, stream)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalGcpFirewallRule reads a value of the 'gcp_firewall_rule' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalGcpFirewallRule(source interface{}) (object *GcpFirewallRule, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadGcpFirewallRule(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadGcpFirewallRule reads a value of the 'gcp_firewall_rule' type from the given iterator.
+func ReadGcpFirewallRule(iterator *jsoniter.Iterator) *GcpFirewallRule {
+	object := &GcpFirewallRule{
+		fieldSet_: make([]bool, 10),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "kind":
+			value := iterator.ReadString()
+			if value == GcpFirewallRuleLinkKind {
+				object.fieldSet_[0] = true
+			}
+		case "id":
+			object.id = iterator.ReadString()
+			object.fieldSet_[1] = true
+		case "href":
+			object.href = iterator.ReadString()
+			object.fieldSet_[2] = true
+		case "gcp_network":
+			value := ReadGcpFirewallRuleGcpNetwork(iterator)
+			object.gcpNetwork = value
+			object.fieldSet_[3] = true
+		case "name":
+			value := iterator.ReadString()
+			object.name = value
+			object.fieldSet_[4] = true
+		case "organization":
+			value := ReadOrganizationLink(iterator)
+			object.organization = value
+			object.fieldSet_[5] = true
+		case "profile":
+			value := iterator.ReadString()
+			object.profile = value
+			object.fieldSet_[6] = true
+		case "status":
+			value := ReadGcpFirewallRuleStatus(iterator)
+			object.status = value
+			object.fieldSet_[7] = true
+		case "template":
+			value := ReadGcpFirewallRuleTemplateRef(iterator)
+			object.template = value
+			object.fieldSet_[8] = true
+		case "wif_config":
+			value := ReadWifConfig(iterator)
+			object.wifConfig = value
+			object.fieldSet_[9] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/gcp_network_builder.go
+++ b/clientapi/clustersmgmt/v1/gcp_network_builder.go
@@ -26,12 +26,13 @@ type GCPNetworkBuilder struct {
 	vpcProjectID       string
 	computeSubnet      string
 	controlPlaneSubnet string
+	firewallRulesId    string
 }
 
 // NewGCPNetwork creates a new builder of 'GCP_network' objects.
 func NewGCPNetwork() *GCPNetworkBuilder {
 	return &GCPNetworkBuilder{
-		fieldSet_: make([]bool, 4),
+		fieldSet_: make([]bool, 5),
 	}
 }
 
@@ -51,7 +52,7 @@ func (b *GCPNetworkBuilder) Empty() bool {
 // VPCName sets the value of the 'VPC_name' attribute to the given value.
 func (b *GCPNetworkBuilder) VPCName(value string) *GCPNetworkBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.vpcName = value
 	b.fieldSet_[0] = true
@@ -61,7 +62,7 @@ func (b *GCPNetworkBuilder) VPCName(value string) *GCPNetworkBuilder {
 // VPCProjectID sets the value of the 'VPC_project_ID' attribute to the given value.
 func (b *GCPNetworkBuilder) VPCProjectID(value string) *GCPNetworkBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.vpcProjectID = value
 	b.fieldSet_[1] = true
@@ -71,7 +72,7 @@ func (b *GCPNetworkBuilder) VPCProjectID(value string) *GCPNetworkBuilder {
 // ComputeSubnet sets the value of the 'compute_subnet' attribute to the given value.
 func (b *GCPNetworkBuilder) ComputeSubnet(value string) *GCPNetworkBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.computeSubnet = value
 	b.fieldSet_[2] = true
@@ -81,10 +82,20 @@ func (b *GCPNetworkBuilder) ComputeSubnet(value string) *GCPNetworkBuilder {
 // ControlPlaneSubnet sets the value of the 'control_plane_subnet' attribute to the given value.
 func (b *GCPNetworkBuilder) ControlPlaneSubnet(value string) *GCPNetworkBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.controlPlaneSubnet = value
 	b.fieldSet_[3] = true
+	return b
+}
+
+// FirewallRulesId sets the value of the 'firewall_rules_id' attribute to the given value.
+func (b *GCPNetworkBuilder) FirewallRulesId(value string) *GCPNetworkBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 5)
+	}
+	b.firewallRulesId = value
+	b.fieldSet_[4] = true
 	return b
 }
 
@@ -101,6 +112,7 @@ func (b *GCPNetworkBuilder) Copy(object *GCPNetwork) *GCPNetworkBuilder {
 	b.vpcProjectID = object.vpcProjectID
 	b.computeSubnet = object.computeSubnet
 	b.controlPlaneSubnet = object.controlPlaneSubnet
+	b.firewallRulesId = object.firewallRulesId
 	return b
 }
 
@@ -115,5 +127,6 @@ func (b *GCPNetworkBuilder) Build() (object *GCPNetwork, err error) {
 	object.vpcProjectID = b.vpcProjectID
 	object.computeSubnet = b.computeSubnet
 	object.controlPlaneSubnet = b.controlPlaneSubnet
+	object.firewallRulesId = b.firewallRulesId
 	return
 }

--- a/clientapi/clustersmgmt/v1/gcp_network_type.go
+++ b/clientapi/clustersmgmt/v1/gcp_network_type.go
@@ -28,6 +28,7 @@ type GCPNetwork struct {
 	vpcProjectID       string
 	computeSubnet      string
 	controlPlaneSubnet string
+	firewallRulesId    string
 }
 
 // Empty returns true if the object is empty, i.e. no attribute has a value.
@@ -131,6 +132,29 @@ func (o *GCPNetwork) GetControlPlaneSubnet() (value string, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
 	if ok {
 		value = o.controlPlaneSubnet
+	}
+	return
+}
+
+// FirewallRulesId returns the value of the 'firewall_rules_id' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// ID of the GCP firewall rule set associated with this cluster.
+func (o *GCPNetwork) FirewallRulesId() string {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
+		return o.firewallRulesId
+	}
+	return ""
+}
+
+// GetFirewallRulesId returns the value of the 'firewall_rules_id' attribute and
+// a flag indicating if the attribute has a value.
+//
+// ID of the GCP firewall rule set associated with this cluster.
+func (o *GCPNetwork) GetFirewallRulesId() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
+	if ok {
+		value = o.firewallRulesId
 	}
 	return
 }

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_resource.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages the collection of gcp endpoints.
-resource GCP {
-	// Reference to the resource that manages wif_configs
-	locator WifConfigs {
-		target WifConfigs
+// Manages a specific GCP firewall rule.
+resource GcpFirewallRule {
+
+	// Retrieves the details of the firewall rule.
+	method Get {
+		out Body GcpFirewallRule
 	}
 
-	// Reference to the resource that manages GCP firewall rules.
-	locator FirewallRules {
-		target GcpFirewallRules
-	}
-
-	// Reference to the resource that manages GCP firewall rule templates.
-	locator FirewallRuleTemplates {
-		target GcpFirewallRuleTemplates
+	// Deletes the firewall rule.
+	method Delete {
 	}
 }

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_template_profiles_resource.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_template_profiles_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages the collection of gcp endpoints.
-resource GCP {
-	// Reference to the resource that manages wif_configs
-	locator WifConfigs {
-		target WifConfigs
-	}
-
-	// Reference to the resource that manages GCP firewall rules.
-	locator FirewallRules {
-		target GcpFirewallRules
-	}
-
-	// Reference to the resource that manages GCP firewall rule templates.
-	locator FirewallRuleTemplates {
-		target GcpFirewallRuleTemplates
+// Collection of profiles for a specific firewall rule template version.
+// Path: /gcp/firewall_rule_templates/{version}/profiles
+resource GcpFirewallRuleTemplateProfiles {
+	// Reference to a specific profile.
+	locator GcpFirewallRuleTemplate {
+		target GcpFirewallRuleTemplate
+		variable Profile
 	}
 }

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_template_resource.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_template_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages the collection of gcp endpoints.
-resource GCP {
-	// Reference to the resource that manages wif_configs
-	locator WifConfigs {
-		target WifConfigs
-	}
-
-	// Reference to the resource that manages GCP firewall rules.
-	locator FirewallRules {
-		target GcpFirewallRules
-	}
-
-	// Reference to the resource that manages GCP firewall rule templates.
-	locator FirewallRuleTemplates {
-		target GcpFirewallRuleTemplates
+// Manages a specific GCP firewall rule template profile.
+// Path: /gcp/firewall_rule_templates/{version}/profiles/{profile}
+resource GcpFirewallRuleTemplate {
+	// Retrieves the details of the firewall rule template.
+	method Get {
+		out Body GcpFirewallRuleTemplate
 	}
 }

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_template_type.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_template_type.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages the collection of gcp endpoints.
-resource GCP {
-	// Reference to the resource that manages wif_configs
-	locator WifConfigs {
-		target WifConfigs
-	}
+// GCP firewall rule template definition.
+// Templates define the set of firewall rules that will be created for a cluster.
+// Each template has a version and one or more profiles (e.g. "public", "private").
+struct GcpFirewallRuleTemplate {
+	// Template version identifier (e.g. "v1").
+	Version String
 
-	// Reference to the resource that manages GCP firewall rules.
-	locator FirewallRules {
-		target GcpFirewallRules
-	}
+	// Profile name (e.g. "public", "private").
+	Profile String
 
-	// Reference to the resource that manages GCP firewall rule templates.
-	locator FirewallRuleTemplates {
-		target GcpFirewallRuleTemplates
-	}
+	// Human-readable description of this template profile.
+	Description String
+
+	// Self link to the template resource.
+	Href String
 }

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_template_version_resource.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_template_version_resource.model
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2024 Red Hat, Inc.
+Copyright (c) 2026 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Manages the collection of gcp endpoints.
-resource GCP {
-	// Reference to the resource that manages wif_configs
-	locator WifConfigs {
-		target WifConfigs
-	}
-
-	// Reference to the resource that manages GCP firewall rules.
-	locator FirewallRules {
-		target GcpFirewallRules
-	}
-
-	// Reference to the resource that manages GCP firewall rule templates.
-	locator FirewallRuleTemplates {
-		target GcpFirewallRuleTemplates
+// Intermediate resource for a specific firewall rule template version.
+// Path: /gcp/firewall_rule_templates/{version}
+resource GcpFirewallRuleTemplateVersion {
+	// Navigate to the profiles for this template version.
+	locator Profiles {
+		target GcpFirewallRuleTemplateProfiles
 	}
 }

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_templates_resource.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_templates_resource.model
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of GCP firewall rule templates.
+resource GcpFirewallRuleTemplates {
+	// Lists all available firewall rule templates.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Total number of items of the collection.
+		out Total Integer
+
+		// Retrieved list of firewall rule templates.
+		out Items []GcpFirewallRuleTemplate
+	}
+
+	// Reference to a specific firewall rule template version.
+	locator GcpFirewallRuleTemplateVersion {
+		target GcpFirewallRuleTemplateVersion
+		variable Version
+	}
+}

--- a/model/clusters_mgmt/v1/gcp_firewall_rule_type.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rule_type.model
@@ -1,0 +1,104 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// GCP firewall rule configuration for BYO (Bring Your Own) firewall workflow.
+// These are organization-level resources that can be created before cluster
+// provisioning and reused after cluster deletion.
+class GcpFirewallRule {
+	// Firewall rule name (unique per organization).
+	Name String
+
+	// Profile type (e.g. "public", "private").
+	Profile String
+
+	// Template version and profile reference.
+	Template GcpFirewallRuleTemplateRef
+
+	// Link to the WIF config used by this firewall rule.
+	link WifConfig WifConfig
+
+	// GCP network configuration.
+	GcpNetwork GcpFirewallRuleGcpNetwork
+
+	// Status containing the rendered firewall rules.
+	Status GcpFirewallRuleStatus
+
+	// Link to the organization that owns this firewall rule.
+	Organization OrganizationLink
+}
+
+// Status of a GCP firewall rule set, containing the rendered rules.
+struct GcpFirewallRuleStatus {
+	// Rendered firewall rule specifications.
+	Rules []GcpFirewallRuleSpec
+}
+
+// A single rendered GCP firewall rule specification.
+struct GcpFirewallRuleSpec {
+	// Name of the firewall rule.
+	Name String
+
+	// GCP network URL.
+	Network String
+
+	// Direction of traffic (INGRESS or EGRESS).
+	Direction String
+
+	// Priority of the rule (0-65535).
+	Priority Integer
+
+	// Allowed protocols and ports.
+	Allowed []GcpFirewallRuleAllowed
+
+	// Source IP CIDR ranges.
+	SourceRanges []String
+
+	// Source service accounts.
+	SourceServiceAccounts []String
+
+	// Target service accounts.
+	TargetServiceAccounts []String
+}
+
+// Allowed protocol and ports for a GCP firewall rule.
+struct GcpFirewallRuleAllowed {
+	// IP protocol (e.g. "tcp", "udp", "icmp").
+	IPProtocol String
+
+	// Ports to allow (e.g. "6443", "10250").
+	Ports []String
+}
+
+// Template version and profile reference for a firewall rule.
+struct GcpFirewallRuleTemplateRef {
+	// Template version identifier.
+	Version String
+
+	// Self link to the template resource.
+	Href String
+}
+
+// GCP network configuration for a firewall rule.
+struct GcpFirewallRuleGcpNetwork {
+	// GCP project ID.
+	ProjectId String
+
+	// VPC network name.
+	VpcName String
+
+	// Machine CIDR block.
+	MachineCidr String
+}

--- a/model/clusters_mgmt/v1/gcp_firewall_rules_resource.model
+++ b/model/clusters_mgmt/v1/gcp_firewall_rules_resource.model
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Manages the collection of GCP firewall rules.
+resource GcpFirewallRules {
+	// Lists the GCP firewall rules.
+	method List {
+		// Index of the requested page, where one corresponds to the first page.
+		in out Page Integer = 1
+
+		// Maximum number of items that will be contained in the returned page.
+		in out Size Integer = 100
+
+		// Total number of items of the collection.
+		out Total Integer
+
+		// Retrieved list of GCP firewall rules.
+		out Items []GcpFirewallRule
+	}
+
+	// Creates a new GCP firewall rule.
+	method Add {
+		// Description of the GCP firewall rule.
+		in out Body GcpFirewallRule
+	}
+
+	// Reference to the resource that manages a specific GCP firewall rule.
+	locator GcpFirewallRule {
+		target GcpFirewallRule
+		variable ID
+	}
+}

--- a/model/clusters_mgmt/v1/gcp_network_type.model
+++ b/model/clusters_mgmt/v1/gcp_network_type.model
@@ -27,4 +27,7 @@ struct GCPNetwork {
 
     // Compute subnet used by the cluster.
     ComputeSubnet   String
+
+    // ID of the GCP firewall rule set associated with this cluster.
+    FirewallRulesId String
 }

--- a/model/clusters_mgmt/v1/gcp_type.model
+++ b/model/clusters_mgmt/v1/gcp_type.model
@@ -41,6 +41,5 @@ struct GCP {
 	// GCP Authentication Method
 	Authentication GcpAuthentication
 	// GCP PrivateServiceConnect configuration
-	PrivateServiceConnect GcpPrivateServiceConnect 
-
+	PrivateServiceConnect GcpPrivateServiceConnect
 }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -11133,6 +11133,292 @@
         }
       }
     },
+    "/api/clusters_mgmt/v1/gcp/firewall_rule_templates": {
+      "get": {
+        "description": "Lists all available firewall rule templates.",
+        "parameters": [
+          {
+            "name": "page",
+            "description": "Index of the requested page, where one corresponds to the first page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "size",
+            "description": "Maximum number of items that will be contained in the returned page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "description": "Retrieved list of firewall rule templates.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GcpFirewallRuleTemplate"
+                      }
+                    },
+                    "page": {
+                      "description": "Index of the requested page, where one corresponds to the first page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "size": {
+                      "description": "Maximum number of items that will be contained in the returned page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "total": {
+                      "description": "Total number of items of the collection.",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clusters_mgmt/v1/gcp/firewall_rule_templates/{gcp_firewall_rule_template_version_id}/profiles/{gcp_firewall_rule_template_id}": {
+      "get": {
+        "description": "Retrieves the details of the firewall rule template.",
+        "parameters": [
+          {
+            "name": "gcp_firewall_rule_template_version_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "gcp_firewall_rule_template_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GcpFirewallRuleTemplate"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clusters_mgmt/v1/gcp/firewall_rules": {
+      "post": {
+        "description": "Creates a new GCP firewall rule.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GcpFirewallRule"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GcpFirewallRule"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Lists the GCP firewall rules.",
+        "parameters": [
+          {
+            "name": "page",
+            "description": "Index of the requested page, where one corresponds to the first page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "size",
+            "description": "Maximum number of items that will be contained in the returned page.",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "description": "Retrieved list of GCP firewall rules.",
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GcpFirewallRule"
+                      }
+                    },
+                    "page": {
+                      "description": "Index of the requested page, where one corresponds to the first page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "size": {
+                      "description": "Maximum number of items that will be contained in the returned page.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "total": {
+                      "description": "Total number of items of the collection.",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/clusters_mgmt/v1/gcp/firewall_rules/{gcp_firewall_rule_id}": {
+      "delete": {
+        "description": "Deletes the firewall rule.",
+        "parameters": [
+          {
+            "name": "gcp_firewall_rule_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Success."
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "description": "Retrieves the details of the firewall rule.",
+        "parameters": [
+          {
+            "name": "gcp_firewall_rule_id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GcpFirewallRule"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/clusters_mgmt/v1/gcp/wif_configs": {
       "post": {
         "description": "Provision a new wif_config resource and add it to the collection of wif_configs.",
@@ -14949,6 +15235,10 @@
           "control_plane_subnet": {
             "description": "Control plane subnet used by the cluster.",
             "type": "string"
+          },
+          "firewall_rules_id": {
+            "description": "ID of the GCP firewall rule set associated with this cluster.",
+            "type": "string"
           }
         }
       },
@@ -17940,6 +18230,180 @@
           },
           "project_id": {
             "description": "ProjectId is the Google Cloud Platform project identifier where the DNS zone is hosted.",
+            "type": "string"
+          }
+        }
+      },
+      "GcpFirewallRule": {
+        "description": "GCP firewall rule configuration for BYO (Bring Your Own) firewall workflow.\nThese are organization-level resources that can be created before cluster\nprovisioning and reused after cluster deletion.",
+        "properties": {
+          "kind": {
+            "description": "Indicates the type of this object. Will be 'GcpFirewallRule' if this is a complete object or 'GcpFirewallRuleLink' if it is just a link.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier of the object.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link.",
+            "type": "string"
+          },
+          "gcp_network": {
+            "description": "GCP network configuration.",
+            "$ref": "#/components/schemas/GcpFirewallRuleGcpNetwork"
+          },
+          "name": {
+            "description": "Firewall rule name (unique per organization).",
+            "type": "string"
+          },
+          "organization": {
+            "description": "Link to the organization that owns this firewall rule.",
+            "$ref": "#/components/schemas/OrganizationLink"
+          },
+          "profile": {
+            "description": "Profile type (e.g. \"public\", \"private\").",
+            "type": "string"
+          },
+          "status": {
+            "description": "Status containing the rendered firewall rules.",
+            "$ref": "#/components/schemas/GcpFirewallRuleStatus"
+          },
+          "template": {
+            "description": "Template version and profile reference.",
+            "$ref": "#/components/schemas/GcpFirewallRuleTemplateRef"
+          },
+          "wif_config": {
+            "description": "Link to the WIF config used by this firewall rule.",
+            "$ref": "#/components/schemas/WifConfig"
+          }
+        }
+      },
+      "GcpFirewallRuleAllowed": {
+        "description": "Allowed protocol and ports for a GCP firewall rule.",
+        "properties": {
+          "ip_protocol": {
+            "description": "IP protocol (e.g. \"tcp\", \"udp\", \"icmp\").",
+            "type": "string"
+          },
+          "ports": {
+            "description": "Ports to allow (e.g. \"6443\", \"10250\").",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GcpFirewallRuleGcpNetwork": {
+        "description": "GCP network configuration for a firewall rule.",
+        "properties": {
+          "machine_cidr": {
+            "description": "Machine CIDR block.",
+            "type": "string"
+          },
+          "project_id": {
+            "description": "GCP project ID.",
+            "type": "string"
+          },
+          "vpc_name": {
+            "description": "VPC network name.",
+            "type": "string"
+          }
+        }
+      },
+      "GcpFirewallRuleSpec": {
+        "description": "A single rendered GCP firewall rule specification.",
+        "properties": {
+          "allowed": {
+            "description": "Allowed protocols and ports.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GcpFirewallRuleAllowed"
+            }
+          },
+          "direction": {
+            "description": "Direction of traffic (INGRESS or EGRESS).",
+            "type": "string"
+          },
+          "name": {
+            "description": "Name of the firewall rule.",
+            "type": "string"
+          },
+          "network": {
+            "description": "GCP network URL.",
+            "type": "string"
+          },
+          "priority": {
+            "description": "Priority of the rule (0-65535).",
+            "type": "integer",
+            "format": "int32"
+          },
+          "source_ranges": {
+            "description": "Source IP CIDR ranges.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "source_service_accounts": {
+            "description": "Source service accounts.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "target_service_accounts": {
+            "description": "Target service accounts.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "GcpFirewallRuleStatus": {
+        "description": "Status of a GCP firewall rule set, containing the rendered rules.",
+        "properties": {
+          "rules": {
+            "description": "Rendered firewall rule specifications.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GcpFirewallRuleSpec"
+            }
+          }
+        }
+      },
+      "GcpFirewallRuleTemplate": {
+        "description": "GCP firewall rule template definition.\nTemplates define the set of firewall rules that will be created for a cluster.\nEach template has a version and one or more profiles (e.g. \"public\", \"private\").",
+        "properties": {
+          "description": {
+            "description": "Human-readable description of this template profile.",
+            "type": "string"
+          },
+          "href": {
+            "description": "Self link to the template resource.",
+            "type": "string"
+          },
+          "profile": {
+            "description": "Profile name (e.g. \"public\", \"private\").",
+            "type": "string"
+          },
+          "version": {
+            "description": "Template version identifier (e.g. \"v1\").",
+            "type": "string"
+          }
+        }
+      },
+      "GcpFirewallRuleTemplateRef": {
+        "description": "Template version and profile reference for a firewall rule.",
+        "properties": {
+          "href": {
+            "description": "Self link to the template resource.",
+            "type": "string"
+          },
+          "version": {
+            "description": "Template version identifier.",
             "type": "string"
           }
         }


### PR DESCRIPTION
## Description

API  changes to support BYO firewall workflow for OSD-GCP deployments. This includes API model changes.

## Type of Change

- [X] Model change (new or modified types, resources, methods, or parameters)
- [X] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [ ] CI/CD or tooling change

## Verification

- [X] `make check` passes (model syntax validation)
- [X] `make verify` passes (generated code matches model)
- [ ] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing GCP BYO firewall rules, including creation, listing, retrieval, and deletion.
  * Added GCP firewall rule templates, version lookup, and profile discovery.
  * Added support for firewall rule networking, protocols, ports, priorities, ranges, service accounts, and rendered status.
  * Added the ability to associate GCP configurations with firewall rule sets.
  * Added JSON request and response support for firewall rule resources and related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->