### PR TITLE
feat: aro-hcp: allow providing CS Provision Shard ID during cluster creation

### DIFF
--- a/clientapi/arohcp/v1alpha1/cluster_builder.go
+++ b/clientapi/arohcp/v1alpha1/cluster_builder.go
@@ -112,7 +112,7 @@ type ClusterBuilder struct {
 	openshiftVersion                  string
 	product                           *ProductBuilder
 	properties                        map[string]string
-	provisionShard                    *ProvisionShardBuilder
+	provisionShardID                  string
 	proxy                             *ProxyBuilder
 	region                            *CloudRegionBuilder
 	registryConfig                    *ClusterRegistryConfigBuilder
@@ -870,19 +870,13 @@ func (b *ClusterBuilder) Properties(value map[string]string) *ClusterBuilder {
 	return b
 }
 
-// ProvisionShard sets the value of the 'provision_shard' attribute to the given value.
-//
-// Contains the properties of the provision shard
-func (b *ClusterBuilder) ProvisionShard(value *ProvisionShardBuilder) *ClusterBuilder {
+// ProvisionShardID sets the value of the 'provision_shard_ID' attribute to the given value.
+func (b *ClusterBuilder) ProvisionShardID(value string) *ClusterBuilder {
 	if len(b.fieldSet_) == 0 {
 		b.fieldSet_ = make([]bool, 63)
 	}
-	b.provisionShard = value
-	if value != nil {
-		b.fieldSet_[54] = true
-	} else {
-		b.fieldSet_[54] = false
-	}
+	b.provisionShardID = value
+	b.fieldSet_[54] = true
 	return b
 }
 
@@ -1248,11 +1242,7 @@ func (b *ClusterBuilder) Copy(object *Cluster) *ClusterBuilder {
 	} else {
 		b.properties = nil
 	}
-	if object.provisionShard != nil {
-		b.provisionShard = NewProvisionShard().Copy(object.provisionShard)
-	} else {
-		b.provisionShard = nil
-	}
+	b.provisionShardID = object.provisionShardID
 	if object.proxy != nil {
 		b.proxy = NewProxy().Copy(object.proxy)
 	} else {
@@ -1527,12 +1517,7 @@ func (b *ClusterBuilder) Build() (object *Cluster, err error) {
 			object.properties[k] = v
 		}
 	}
-	if b.provisionShard != nil {
-		object.provisionShard, err = b.provisionShard.Build()
-		if err != nil {
-			return
-		}
-	}
+	object.provisionShardID = b.provisionShardID
 	if b.proxy != nil {
 		object.proxy, err = b.proxy.Build()
 		if err != nil {

--- a/clientapi/arohcp/v1alpha1/cluster_type.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type.go
@@ -126,7 +126,7 @@ type Cluster struct {
 	openshiftVersion                  string
 	product                           *Product
 	properties                        map[string]string
-	provisionShard                    *ProvisionShard
+	provisionShardID                  string
 	proxy                             *Proxy
 	region                            *CloudRegion
 	registryConfig                    *ClusterRegistryConfig
@@ -1436,25 +1436,41 @@ func (o *Cluster) GetProperties() (value map[string]string, ok bool) {
 	return
 }
 
-// ProvisionShard returns the value of the 'provision_shard' attribute, or
+// ProvisionShardID returns the value of the 'provision_shard_ID' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
-// ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
-func (o *Cluster) ProvisionShard() *ProvisionShard {
+// ProvisionShardID is the CS Provision Shard identifier where the cluster
+// is allocated. It is not the full HREF.
+// Optional.
+// When provided during creation, the Cluster is allocated to the
+// CS Provision Shard identified by ProvisionShardID. Additionally, all
+// the capacity checks and provision shard state checks are bypassed.
+// When not provided during creation, selection of a suitable CS provision shard
+// is automatically performed by CS.
+// Immutable.
+func (o *Cluster) ProvisionShardID() string {
 	if o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54] {
-		return o.provisionShard
+		return o.provisionShardID
 	}
-	return nil
+	return ""
 }
 
-// GetProvisionShard returns the value of the 'provision_shard' attribute and
+// GetProvisionShardID returns the value of the 'provision_shard_ID' attribute and
 // a flag indicating if the attribute has a value.
 //
-// ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
-func (o *Cluster) GetProvisionShard() (value *ProvisionShard, ok bool) {
+// ProvisionShardID is the CS Provision Shard identifier where the cluster
+// is allocated. It is not the full HREF.
+// Optional.
+// When provided during creation, the Cluster is allocated to the
+// CS Provision Shard identified by ProvisionShardID. Additionally, all
+// the capacity checks and provision shard state checks are bypassed.
+// When not provided during creation, selection of a suitable CS provision shard
+// is automatically performed by CS.
+// Immutable.
+func (o *Cluster) GetProvisionShardID() (value string, ok bool) {
 	ok = o != nil && len(o.fieldSet_) > 54 && o.fieldSet_[54]
 	if ok {
-		value = o.provisionShard
+		value = o.provisionShardID
 	}
 	return
 }

--- a/clientapi/arohcp/v1alpha1/cluster_type_json.go
+++ b/clientapi/arohcp/v1alpha1/cluster_type_json.go
@@ -570,13 +570,13 @@ func WriteCluster(object *Cluster, stream *jsoniter.Stream) {
 		}
 		count++
 	}
-	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54] && object.provisionShard != nil
+	present_ = len(object.fieldSet_) > 54 && object.fieldSet_[54]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
 		}
-		stream.WriteObjectField("provision_shard")
-		WriteProvisionShard(object.provisionShard, stream)
+		stream.WriteObjectField("provision_shard_id")
+		stream.WriteString(object.provisionShardID)
 		count++
 	}
 	present_ = len(object.fieldSet_) > 55 && object.fieldSet_[55] && object.proxy != nil
@@ -1045,9 +1045,9 @@ func ReadCluster(iterator *jsoniter.Iterator) *Cluster {
 			}
 			object.properties = value
 			object.fieldSet_[53] = true
-		case "provision_shard":
-			value := ReadProvisionShard(iterator)
-			object.provisionShard = value
+		case "provision_shard_id":
+			value := iterator.ReadString()
+			object.provisionShardID = value
 			object.fieldSet_[54] = true
 		case "proxy":
 			value := ReadProxy(iterator)

--- a/model/aro_hcp/v1alpha1/cluster_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_type.model
@@ -199,6 +199,17 @@ class Cluster {
 	// ExternalConfiguration shows external configuration on the cluster.
 	ExternalConfiguration ExternalConfiguration
 
+	// ProvisionShardID is the CS Provision Shard identifier where the cluster
+	// is allocated. It is not the full HREF.
+	// Optional.
+	// When provided during creation, the Cluster is allocated to the
+	// CS Provision Shard identified by ProvisionShardID. Additionally, all
+	// the capacity checks and provision shard state checks are bypassed.
+	// When not provided during creation, selection of a suitable CS provision shard
+	// is automatically performed by CS.
+	// Immutable.
+	ProvisionShardID String
+
 	// Status of cluster
 	Status ClusterStatus
 

--- a/model/aro_hcp/v1alpha1/cluster_type.model
+++ b/model/aro_hcp/v1alpha1/cluster_type.model
@@ -199,10 +199,7 @@ class Cluster {
 	// ExternalConfiguration shows external configuration on the cluster.
 	ExternalConfiguration ExternalConfiguration
 
-	// ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations
-	ProvisionShard ProvisionShard
-
-	//Status of cluster
+	// Status of cluster
 	Status ClusterStatus
 
 	// Node drain grace period.

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -4950,9 +4950,9 @@
               "type": "string"
             }
           },
-          "provision_shard": {
-            "description": "ProvisionShard contains the properties of the provision shard, including AWS and GCP related configurations",
-            "$ref": "#/components/schemas/ProvisionShard"
+          "provision_shard_id": {
+            "description": "ProvisionShardID is the CS Provision Shard identifier where the cluster\nis allocated. It is not the full HREF.\nOptional.\nWhen provided during creation, the Cluster is allocated to the\nCS Provision Shard identified by ProvisionShardID. Additionally, all\nthe capacity checks and provision shard state checks are bypassed.\nWhen not provided during creation, selection of a suitable CS provision shard\nis automatically performed by CS.\nImmutable.",
+            "type": "string"
           },
           "proxy": {
             "description": "Proxy.",


### PR DESCRIPTION
The placement decision is going to be outsourced outside of CS. This
allows CS receiving the provision shard ID directly instead of
leveraging the CS Provision Shard pinning mechanism based on the
properties map which is fragile.

Additionally, we remove the ProvisionShardID attribute in the Cluster type that existed. It was not being used nor referenced in inbound nor outbound mappers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clusters can now be assigned using a provision shard ID.
  * When no ID is provided, the system automatically selects a suitable shard.
  * Updated cluster APIs and schemas expose the new `provision_shard_id` field.

* **Breaking Changes**
  * The previous provision shard object and related accessors have been replaced by the provision shard ID string.
  * Providing an ID bypasses automatic capacity and shard-state checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->