### PR TITLE
feat(arohcp): support specifying RHCOS marketplace image

### DIFF
--- a/clientapi/arohcp/v1alpha1/azure_node_pool_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_builder.go
@@ -24,6 +24,7 @@ type AzureNodePoolBuilder struct {
 	fieldSet_        []bool
 	vmSize           string
 	encryptionAtHost *AzureNodePoolEncryptionAtHostBuilder
+	image            *AzureNodePoolImageBuilder
 	osDisk           *AzureNodePoolOsDiskBuilder
 	resourceName     string
 }
@@ -31,7 +32,7 @@ type AzureNodePoolBuilder struct {
 // NewAzureNodePool creates a new builder of 'azure_node_pool' objects.
 func NewAzureNodePool() *AzureNodePoolBuilder {
 	return &AzureNodePoolBuilder{
-		fieldSet_: make([]bool, 4),
+		fieldSet_: make([]bool, 5),
 	}
 }
 
@@ -51,7 +52,7 @@ func (b *AzureNodePoolBuilder) Empty() bool {
 // VMSize sets the value of the 'VM_size' attribute to the given value.
 func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.vmSize = value
 	b.fieldSet_[0] = true
@@ -64,7 +65,7 @@ func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 // If not specified, Encryption at Host is not enabled.
 func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAtHostBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.encryptionAtHost = value
 	if value != nil {
@@ -75,14 +76,17 @@ func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAt
 	return b
 }
 
-// OsDisk sets the value of the 'os_disk' attribute to the given value.
+// Image sets the value of the 'image' attribute to the given value.
 //
-// Defines the configuration of a Node Pool's OS disk.
-func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+func (b *AzureNodePoolBuilder) Image(value *AzureNodePoolImageBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
-	b.osDisk = value
+	b.image = value
 	if value != nil {
 		b.fieldSet_[2] = true
 	} else {
@@ -91,13 +95,29 @@ func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureN
 	return b
 }
 
+// OsDisk sets the value of the 'os_disk' attribute to the given value.
+//
+// Defines the configuration of a Node Pool's OS disk.
+func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 5)
+	}
+	b.osDisk = value
+	if value != nil {
+		b.fieldSet_[3] = true
+	} else {
+		b.fieldSet_[3] = false
+	}
+	return b
+}
+
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureNodePoolBuilder) ResourceName(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.resourceName = value
-	b.fieldSet_[3] = true
+	b.fieldSet_[4] = true
 	return b
 }
 
@@ -115,6 +135,11 @@ func (b *AzureNodePoolBuilder) Copy(object *AzureNodePool) *AzureNodePoolBuilder
 		b.encryptionAtHost = NewAzureNodePoolEncryptionAtHost().Copy(object.encryptionAtHost)
 	} else {
 		b.encryptionAtHost = nil
+	}
+	if object.image != nil {
+		b.image = NewAzureNodePoolImage().Copy(object.image)
+	} else {
+		b.image = nil
 	}
 	if object.osDisk != nil {
 		b.osDisk = NewAzureNodePoolOsDisk().Copy(object.osDisk)
@@ -135,6 +160,12 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 	object.vmSize = b.vmSize
 	if b.encryptionAtHost != nil {
 		object.encryptionAtHost, err = b.encryptionAtHost.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.image != nil {
+		object.image, err = b.image.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_image_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_image_builder.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+type AzureNodePoolImageBuilder struct {
+	fieldSet_ []bool
+	sku       string
+	offer     string
+	publisher string
+	version   string
+}
+
+// NewAzureNodePoolImage creates a new builder of 'azure_node_pool_image' objects.
+func NewAzureNodePoolImage() *AzureNodePoolImageBuilder {
+	return &AzureNodePoolImageBuilder{
+		fieldSet_: make([]bool, 4),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureNodePoolImageBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// SKU sets the value of the 'SKU' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) SKU(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.sku = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Offer sets the value of the 'offer' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) Offer(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.offer = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Publisher sets the value of the 'publisher' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) Publisher(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.publisher = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Version sets the value of the 'version' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) Version(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.version = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureNodePoolImageBuilder) Copy(object *AzureNodePoolImage) *AzureNodePoolImageBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.sku = object.sku
+	b.offer = object.offer
+	b.publisher = object.publisher
+	b.version = object.version
+	return b
+}
+
+// Build creates a 'azure_node_pool_image' object using the configuration stored in the builder.
+func (b *AzureNodePoolImageBuilder) Build() (object *AzureNodePoolImage, err error) {
+	object = new(AzureNodePoolImage)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.sku = b.sku
+	object.offer = b.offer
+	object.publisher = b.publisher
+	object.version = b.version
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_image_list_builder.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_image_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureNodePoolImageListBuilder contains the data and logic needed to build
+// 'azure_node_pool_image' objects.
+type AzureNodePoolImageListBuilder struct {
+	items []*AzureNodePoolImageBuilder
+}
+
+// NewAzureNodePoolImageList creates a new builder of 'azure_node_pool_image' objects.
+func NewAzureNodePoolImageList() *AzureNodePoolImageListBuilder {
+	return new(AzureNodePoolImageListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureNodePoolImageListBuilder) Items(values ...*AzureNodePoolImageBuilder) *AzureNodePoolImageListBuilder {
+	b.items = make([]*AzureNodePoolImageBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureNodePoolImageListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureNodePoolImageListBuilder) Copy(list *AzureNodePoolImageList) *AzureNodePoolImageListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureNodePoolImageBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureNodePoolImage().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_node_pool_image' objects using the
+// configuration stored in the builder.
+func (b *AzureNodePoolImageListBuilder) Build() (list *AzureNodePoolImageList, err error) {
+	items := make([]*AzureNodePoolImage, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureNodePoolImageList)
+	list.items = items
+	return
+}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_image_list_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_image_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureNodePoolImageList writes a list of values of the 'azure_node_pool_image' type to
+// the given writer.
+func MarshalAzureNodePoolImageList(list []*AzureNodePoolImage, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureNodePoolImageList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureNodePoolImageList writes a list of value of the 'azure_node_pool_image' type to
+// the given stream.
+func WriteAzureNodePoolImageList(list []*AzureNodePoolImage, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureNodePoolImage(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureNodePoolImageList reads a list of values of the 'azure_node_pool_image' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureNodePoolImageList(source interface{}) (items []*AzureNodePoolImage, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureNodePoolImageList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureNodePoolImageList reads list of values of the ”azure_node_pool_image' type from
+// the given iterator.
+func ReadAzureNodePoolImageList(iterator *jsoniter.Iterator) []*AzureNodePoolImage {
+	list := []*AzureNodePoolImage{}
+	for iterator.ReadArray() {
+		item := ReadAzureNodePoolImage(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_image_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_image_type.go
@@ -1,0 +1,248 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+// AzureNodePoolImage represents the values of the 'azure_node_pool_image' type.
+//
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+type AzureNodePoolImage struct {
+	fieldSet_ []bool
+	sku       string
+	offer     string
+	publisher string
+	version   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureNodePoolImage) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// SKU returns the value of the 'SKU' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// SKU specifies an instance of an offer, such as a major release of a distribution.
+func (o *AzureNodePoolImage) SKU() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.sku
+	}
+	return ""
+}
+
+// GetSKU returns the value of the 'SKU' attribute and
+// a flag indicating if the attribute has a value.
+//
+// SKU specifies an instance of an offer, such as a major release of a distribution.
+func (o *AzureNodePoolImage) GetSKU() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.sku
+	}
+	return
+}
+
+// Offer returns the value of the 'offer' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Offer specifies the name of a group of related images created by the publisher.
+func (o *AzureNodePoolImage) Offer() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.offer
+	}
+	return ""
+}
+
+// GetOffer returns the value of the 'offer' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Offer specifies the name of a group of related images created by the publisher.
+func (o *AzureNodePoolImage) GetOffer() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.offer
+	}
+	return
+}
+
+// Publisher returns the value of the 'publisher' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Publisher is the name of the organization that created the image.
+func (o *AzureNodePoolImage) Publisher() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.publisher
+	}
+	return ""
+}
+
+// GetPublisher returns the value of the 'publisher' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Publisher is the name of the organization that created the image.
+func (o *AzureNodePoolImage) GetPublisher() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.publisher
+	}
+	return
+}
+
+// Version returns the value of the 'version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Version specifies the version of an image SKU.
+func (o *AzureNodePoolImage) Version() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.version
+	}
+	return ""
+}
+
+// GetVersion returns the value of the 'version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Version specifies the version of an image SKU.
+func (o *AzureNodePoolImage) GetVersion() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.version
+	}
+	return
+}
+
+// AzureNodePoolImageListKind is the name of the type used to represent list of objects of
+// type 'azure_node_pool_image'.
+const AzureNodePoolImageListKind = "AzureNodePoolImageList"
+
+// AzureNodePoolImageListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_node_pool_image'.
+const AzureNodePoolImageListLinkKind = "AzureNodePoolImageListLink"
+
+// AzureNodePoolImageNilKind is the name of the type used to nil lists of objects of
+// type 'azure_node_pool_image'.
+const AzureNodePoolImageListNilKind = "AzureNodePoolImageListNil"
+
+// AzureNodePoolImageList is a list of values of the 'azure_node_pool_image' type.
+type AzureNodePoolImageList struct {
+	href  string
+	link  bool
+	items []*AzureNodePoolImage
+}
+
+// Len returns the length of the list.
+func (l *AzureNodePoolImageList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureNodePoolImageList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureNodePoolImageList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureNodePoolImageList) SetItems(items []*AzureNodePoolImage) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureNodePoolImageList) Items() []*AzureNodePoolImage {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureNodePoolImageList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureNodePoolImageList) Get(i int) *AzureNodePoolImage {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureNodePoolImageList) Slice() []*AzureNodePoolImage {
+	var slice []*AzureNodePoolImage
+	if l == nil {
+		slice = make([]*AzureNodePoolImage, 0)
+	} else {
+		slice = make([]*AzureNodePoolImage, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureNodePoolImageList) Each(f func(item *AzureNodePoolImage) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureNodePoolImageList) Range(f func(index int, item *AzureNodePoolImage) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_image_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_image_type_json.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1alpha1 // github.com/openshift-online/ocm-api-model/clientapi/arohcp/v1alpha1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureNodePoolImage writes a value of the 'azure_node_pool_image' type to the given writer.
+func MarshalAzureNodePoolImage(object *AzureNodePoolImage, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureNodePoolImage(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureNodePoolImage writes a value of the 'azure_node_pool_image' type to the given stream.
+func WriteAzureNodePoolImage(object *AzureNodePoolImage, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("sku")
+		stream.WriteString(object.sku)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("offer")
+		stream.WriteString(object.offer)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("publisher")
+		stream.WriteString(object.publisher)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("version")
+		stream.WriteString(object.version)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureNodePoolImage reads a value of the 'azure_node_pool_image' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureNodePoolImage(source interface{}) (object *AzureNodePoolImage, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureNodePoolImage(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureNodePoolImage reads a value of the 'azure_node_pool_image' type from the given iterator.
+func ReadAzureNodePoolImage(iterator *jsoniter.Iterator) *AzureNodePoolImage {
+	object := &AzureNodePoolImage{
+		fieldSet_: make([]bool, 4),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "sku":
+			value := iterator.ReadString()
+			object.sku = value
+			object.fieldSet_[0] = true
+		case "offer":
+			value := iterator.ReadString()
+			object.offer = value
+			object.fieldSet_[1] = true
+		case "publisher":
+			value := iterator.ReadString()
+			object.publisher = value
+			object.fieldSet_[2] = true
+		case "version":
+			value := iterator.ReadString()
+			object.version = value
+			object.fieldSet_[3] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_type.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_type.go
@@ -26,6 +26,7 @@ type AzureNodePool struct {
 	fieldSet_        []bool
 	vmSize           string
 	encryptionAtHost *AzureNodePoolEncryptionAtHost
+	image            *AzureNodePoolImage
 	osDisk           *AzureNodePoolOsDisk
 	resourceName     string
 }
@@ -105,12 +106,39 @@ func (o *AzureNodePool) GetEncryptionAtHost() (value *AzureNodePoolEncryptionAtH
 	return
 }
 
+// Image returns the value of the 'image' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// Optional during creation. Immutable.
+func (o *AzureNodePool) Image() *AzureNodePoolImage {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.image
+	}
+	return nil
+}
+
+// GetImage returns the value of the 'image' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// Optional during creation. Immutable.
+func (o *AzureNodePool) GetImage() (value *AzureNodePoolImage, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.image
+	}
+	return
+}
+
 // OsDisk returns the value of the 'os_disk' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
-	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
 		return o.osDisk
 	}
 	return nil
@@ -121,7 +149,7 @@ func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
 	if ok {
 		value = o.osDisk
 	}
@@ -143,7 +171,7 @@ func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
 		return o.resourceName
 	}
 	return ""
@@ -164,7 +192,7 @@ func (o *AzureNodePool) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
 	if ok {
 		value = o.resourceName
 	}

--- a/clientapi/arohcp/v1alpha1/azure_node_pool_type_json.go
+++ b/clientapi/arohcp/v1alpha1/azure_node_pool_type_json.go
@@ -60,7 +60,16 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolEncryptionAtHost(object.encryptionAtHost, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2] && object.osDisk != nil
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2] && object.image != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("image")
+		WriteAzureNodePoolImage(object.image, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3] && object.osDisk != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -69,7 +78,7 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolOsDisk(object.osDisk, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -95,7 +104,7 @@ func UnmarshalAzureNodePool(source interface{}) (object *AzureNodePool, err erro
 // ReadAzureNodePool reads a value of the 'azure_node_pool' type from the given iterator.
 func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 	object := &AzureNodePool{
-		fieldSet_: make([]bool, 4),
+		fieldSet_: make([]bool, 5),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -111,14 +120,18 @@ func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 			value := ReadAzureNodePoolEncryptionAtHost(iterator)
 			object.encryptionAtHost = value
 			object.fieldSet_[1] = true
+		case "image":
+			value := ReadAzureNodePoolImage(iterator)
+			object.image = value
+			object.fieldSet_[2] = true
 		case "os_disk":
 			value := ReadAzureNodePoolOsDisk(iterator)
 			object.osDisk = value
-			object.fieldSet_[2] = true
+			object.fieldSet_[3] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[3] = true
+			object.fieldSet_[4] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_builder.go
@@ -24,6 +24,7 @@ type AzureNodePoolBuilder struct {
 	fieldSet_        []bool
 	vmSize           string
 	encryptionAtHost *AzureNodePoolEncryptionAtHostBuilder
+	image            *AzureNodePoolImageBuilder
 	osDisk           *AzureNodePoolOsDiskBuilder
 	resourceName     string
 }
@@ -31,7 +32,7 @@ type AzureNodePoolBuilder struct {
 // NewAzureNodePool creates a new builder of 'azure_node_pool' objects.
 func NewAzureNodePool() *AzureNodePoolBuilder {
 	return &AzureNodePoolBuilder{
-		fieldSet_: make([]bool, 4),
+		fieldSet_: make([]bool, 5),
 	}
 }
 
@@ -51,7 +52,7 @@ func (b *AzureNodePoolBuilder) Empty() bool {
 // VMSize sets the value of the 'VM_size' attribute to the given value.
 func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.vmSize = value
 	b.fieldSet_[0] = true
@@ -64,7 +65,7 @@ func (b *AzureNodePoolBuilder) VMSize(value string) *AzureNodePoolBuilder {
 // If not specified, Encryption at Host is not enabled.
 func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAtHostBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.encryptionAtHost = value
 	if value != nil {
@@ -75,14 +76,17 @@ func (b *AzureNodePoolBuilder) EncryptionAtHost(value *AzureNodePoolEncryptionAt
 	return b
 }
 
-// OsDisk sets the value of the 'os_disk' attribute to the given value.
+// Image sets the value of the 'image' attribute to the given value.
 //
-// Defines the configuration of a Node Pool's OS disk.
-func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+func (b *AzureNodePoolBuilder) Image(value *AzureNodePoolImageBuilder) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
-	b.osDisk = value
+	b.image = value
 	if value != nil {
 		b.fieldSet_[2] = true
 	} else {
@@ -91,13 +95,29 @@ func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureN
 	return b
 }
 
+// OsDisk sets the value of the 'os_disk' attribute to the given value.
+//
+// Defines the configuration of a Node Pool's OS disk.
+func (b *AzureNodePoolBuilder) OsDisk(value *AzureNodePoolOsDiskBuilder) *AzureNodePoolBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 5)
+	}
+	b.osDisk = value
+	if value != nil {
+		b.fieldSet_[3] = true
+	} else {
+		b.fieldSet_[3] = false
+	}
+	return b
+}
+
 // ResourceName sets the value of the 'resource_name' attribute to the given value.
 func (b *AzureNodePoolBuilder) ResourceName(value string) *AzureNodePoolBuilder {
 	if len(b.fieldSet_) == 0 {
-		b.fieldSet_ = make([]bool, 4)
+		b.fieldSet_ = make([]bool, 5)
 	}
 	b.resourceName = value
-	b.fieldSet_[3] = true
+	b.fieldSet_[4] = true
 	return b
 }
 
@@ -115,6 +135,11 @@ func (b *AzureNodePoolBuilder) Copy(object *AzureNodePool) *AzureNodePoolBuilder
 		b.encryptionAtHost = NewAzureNodePoolEncryptionAtHost().Copy(object.encryptionAtHost)
 	} else {
 		b.encryptionAtHost = nil
+	}
+	if object.image != nil {
+		b.image = NewAzureNodePoolImage().Copy(object.image)
+	} else {
+		b.image = nil
 	}
 	if object.osDisk != nil {
 		b.osDisk = NewAzureNodePoolOsDisk().Copy(object.osDisk)
@@ -135,6 +160,12 @@ func (b *AzureNodePoolBuilder) Build() (object *AzureNodePool, err error) {
 	object.vmSize = b.vmSize
 	if b.encryptionAtHost != nil {
 		object.encryptionAtHost, err = b.encryptionAtHost.Build()
+		if err != nil {
+			return
+		}
+	}
+	if b.image != nil {
+		object.image, err = b.image.Build()
 		if err != nil {
 			return
 		}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_image_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_image_builder.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+type AzureNodePoolImageBuilder struct {
+	fieldSet_ []bool
+	sku       string
+	offer     string
+	publisher string
+	version   string
+}
+
+// NewAzureNodePoolImage creates a new builder of 'azure_node_pool_image' objects.
+func NewAzureNodePoolImage() *AzureNodePoolImageBuilder {
+	return &AzureNodePoolImageBuilder{
+		fieldSet_: make([]bool, 4),
+	}
+}
+
+// Empty returns true if the builder is empty, i.e. no attribute has a value.
+func (b *AzureNodePoolImageBuilder) Empty() bool {
+	if b == nil || len(b.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range b.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// SKU sets the value of the 'SKU' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) SKU(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.sku = value
+	b.fieldSet_[0] = true
+	return b
+}
+
+// Offer sets the value of the 'offer' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) Offer(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.offer = value
+	b.fieldSet_[1] = true
+	return b
+}
+
+// Publisher sets the value of the 'publisher' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) Publisher(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.publisher = value
+	b.fieldSet_[2] = true
+	return b
+}
+
+// Version sets the value of the 'version' attribute to the given value.
+func (b *AzureNodePoolImageBuilder) Version(value string) *AzureNodePoolImageBuilder {
+	if len(b.fieldSet_) == 0 {
+		b.fieldSet_ = make([]bool, 4)
+	}
+	b.version = value
+	b.fieldSet_[3] = true
+	return b
+}
+
+// Copy copies the attributes of the given object into this builder, discarding any previous values.
+func (b *AzureNodePoolImageBuilder) Copy(object *AzureNodePoolImage) *AzureNodePoolImageBuilder {
+	if object == nil {
+		return b
+	}
+	if len(object.fieldSet_) > 0 {
+		b.fieldSet_ = make([]bool, len(object.fieldSet_))
+		copy(b.fieldSet_, object.fieldSet_)
+	}
+	b.sku = object.sku
+	b.offer = object.offer
+	b.publisher = object.publisher
+	b.version = object.version
+	return b
+}
+
+// Build creates a 'azure_node_pool_image' object using the configuration stored in the builder.
+func (b *AzureNodePoolImageBuilder) Build() (object *AzureNodePoolImage, err error) {
+	object = new(AzureNodePoolImage)
+	if len(b.fieldSet_) > 0 {
+		object.fieldSet_ = make([]bool, len(b.fieldSet_))
+		copy(object.fieldSet_, b.fieldSet_)
+	}
+	object.sku = b.sku
+	object.offer = b.offer
+	object.publisher = b.publisher
+	object.version = b.version
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_image_list_builder.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_image_list_builder.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureNodePoolImageListBuilder contains the data and logic needed to build
+// 'azure_node_pool_image' objects.
+type AzureNodePoolImageListBuilder struct {
+	items []*AzureNodePoolImageBuilder
+}
+
+// NewAzureNodePoolImageList creates a new builder of 'azure_node_pool_image' objects.
+func NewAzureNodePoolImageList() *AzureNodePoolImageListBuilder {
+	return new(AzureNodePoolImageListBuilder)
+}
+
+// Items sets the items of the list.
+func (b *AzureNodePoolImageListBuilder) Items(values ...*AzureNodePoolImageBuilder) *AzureNodePoolImageListBuilder {
+	b.items = make([]*AzureNodePoolImageBuilder, len(values))
+	copy(b.items, values)
+	return b
+}
+
+// Empty returns true if the list is empty.
+func (b *AzureNodePoolImageListBuilder) Empty() bool {
+	return b == nil || len(b.items) == 0
+}
+
+// Copy copies the items of the given list into this builder, discarding any previous items.
+func (b *AzureNodePoolImageListBuilder) Copy(list *AzureNodePoolImageList) *AzureNodePoolImageListBuilder {
+	if list == nil || list.items == nil {
+		b.items = nil
+	} else {
+		b.items = make([]*AzureNodePoolImageBuilder, len(list.items))
+		for i, v := range list.items {
+			b.items[i] = NewAzureNodePoolImage().Copy(v)
+		}
+	}
+	return b
+}
+
+// Build creates a list of 'azure_node_pool_image' objects using the
+// configuration stored in the builder.
+func (b *AzureNodePoolImageListBuilder) Build() (list *AzureNodePoolImageList, err error) {
+	items := make([]*AzureNodePoolImage, len(b.items))
+	for i, item := range b.items {
+		items[i], err = item.Build()
+		if err != nil {
+			return
+		}
+	}
+	list = new(AzureNodePoolImageList)
+	list.items = items
+	return
+}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_image_list_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_image_list_type_json.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureNodePoolImageList writes a list of values of the 'azure_node_pool_image' type to
+// the given writer.
+func MarshalAzureNodePoolImageList(list []*AzureNodePoolImage, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureNodePoolImageList(list, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureNodePoolImageList writes a list of value of the 'azure_node_pool_image' type to
+// the given stream.
+func WriteAzureNodePoolImageList(list []*AzureNodePoolImage, stream *jsoniter.Stream) {
+	stream.WriteArrayStart()
+	for i, value := range list {
+		if i > 0 {
+			stream.WriteMore()
+		}
+		WriteAzureNodePoolImage(value, stream)
+	}
+	stream.WriteArrayEnd()
+}
+
+// UnmarshalAzureNodePoolImageList reads a list of values of the 'azure_node_pool_image' type
+// from the given source, which can be a slice of bytes, a string or a reader.
+func UnmarshalAzureNodePoolImageList(source interface{}) (items []*AzureNodePoolImage, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	items = ReadAzureNodePoolImageList(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureNodePoolImageList reads list of values of the ”azure_node_pool_image' type from
+// the given iterator.
+func ReadAzureNodePoolImageList(iterator *jsoniter.Iterator) []*AzureNodePoolImage {
+	list := []*AzureNodePoolImage{}
+	for iterator.ReadArray() {
+		item := ReadAzureNodePoolImage(iterator)
+		list = append(list, item)
+	}
+	return list
+}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_image_type.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_image_type.go
@@ -1,0 +1,248 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+// AzureNodePoolImage represents the values of the 'azure_node_pool_image' type.
+//
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+type AzureNodePoolImage struct {
+	fieldSet_ []bool
+	sku       string
+	offer     string
+	publisher string
+	version   string
+}
+
+// Empty returns true if the object is empty, i.e. no attribute has a value.
+func (o *AzureNodePoolImage) Empty() bool {
+	if o == nil || len(o.fieldSet_) == 0 {
+		return true
+	}
+	for _, set := range o.fieldSet_ {
+		if set {
+			return false
+		}
+	}
+	return true
+}
+
+// SKU returns the value of the 'SKU' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// SKU specifies an instance of an offer, such as a major release of a distribution.
+func (o *AzureNodePoolImage) SKU() string {
+	if o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0] {
+		return o.sku
+	}
+	return ""
+}
+
+// GetSKU returns the value of the 'SKU' attribute and
+// a flag indicating if the attribute has a value.
+//
+// SKU specifies an instance of an offer, such as a major release of a distribution.
+func (o *AzureNodePoolImage) GetSKU() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 0 && o.fieldSet_[0]
+	if ok {
+		value = o.sku
+	}
+	return
+}
+
+// Offer returns the value of the 'offer' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Offer specifies the name of a group of related images created by the publisher.
+func (o *AzureNodePoolImage) Offer() string {
+	if o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1] {
+		return o.offer
+	}
+	return ""
+}
+
+// GetOffer returns the value of the 'offer' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Offer specifies the name of a group of related images created by the publisher.
+func (o *AzureNodePoolImage) GetOffer() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 1 && o.fieldSet_[1]
+	if ok {
+		value = o.offer
+	}
+	return
+}
+
+// Publisher returns the value of the 'publisher' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Publisher is the name of the organization that created the image.
+func (o *AzureNodePoolImage) Publisher() string {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.publisher
+	}
+	return ""
+}
+
+// GetPublisher returns the value of the 'publisher' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Publisher is the name of the organization that created the image.
+func (o *AzureNodePoolImage) GetPublisher() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.publisher
+	}
+	return
+}
+
+// Version returns the value of the 'version' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Version specifies the version of an image SKU.
+func (o *AzureNodePoolImage) Version() string {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+		return o.version
+	}
+	return ""
+}
+
+// GetVersion returns the value of the 'version' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Version specifies the version of an image SKU.
+func (o *AzureNodePoolImage) GetVersion() (value string, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	if ok {
+		value = o.version
+	}
+	return
+}
+
+// AzureNodePoolImageListKind is the name of the type used to represent list of objects of
+// type 'azure_node_pool_image'.
+const AzureNodePoolImageListKind = "AzureNodePoolImageList"
+
+// AzureNodePoolImageListLinkKind is the name of the type used to represent links to list
+// of objects of type 'azure_node_pool_image'.
+const AzureNodePoolImageListLinkKind = "AzureNodePoolImageListLink"
+
+// AzureNodePoolImageNilKind is the name of the type used to nil lists of objects of
+// type 'azure_node_pool_image'.
+const AzureNodePoolImageListNilKind = "AzureNodePoolImageListNil"
+
+// AzureNodePoolImageList is a list of values of the 'azure_node_pool_image' type.
+type AzureNodePoolImageList struct {
+	href  string
+	link  bool
+	items []*AzureNodePoolImage
+}
+
+// Len returns the length of the list.
+func (l *AzureNodePoolImageList) Len() int {
+	if l == nil {
+		return 0
+	}
+	return len(l.items)
+}
+
+// Items sets the items of the list.
+func (l *AzureNodePoolImageList) SetLink(link bool) {
+	l.link = link
+}
+
+// Items sets the items of the list.
+func (l *AzureNodePoolImageList) SetHREF(href string) {
+	l.href = href
+}
+
+// Items sets the items of the list.
+func (l *AzureNodePoolImageList) SetItems(items []*AzureNodePoolImage) {
+	l.items = items
+}
+
+// Items returns the items of the list.
+func (l *AzureNodePoolImageList) Items() []*AzureNodePoolImage {
+	if l == nil {
+		return nil
+	}
+	return l.items
+}
+
+// Empty returns true if the list is empty.
+func (l *AzureNodePoolImageList) Empty() bool {
+	return l == nil || len(l.items) == 0
+}
+
+// Get returns the item of the list with the given index. If there is no item with
+// that index it returns nil.
+func (l *AzureNodePoolImageList) Get(i int) *AzureNodePoolImage {
+	if l == nil || i < 0 || i >= len(l.items) {
+		return nil
+	}
+	return l.items[i]
+}
+
+// Slice returns an slice containing the items of the list. The returned slice is a
+// copy of the one used internally, so it can be modified without affecting the
+// internal representation.
+//
+// If you don't need to modify the returned slice consider using the Each or Range
+// functions, as they don't need to allocate a new slice.
+func (l *AzureNodePoolImageList) Slice() []*AzureNodePoolImage {
+	var slice []*AzureNodePoolImage
+	if l == nil {
+		slice = make([]*AzureNodePoolImage, 0)
+	} else {
+		slice = make([]*AzureNodePoolImage, len(l.items))
+		copy(slice, l.items)
+	}
+	return slice
+}
+
+// Each runs the given function for each item of the list, in order. If the function
+// returns false the iteration stops, otherwise it continues till all the elements
+// of the list have been processed.
+func (l *AzureNodePoolImageList) Each(f func(item *AzureNodePoolImage) bool) {
+	if l == nil {
+		return
+	}
+	for _, item := range l.items {
+		if !f(item) {
+			break
+		}
+	}
+}
+
+// Range runs the given function for each index and item of the list, in order. If
+// the function returns false the iteration stops, otherwise it continues till all
+// the elements of the list have been processed.
+func (l *AzureNodePoolImageList) Range(f func(index int, item *AzureNodePoolImage) bool) {
+	if l == nil {
+		return
+	}
+	for index, item := range l.items {
+		if !f(index, item) {
+			break
+		}
+	}
+}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_image_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_image_type_json.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2020 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// IMPORTANT: This file has been generated automatically, refrain from modifying it manually as all
+// your changes will be lost when the file is generated again.
+
+package v1 // github.com/openshift-online/ocm-api-model/clientapi/clustersmgmt/v1
+
+import (
+	"io"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/openshift-online/ocm-api-model/clientapi/helpers"
+)
+
+// MarshalAzureNodePoolImage writes a value of the 'azure_node_pool_image' type to the given writer.
+func MarshalAzureNodePoolImage(object *AzureNodePoolImage, writer io.Writer) error {
+	stream := helpers.NewStream(writer)
+	WriteAzureNodePoolImage(object, stream)
+	err := stream.Flush()
+	if err != nil {
+		return err
+	}
+	return stream.Error
+}
+
+// WriteAzureNodePoolImage writes a value of the 'azure_node_pool_image' type to the given stream.
+func WriteAzureNodePoolImage(object *AzureNodePoolImage, stream *jsoniter.Stream) {
+	count := 0
+	stream.WriteObjectStart()
+	var present_ bool
+	present_ = len(object.fieldSet_) > 0 && object.fieldSet_[0]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("sku")
+		stream.WriteString(object.sku)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 1 && object.fieldSet_[1]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("offer")
+		stream.WriteString(object.offer)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("publisher")
+		stream.WriteString(object.publisher)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("version")
+		stream.WriteString(object.version)
+	}
+	stream.WriteObjectEnd()
+}
+
+// UnmarshalAzureNodePoolImage reads a value of the 'azure_node_pool_image' type from the given
+// source, which can be an slice of bytes, a string or a reader.
+func UnmarshalAzureNodePoolImage(source interface{}) (object *AzureNodePoolImage, err error) {
+	iterator, err := helpers.NewIterator(source)
+	if err != nil {
+		return
+	}
+	object = ReadAzureNodePoolImage(iterator)
+	err = iterator.Error
+	return
+}
+
+// ReadAzureNodePoolImage reads a value of the 'azure_node_pool_image' type from the given iterator.
+func ReadAzureNodePoolImage(iterator *jsoniter.Iterator) *AzureNodePoolImage {
+	object := &AzureNodePoolImage{
+		fieldSet_: make([]bool, 4),
+	}
+	for {
+		field := iterator.ReadObject()
+		if field == "" {
+			break
+		}
+		switch field {
+		case "sku":
+			value := iterator.ReadString()
+			object.sku = value
+			object.fieldSet_[0] = true
+		case "offer":
+			value := iterator.ReadString()
+			object.offer = value
+			object.fieldSet_[1] = true
+		case "publisher":
+			value := iterator.ReadString()
+			object.publisher = value
+			object.fieldSet_[2] = true
+		case "version":
+			value := iterator.ReadString()
+			object.version = value
+			object.fieldSet_[3] = true
+		default:
+			iterator.ReadAny()
+		}
+	}
+	return object
+}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_type.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_type.go
@@ -26,6 +26,7 @@ type AzureNodePool struct {
 	fieldSet_        []bool
 	vmSize           string
 	encryptionAtHost *AzureNodePoolEncryptionAtHost
+	image            *AzureNodePoolImage
 	osDisk           *AzureNodePoolOsDisk
 	resourceName     string
 }
@@ -105,12 +106,39 @@ func (o *AzureNodePool) GetEncryptionAtHost() (value *AzureNodePoolEncryptionAtH
 	return
 }
 
+// Image returns the value of the 'image' attribute, or
+// the zero value of the type if the attribute doesn't have a value.
+//
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// Optional during creation. Immutable.
+func (o *AzureNodePool) Image() *AzureNodePoolImage {
+	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+		return o.image
+	}
+	return nil
+}
+
+// GetImage returns the value of the 'image' attribute and
+// a flag indicating if the attribute has a value.
+//
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// Optional during creation. Immutable.
+func (o *AzureNodePool) GetImage() (value *AzureNodePoolImage, ok bool) {
+	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	if ok {
+		value = o.image
+	}
+	return
+}
+
 // OsDisk returns the value of the 'os_disk' attribute, or
 // the zero value of the type if the attribute doesn't have a value.
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
-	if o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2] {
+	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
 		return o.osDisk
 	}
 	return nil
@@ -121,7 +149,7 @@ func (o *AzureNodePool) OsDisk() *AzureNodePoolOsDisk {
 //
 // The configuration for the OS disk used by the nodes in the Node Pool.
 func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 2 && o.fieldSet_[2]
+	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
 	if ok {
 		value = o.osDisk
 	}
@@ -143,7 +171,7 @@ func (o *AzureNodePool) GetOsDisk() (value *AzureNodePoolOsDisk, ok bool) {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) ResourceName() string {
-	if o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3] {
+	if o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4] {
 		return o.resourceName
 	}
 	return ""
@@ -164,7 +192,7 @@ func (o *AzureNodePool) ResourceName() string {
 // Required during creation.
 // Immutable.
 func (o *AzureNodePool) GetResourceName() (value string, ok bool) {
-	ok = o != nil && len(o.fieldSet_) > 3 && o.fieldSet_[3]
+	ok = o != nil && len(o.fieldSet_) > 4 && o.fieldSet_[4]
 	if ok {
 		value = o.resourceName
 	}

--- a/clientapi/clustersmgmt/v1/azure_node_pool_type_json.go
+++ b/clientapi/clustersmgmt/v1/azure_node_pool_type_json.go
@@ -60,7 +60,16 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolEncryptionAtHost(object.encryptionAtHost, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2] && object.osDisk != nil
+	present_ = len(object.fieldSet_) > 2 && object.fieldSet_[2] && object.image != nil
+	if present_ {
+		if count > 0 {
+			stream.WriteMore()
+		}
+		stream.WriteObjectField("image")
+		WriteAzureNodePoolImage(object.image, stream)
+		count++
+	}
+	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3] && object.osDisk != nil
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -69,7 +78,7 @@ func WriteAzureNodePool(object *AzureNodePool, stream *jsoniter.Stream) {
 		WriteAzureNodePoolOsDisk(object.osDisk, stream)
 		count++
 	}
-	present_ = len(object.fieldSet_) > 3 && object.fieldSet_[3]
+	present_ = len(object.fieldSet_) > 4 && object.fieldSet_[4]
 	if present_ {
 		if count > 0 {
 			stream.WriteMore()
@@ -95,7 +104,7 @@ func UnmarshalAzureNodePool(source interface{}) (object *AzureNodePool, err erro
 // ReadAzureNodePool reads a value of the 'azure_node_pool' type from the given iterator.
 func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 	object := &AzureNodePool{
-		fieldSet_: make([]bool, 4),
+		fieldSet_: make([]bool, 5),
 	}
 	for {
 		field := iterator.ReadObject()
@@ -111,14 +120,18 @@ func ReadAzureNodePool(iterator *jsoniter.Iterator) *AzureNodePool {
 			value := ReadAzureNodePoolEncryptionAtHost(iterator)
 			object.encryptionAtHost = value
 			object.fieldSet_[1] = true
+		case "image":
+			value := ReadAzureNodePoolImage(iterator)
+			object.image = value
+			object.fieldSet_[2] = true
 		case "os_disk":
 			value := ReadAzureNodePoolOsDisk(iterator)
 			object.osDisk = value
-			object.fieldSet_[2] = true
+			object.fieldSet_[3] = true
 		case "resource_name":
 			value := iterator.ReadString()
 			object.resourceName = value
-			object.fieldSet_[3] = true
+			object.fieldSet_[4] = true
 		default:
 			iterator.ReadAny()
 		}

--- a/model/aro_hcp/v1alpha1/azure_node_pool_image_type.model
+++ b/model/aro_hcp/v1alpha1/azure_node_pool_image_type.model
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+struct AzureNodePoolImage {
+	// Publisher is the name of the organization that created the image.
+	Publisher String
+
+	// Offer specifies the name of a group of related images created by the publisher.
+	Offer String
+
+	// SKU specifies an instance of an offer, such as a major release of a distribution.
+	SKU String
+
+	// Version specifies the version of an image SKU.
+	Version String
+}

--- a/model/aro_hcp/v1alpha1/azure_node_pool_type.model
+++ b/model/aro_hcp/v1alpha1/azure_node_pool_type.model
@@ -16,33 +16,38 @@ limitations under the License.
 
 // Representation of azure node pool specific parameters.
 struct AzureNodePool {
-    // ResourceName is the Azure Resource Name of the NodePool.
-    // ResourceName must be within the Azure Resource Group Name of the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Location as the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Subscription as the parent
-    // Cluster it belongs to.
-    // ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
-    // Cluster it belongs to.
-    // Required during creation.
-    // Immutable.
-    ResourceName String
+	// ResourceName is the Azure Resource Name of the NodePool.
+	// ResourceName must be within the Azure Resource Group Name of the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Location as the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Subscription as the parent
+	// Cluster it belongs to.
+	// ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
+	// Cluster it belongs to.
+	// Required during creation.
+	// Immutable.
+	ResourceName String
 
-    // The Azure Virtual Machine size identifier used for the
-    // Nodes of the Node Pool.
-    // Availability of VM sizes are dependent on the Azure Location
-    // of the parent Cluster.
-    // Required during creation.
-    VMSize String
+	// The Azure Virtual Machine size identifier used for the
+	// Nodes of the Node Pool.
+	// Availability of VM sizes are dependent on the Azure Location
+	// of the parent Cluster.
+	// Required during creation.
+	VMSize String
 
-    // EncryptionAtHost contains Encryption At Host disk encryption configuration.
-    // When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
-    // and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
-    // If not specified, Encryption at Host is not enabled.
-    // Immutable.
-    EncryptionAtHost AzureNodePoolEncryptionAtHost
+	// EncryptionAtHost contains Encryption At Host disk encryption configuration.
+	// When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
+	// and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
+	// If not specified, Encryption at Host is not enabled.
+	// Immutable.
+	EncryptionAtHost AzureNodePoolEncryptionAtHost
 
-    // The configuration for the OS disk used by the nodes in the Node Pool.
-    OsDisk AzureNodePoolOsDisk
+	// The configuration for the OS disk used by the nodes in the Node Pool.
+	OsDisk AzureNodePoolOsDisk
+
+	// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+	// When specified, the provided image is used instead of the default RHCOS image.
+	// Optional during creation. Immutable.
+	Image AzureNodePoolImage
 }

--- a/model/clusters_mgmt/v1/azure_node_pool_image_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_image_type.model
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2026 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+// When specified, the provided image is used instead of the default RHCOS image.
+// All four fields must be provided together.
+// Optional during creation. Immutable.
+struct AzureNodePoolImage {
+	// Publisher is the name of the organization that created the image.
+	Publisher String
+
+	// Offer specifies the name of a group of related images created by the publisher.
+	Offer String
+
+	// SKU specifies an instance of an offer, such as a major release of a distribution.
+	SKU String
+
+	// Version specifies the version of an image SKU.
+	Version String
+}

--- a/model/clusters_mgmt/v1/azure_node_pool_type.model
+++ b/model/clusters_mgmt/v1/azure_node_pool_type.model
@@ -16,33 +16,38 @@ limitations under the License.
 
 // Representation of azure node pool specific parameters.
 struct AzureNodePool {
-    // ResourceName is the Azure Resource Name of the NodePool.
-    // ResourceName must be within the Azure Resource Group Name of the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Location as the parent
-    // Cluster it belongs to.
-    // ResourceName must be located in the same Azure Subscription as the parent
-    // Cluster it belongs to.
-    // ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
-    // Cluster it belongs to.
-    // Required during creation.
-    // Immutable.
-    ResourceName String
+	// ResourceName is the Azure Resource Name of the NodePool.
+	// ResourceName must be within the Azure Resource Group Name of the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Location as the parent
+	// Cluster it belongs to.
+	// ResourceName must be located in the same Azure Subscription as the parent
+	// Cluster it belongs to.
+	// ResourceName must belong to the same Microsoft Entra Tenant ID as the parent
+	// Cluster it belongs to.
+	// Required during creation.
+	// Immutable.
+	ResourceName String
 
-    // The Azure Virtual Machine size identifier used for the
-    // Nodes of the Node Pool.
-    // Availability of VM sizes are dependent on the Azure Location
-    // of the parent Cluster.
-    // Required during creation.
-    VMSize String
+	// The Azure Virtual Machine size identifier used for the
+	// Nodes of the Node Pool.
+	// Availability of VM sizes are dependent on the Azure Location
+	// of the parent Cluster.
+	// Required during creation.
+	VMSize String
 
-    // EncryptionAtHost contains Encryption At Host disk encryption configuration.
-    // When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
-    // and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
-    // If not specified, Encryption at Host is not enabled.
-    // Immutable.
-    EncryptionAtHost AzureNodePoolEncryptionAtHost
+	// EncryptionAtHost contains Encryption At Host disk encryption configuration.
+	// When enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks
+	// and disk caches are encrypted at rest and flow encrypted to the Storage clusters.
+	// If not specified, Encryption at Host is not enabled.
+	// Immutable.
+	EncryptionAtHost AzureNodePoolEncryptionAtHost
 
-    // The configuration for the OS disk used by the nodes in the Node Pool.
-    OsDisk AzureNodePoolOsDisk
+	// The configuration for the OS disk used by the nodes in the Node Pool.
+	OsDisk AzureNodePoolOsDisk
+
+	// Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.
+	// When specified, the provided image is used instead of the default RHCOS image.
+	// Optional during creation. Immutable.
+	Image AzureNodePoolImage
 }

--- a/openapi/aro_hcp/v1alpha1/openapi.json
+++ b/openapi/aro_hcp/v1alpha1/openapi.json
@@ -4256,6 +4256,10 @@
             "description": "EncryptionAtHost contains Encryption At Host disk encryption configuration.\nWhen enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks\nand disk caches are encrypted at rest and flow encrypted to the Storage clusters.\nIf not specified, Encryption at Host is not enabled.\nImmutable.",
             "$ref": "#/components/schemas/AzureNodePoolEncryptionAtHost"
           },
+          "image": {
+            "description": "Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.\nWhen specified, the provided image is used instead of the default RHCOS image.\nOptional during creation. Immutable.",
+            "$ref": "#/components/schemas/AzureNodePoolImage"
+          },
           "os_disk": {
             "description": "The configuration for the OS disk used by the nodes in the Node Pool.",
             "$ref": "#/components/schemas/AzureNodePoolOsDisk"
@@ -4271,6 +4275,27 @@
         "properties": {
           "state": {
             "description": "State indicates whether Encryption At Host is enabled.\nWhen enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks\nand disk caches are encrypted at rest and flow encrypted to the Storage clusters.\nAccepted values are: \"disabled\" or \"enabled\".\nIf not specified, its value is \"disabled\", which indicates Encryption At Host is disabled.\nImmutable.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureNodePoolImage": {
+        "description": "Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.\nWhen specified, the provided image is used instead of the default RHCOS image.\nAll four fields must be provided together.\nOptional during creation. Immutable.",
+        "properties": {
+          "sku": {
+            "description": "SKU specifies an instance of an offer, such as a major release of a distribution.",
+            "type": "string"
+          },
+          "offer": {
+            "description": "Offer specifies the name of a group of related images created by the publisher.",
+            "type": "string"
+          },
+          "publisher": {
+            "description": "Publisher is the name of the organization that created the image.",
+            "type": "string"
+          },
+          "version": {
+            "description": "Version specifies the version of an image SKU.",
             "type": "string"
           }
         }

--- a/openapi/clusters_mgmt/v1/openapi.json
+++ b/openapi/clusters_mgmt/v1/openapi.json
@@ -16445,6 +16445,10 @@
             "description": "EncryptionAtHost contains Encryption At Host disk encryption configuration.\nWhen enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks\nand disk caches are encrypted at rest and flow encrypted to the Storage clusters.\nIf not specified, Encryption at Host is not enabled.\nImmutable.",
             "$ref": "#/components/schemas/AzureNodePoolEncryptionAtHost"
           },
+          "image": {
+            "description": "Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.\nWhen specified, the provided image is used instead of the default RHCOS image.\nOptional during creation. Immutable.",
+            "$ref": "#/components/schemas/AzureNodePoolImage"
+          },
           "os_disk": {
             "description": "The configuration for the OS disk used by the nodes in the Node Pool.",
             "$ref": "#/components/schemas/AzureNodePoolOsDisk"
@@ -16460,6 +16464,27 @@
         "properties": {
           "state": {
             "description": "State indicates whether Encryption At Host is enabled.\nWhen enabled, it enhances Azure Disk Storage Server-Side Encryption to ensure that all temporary disks\nand disk caches are encrypted at rest and flow encrypted to the Storage clusters.\nAccepted values are: \"disabled\" or \"enabled\".\nIf not specified, its value is \"disabled\", which indicates Encryption At Host is disabled.\nImmutable.",
+            "type": "string"
+          }
+        }
+      },
+      "AzureNodePoolImage": {
+        "description": "Specifies the Azure Marketplace image to use for the Nodes of the Node Pool.\nWhen specified, the provided image is used instead of the default RHCOS image.\nAll four fields must be provided together.\nOptional during creation. Immutable.",
+        "properties": {
+          "sku": {
+            "description": "SKU specifies an instance of an offer, such as a major release of a distribution.",
+            "type": "string"
+          },
+          "offer": {
+            "description": "Offer specifies the name of a group of related images created by the publisher.",
+            "type": "string"
+          },
+          "publisher": {
+            "description": "Publisher is the name of the organization that created the image.",
+            "type": "string"
+          },
+          "version": {
+            "description": "Version specifies the version of an image SKU.",
             "type": "string"
           }
         }


### PR DESCRIPTION
## Description

Support specifying the RHCOS marketplace image for Azure nodepools to allow us to test rhcos images before they're available.  

## Type of Change

- [x] Model change (new or modified types, resources, methods, or parameters)
- [x] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [ ] CI/CD or tooling change

## Verification

- [x] `make check` passes (model syntax validation)
- [x] `make verify` passes (generated code matches model)
- [x] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Azure Marketplace image configuration for node pools.
  * Image settings support publisher, offer, SKU, and version details.
  * Added support for creating, copying, validating, and listing image configurations.
  * Added JSON serialization and deserialization for image settings and lists.
* **API Updates**
  * Node pool image settings are available through both supported API versions.
  * Image configuration is immutable after node pool creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->