### PR TITLE
make linting BSD compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ metamodel:
 
 # Enforce indentation by tabs. License contains 2 spaces, so reject 3+.
 lint:
-	find -name '*.model' -print0 | xargs -0 sh -c '! egrep --with-filename --line-number "^(   |\t+ )" "$$@"'
+	find . -name '*.model' -print0 | xargs -0 sh -c '! egrep --with-filename --line-number "^(   |\t+ )" "$$@"'
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
## Description

The `lint` target in the `Makefile` did not work on BSD systems like MacOs.

With this change, it will run on Linux and BSD systems.

## Type of Change

- [ ] Model change (new or modified types, resources, methods, or parameters)
- [ ] Generated code update (`make update` after model change)
- [ ] Breaking change (removes or renames existing model elements)
- [ ] Documentation update
- [x] CI/CD or tooling change

## Verification

- [ ] `make check` passes (model syntax validation)
- [ ] `make verify` passes (generated code matches model)
- [ ] `make lint` passes (indentation enforcement)

## Checklist

- [ ] Model files follow the project's DSL conventions (see [README](../README.md#concepts))
- [ ] Documentation comments use Markdown format
- [ ] Generated `clientapi/` and `openapi/` are updated if model changed (`make update`)
